### PR TITLE
Python docstrings eval

### DIFF
--- a/evals/registry/data/python_docstring/python_docstring.jsonl
+++ b/evals/registry/data/python_docstring/python_docstring.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:431af2e75cd39ecba0f2c8bdc598cdd088f2821616e851b9e8b6ea4fe01b86a1
+size 114785

--- a/evals/registry/data/python_docstring/python_docstring.jsonl
+++ b/evals/registry/data/python_docstring/python_docstring.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:431af2e75cd39ecba0f2c8bdc598cdd088f2821616e851b9e8b6ea4fe01b86a1
-size 114785
+oid sha256:60e92fbeb8c35a1f0558639f5ce743856e0cb755041b324cfbd7d4f60834ffcd
+size 739786

--- a/evals/registry/evals/python-docstring.yaml
+++ b/evals/registry/evals/python-docstring.yaml
@@ -1,0 +1,9 @@
+python-docstring:
+  id: python-docstring.dev.v0
+  description: Test the model's ability to write docstrings for Python functions.
+  disclaimer: The eval could struggle from the subjective nature of natural language, allowing for multiple correct answers.
+  metrics: [accuracy, sacrebleu_score]
+python-docstring.dev.v0:
+  class: evals.elsuite.translate:Translate
+  args:
+    samples_jsonl: python_docstring/python_docstring.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4.

## Eval details 📑
### Eval name
python-docstring

### Eval description

Tests the model on its ability to write docstrings for Python functions.

### What makes this a useful eval?

The ability to write Python docstrings requires a nuanced understanding of both the code at hand, general experience in designing software, and excellent ability to follow instructions. Further, succinctly conveying that in plain language requires the ability to seamlessly move between and understand both natural and programming languages.

Existing literature evaluates language models on docstring generation using a smoothed bleu-4 score. Typically, this is done using the [CodeXGLUE code-to-text](https://github.com/microsoft/CodeXGLUE/tree/main/Code-Text/code-to-text) benchmark. Recent examples of this evaluation in the literature include:
* SantaCoder by [Allal et. al, 2023](https://arxiv.org/abs/2301.03988)
* InCoder by [Fried et. al, 2022](https://arxiv.org/abs/2204.05999) 

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

By using the accuracy and sacrebleu_score metrics from the provided `Translate` class, we can evaluate docstring generation similarly to other industry-standard benchmarks, without having to add additional eval classes.

Anecdotally, measuring docstring generation allows us to understand what models may be helpful to those trying to understand code. As we move towards tooling that lowers the barrier of entry to software development, having systems in place to help newcomers understand what's going on is and will continue to be incredibly helpful. Though not getting us all the way there, docstring generation is a great standard to begin evaluating this capability.

Note that due to the length of our eval examples (them being code files after all), I have only included the first 5 as 100 do not fit.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in their first 100 JSONL eval lines.

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Write a docstring for the following Python code:\n```python\ndef GetZones(self, resource_refs):\n    \n    errors = []\n    requests = []\n    zone_names = set()\n    for resource_ref in resource_refs:\n        if (resource_ref.zone not in zone_names):\n            zone_names.add(resource_ref.zone)\n            requests.append((self._compute.zones, 'Get', self._messages.ComputeZonesGetRequest(project=resource_ref.project, zone=resource_ref.zone)))\n    res = list(request_helper.MakeRequests(requests=requests, http=self._http, batch_url=self._batch_url, errors=errors))\n    if errors:\n        return None\n    else:\n        return res```"}], "ideal": "Fetches zone resources."}
{"input": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Write a docstring for the following Python code:\n```python\ndef WarnForZonalCreation(self, resource_refs):\n    \n    zones = self.GetZones(resource_refs)\n    if (not zones):\n        return\n    prompts = []\n    zones_with_deprecated = []\n    for zone in zones:\n        if zone.deprecated:\n            zones_with_deprecated.append(zone)\n    if (not zones_with_deprecated):\n        return\n    if zones_with_deprecated:\n        phrases = []\n        if (len(zones_with_deprecated) == 1):\n            phrases = ('zone is', 'this zone', 'the')\n        else:\n            phrases = ('zones are', 'these zones', 'their')\n        title = '\\nWARNING: The following selected {0} deprecated. All resources in {1} will be deleted after {2} turndown date.'.format(phrases[0], phrases[1], phrases[2])\n        printable_deprecated_zones = []\n        for zone in zones_with_deprecated:\n            if zone.deprecated.deleted:\n                printable_deprecated_zones.append('[{0}] {1}'.format(zone.name, zone.deprecated.deleted))\n            else:\n                printable_deprecated_zones.append('[{0}]'.format(zone.name))\n        prompts.append(utils.ConstructList(title, printable_deprecated_zones))\n    final_message = ' '.join(prompts)\n    if (not console_io.PromptContinue(message=final_message)):\n        raise calliope_exceptions.ToolException('Creation aborted by user.')```"}], "ideal": "Warns the user if a zone has upcoming deprecation."}
{"input": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Write a docstring for the following Python code:\n```python\ndef run_forever():\n    'Runs the asyncio event loop with and\\n    ensures state machines are exited upon a KeyboardInterrupt.\\n    '\n    loop = asyncio.get_event_loop()\n    try:\n        loop.run_forever()\n    except KeyboardInterrupt:\n        Framework.stop()\n    loop.close()```"}], "ideal": "Runs the asyncio event loop with and\nensures state machines are exited upon a KeyboardInterrupt."}
{"input": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Write a docstring for the following Python code:\n```python\n@staticmethod\ndef enable_spy(spy_cls):\n    'Sets the Spy to use the given class\\n        and calls its initializer.\\n        '\n    Spy._actv_cls = spy_cls\n    spy_cls.init()```"}], "ideal": "Sets the Spy to use the given class\nand calls its initializer."}
{"input": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Write a docstring for the following Python code:\n```python\ndef __getattr__(*args):\n    'Returns\\n        1) the enable_spy static method if requested by name, or\\n        2) the attribute from the active class (if active class was set), or\\n        3) a function that swallows any arguments and does nothing.\\n        '\n    if (args[1] == 'enable_spy'):\n        return Spy.enable_spy\n    if Spy._actv_cls:\n        return getattr(Spy._actv_cls, args[1])\n    return (lambda *x: None)```"}], "ideal": "Returns\n1) the enable_spy static method if requested by name, or\n2) the attribute from the active class (if active class was set), or\n3) a function that swallows any arguments and does nothing."}
  ```
</details>
