### PR TITLE
docs: fix/simplify custom eval example

### DIFF
--- a/docs/custom-eval.md
+++ b/docs/custom-eval.md
@@ -74,24 +74,20 @@ Generally, most `run` methods will follow the same pattern shown here: loading t
         """
         test_prompt, test_expected = test_sample
 
-        # flatten a random sample of training examples to [{...}, {...}]
-        examples = itertools.chain.from_iterable(
-          rng.sample(self.train_samples, self.train_samples_per_prompt)
-        )
+        # flatten a random sample of training samples to [{...}, {...}]
+        training_samples = rng.sample(self.train_samples, self.train_samples_per_prompt)
+        training_samples = itertools.chain.from_iterable(training_samples)
 
-        # set up context, add examples and test prompt
+        # set up a context, add examples and test prompt
         prompt = [
             {"role": "system", "content": "Solve the following math problems"},
-            *examples,
+            *training_samples,
             test_prompt,
         ]
 
         # evaluate the model's response against the expected answer
-        evals.check_sampled_text(
-          self.model_spec, 
-          prompt, 
-          expected=test_expected["content"],
-        )
+        expected = test_expected["content"]
+        evals.check_sampled_text(self.model_spec, prompt, expected)
 ```
 You'll notice that `eval_sample` doesn't take the `recorder` as an argument. This is because `eval_all_samples` sets it to be the default recorder before calling `eval_sample`, and the recording utilities defined in `evals/record.py` use the default recorder. In this example, the `eval_sample` method passes off a lot of the heavy lifting to the `evals.check_sampled_text` utility function, which is defined in `evals/api.py`. This utility function queries the model, defined by `self.model_spec`, with the given `prompt` and checks to see if the result matches the `expected` answer (or one of them, if given a list). It then records these matches (or non matches) using the default recorder.
 

--- a/docs/custom-eval.md
+++ b/docs/custom-eval.md
@@ -79,15 +79,14 @@ Generally, most `run` methods will follow the same pattern shown here: loading t
           rng.sample(self.train_samples, self.train_samples_per_prompt)
         )
 
-        # set up a context and add examples
+        # set up context, add examples and test prompt
         prompt = [
             {"role": "system", "content": "Solve the following math problems"},
             *examples,
+            test_prompt,
         ]
 
-        # add the test prompt, and measure the response against expected result
-        prompt += [test_prompt]
-
+        # evaluate the model's response against the expected answer
         evals.check_sampled_text(
           self.model_spec, 
           prompt, 


### PR DESCRIPTION
#### Docs-only changes.

The arithmetic example did not work. I updated it to be a little less verbose and ensure it runs. 

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.