### PR TITLE
Evaluation: Playing chess

### DIFF
--- a/evals/registry/data/chess/match.jsonl
+++ b/evals/registry/data/chess/match.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04fe325bc42c9f19df67751069dd20038f3b866e02cccbdac36f8698b7a24d99
+size 1456

--- a/evals/registry/data/chess/match.jsonl
+++ b/evals/registry/data/chess/match.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04fe325bc42c9f19df67751069dd20038f3b866e02cccbdac36f8698b7a24d99
-size 1456
+oid sha256:5cdaf29dc3e6449500804734d7a2f7dad63bab3c3cf053d9c6c0a735d76b3d47
+size 48775

--- a/evals/registry/evals/chess.yaml
+++ b/evals/registry/evals/chess.yaml
@@ -1,0 +1,7 @@
+chess-match:
+  id: chess.match.dev.v0
+  metrics: [accuracy]
+chess.match.dev.v0:
+  class: evals.elsuite.basic.fuzzy_match:FuzzyMatch
+  args:
+    samples_jsonl: chess/match.jsonl

--- a/evals/registry/evals/chess.yaml
+++ b/evals/registry/evals/chess.yaml
@@ -1,5 +1,6 @@
 chess-match:
   id: chess.match.dev.v0
+  description: Test the model's ability to play chess
   metrics: [accuracy]
 chess.match.dev.v0:
   class: evals.elsuite.basic.fuzzy_match:FuzzyMatch


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4.

## Eval details 📑
### Eval name
Chess

### Eval description
This prompts GPT with the FEN of a board position. Using Stockfish, the best move ("correct answer") is taken as a groundtruth.

### What makes this a useful eval?

ChatGPT is famously known for not being able to play chess well (https://www.youtube.com/watch?v=GneReITaRvs)

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

Chess is a tough task, no language model was capable of having a good performance in

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.
-> t.zehle@gmail.com

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in their first 100 JSONL eval lines.

<details>
  <summary>View evals in JSON</summary>

  ### Eval
{"input": [{"role": "system", "content": "TASK: Read the chess position provided in FEN-notation, then identify the best move to the board position below, in the format A. Your answer should only contain the letter of the correct move. Do not provide any further explanation."}, {"role": "user", "content": "White to move FEN: 2r3k1/p1q2ppp/1p3n2/1Q2p3/2P5/6P1/P4PKP/3R4 Possible Moves: A: f4, B: Rd2, C: Kg1, D: Qb2 Answer only with the letter of the beset move."}], "ideal": "D"}
{"input": [{"role": "system", "content": "TASK: Read the chess position provided in FEN-notation, then identify the best move to the board position below, in the format A. Your answer should only contain the letter of the correct move. Do not provide any further explanation."}, {"role": "user", "content": "Black to move FEN: r1bq1rk1/pp5p/3pp1p1/2p1b2p/2P1P2P/3PQ3/PP3P2/RNB2RK1 Possible Moves: A: h8, B: Qxh4, C: Kg7, D: Bxb2 Answer only with the letter of the beset move."}], "ideal": "B"}
{"input": [{"role": "system", "content": "TASK: Read the chess position provided in FEN-notation, then identify the best move to the board position below, in the format A. Your answer should only contain the letter of the correct move. Do not provide any further explanation."}, {"role": "user", "content": "White to move FEN: r12k5/4b3/1p4p1/p3P2p/PP3P1P/2P2KP1/8/8 Possible Moves: A: Ke4, B: g4, C: c3, D: bxa Answer only with the letter of the beset move."}], "ideal": "D"}

</details>
