### PR TITLE
Sarcasm Detection

### DIFF
--- a/evals/registry/data/sarcasm/few_shot.jsonl
+++ b/evals/registry/data/sarcasm/few_shot.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4219009dc059a6c368f11129f0cb2c63119dae581795d6611b4664f259e4eabc
+size 963

--- a/evals/registry/data/sarcasm/samples.jsonl
+++ b/evals/registry/data/sarcasm/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cb34ff4d2718da62368440ffe8dece7ece39a46b0fe4d172fdd8a76bc420f46
+size 6906270

--- a/evals/registry/evals/sarcasm.yaml
+++ b/evals/registry/evals/sarcasm.yaml
@@ -1,0 +1,10 @@
+sarcasm:
+  id: sarcasm.test.v1
+  description: An evaluation on sarcasm detection. 
+  metrics: [accuracy]
+sarcasm.test.v1:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: sarcasm/samples.jsonl
+    few_shot_jsonl: sarcasm/few_shot.jsonl
+    num_few_shot: 5


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4.

## Eval details 📑
### Eval name
sarcasm

### Eval description

Gauges how well the current model can pick up on sarcasm. Uses dataset found here: https://www.kaggle.com/datasets/rmisra/news-headlines-dataset-for-sarcasm-detection

Also uses 5 few-prompt examples.

### What makes this a useful eval?

Sarcasm could be one of the most dreaded and misinterpreted device used online. It has such a powerful effect, it can completely reverse the purpose of a message.

A simple example of how critical it is to identify sarcasm:
User -> "Hello, I'm looking to fix A!"
AI -> "Oh, okay, here's a solution for B!"
User -> "Oh, right, that's clearly the correct solution"
AI -> "Thank you! Have a great day!"

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
-  [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
------
FEW SHOTS
------
{"sample": [{"role": "user", "content": "paul ryan's wonk shtick is getting old", "name": "example_user"}, {"role": "assistant", "content": "0", "name": "example_assistant"}]
{"sample": [{"role": "user", "content": "temple university receives anonymous donation to build center for discrediting rape allegations", "name": "example_user"}, {"role": "assistant", "content": "1", "name": "example_assistant"}]}
{"sample": [{"role": "user", "content": "gop gasps as red-eyed shadow counsel smashes out of gestation tank", "name": "example_user"}, {"role": "assistant", "content": "1", "name": "example_assistant"}]}
{"sample": [{"role": "user", "content": "area russian to hug you", "name": "example_user"}, {"role": "assistant", "content": "1", "name": "example_assistant"}]}
------
SAMPLES
------
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "thirtysomething scientists unveil doomsday clock of hair loss"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "dem rep. totally nails why congress is falling short on gender, racial equality"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "eat your veggies: 9 deliciously different recipes"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "inclement weather prevents liar from getting to work"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "mother comes pretty close to using word 'streaming' correctly"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "my white inheritance"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "5 ways to file your taxes with less stress"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "richard branson's global-warming donation nearly as much as cost of failed balloon trips"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "shadow government getting too large to meet in marriott conference room b"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "lots of parents know this scenario"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "this lesbian is considered a father in indiana (and an amazing one at that)"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "amanda peet told her daughter sex is 'a special hug'"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "what to know regarding current treatments for ebola"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "chris christie suggests hillary clinton was to blame for boko haram's kidnapping of hundreds of schoolgirls"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "ford develops new suv that runs purely on gasoline"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "uber ceo travis kalanick stepping down from trump economic advisory council"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "area boy enters jumping-and-touching-tops-of-doorways phase"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "area man does most of his traveling by gurney"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "leave no person with disabilities behind"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "lin-manuel miranda would like to remind you to put your phone away"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "60 journalists killed in 2014 as targeting of international press rises"}], "ideal": "0"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "guard in video game under strict orders to repeatedly pace same stretch of hallway"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "how to live to be 110"}], "ideal": "0"}
-------
EVAL RESULT LOG
-------
{"spec": {"model_name": "gpt-3.5-turbo", "model_names": {"completions": ["gpt-3.5-turbo"]}, "eval_name": "sarcasm.test.v1", "base_eval": "sarcasm", "split": "test", "run_config": {"model_specs": {"completions_": [{"name": "gpt-3.5-turbo", "model": "gpt-3.5-turbo", "is_chat": true, "encoding": null, "organization": null, "api_key": null, "extra_options": {}, "headers": {}, "strip_completion": true, "n_ctx": 4096, "format": null, "key": null, "group": null}], "embedding_": null, "ranking_": null}, "eval_spec": {"cls": "evals.elsuite.basic.match:Match", "args": {"samples_jsonl": "sarcasm/samples.jsonl", "few_shot_jsonl": "sarcasm/few_shot.jsonl", "num_few_shot": 5}, "key": "sarcasm.test.v1", "group": "sarcasm"}, "seed": 20220722, "max_samples": 50, "command": "'D:\\Projects\\oaieval' gpt-3.5-turbo sarcasm --max_samples 50", "initial_settings": {"visible": false}}, "created_by": "", "run_id": "230314224027GVCSXXU3", "created_at": "2023-03-14 22:40:27.197172"}}
{"run_id": "230314224027GVCSXXU3", "event_id": 0, "sample_id": "sarcasm.test.14435", "type": "raw_sample", "data": {"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "'extinction labels' tell you how your food choices affect wildlife"}], "ideal": "0"}, "created_by": "", "created_at": "2023-03-14 22:40:27.287173+00:00"}
{"run_id": "230314224027GVCSXXU3", "event_id": 1, "sample_id": "sarcasm.test.10818", "type": "raw_sample", "data": {"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "indian prince manvendra singh gohil to open lgbtq center on family's royal grounds"}], "ideal": "0"}, "created_by": "", "created_at": "2023-03-14 22:40:27.287173+00:00"}
{"run_id": "230314224027GVCSXXU3", "event_id": 2, "sample_id": "sarcasm.test.16501", "type": "raw_sample", "data": {"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "gop senator really doesn't want to talk about donald trump"}], "ideal": "0"}, "created_by": "", "created_at": "2023-03-14 22:40:27.287173+00:00"}
{"run_id": "230314224027GVCSXXU3", "event_id": 3, "sample_id": "sarcasm.test.2213", "type": "raw_sample", "data": {"input": [{"role": "system", "content": "Respond with only a 1 or 0 to signify if the user's message includes sarcasm, or not"}, {"role": "user", "content": "experts say puerto rico still extremely vulnerable to future u.s. government"}], "ideal": "1"}, "created_by": "", "created_at": "2023-03-14 22:40:27.288174+00:00"}
[...]
{"final_report": {"accuracy": 0.62}}

  ```
</details>
