### PR TITLE
Fix typo in api.py

### DIFF
--- a/evals/api.py
+++ b/evals/api.py
@@ -36,7 +36,7 @@ def completion_query(
     `model_spec`: `ModelSpec` containing model details to use in the query.
         This should be the dict returned by `registry.get_model()`.
         If `model_spec` is not provided, we use the default model that was
-            intialized at the beginning of the run.
+            initialized at the beginning of the run.
     `prompt`: Either a `Prompt` object or a raw prompt that will get wrapped in
         the approriate `Prompt` class.
     `kwargs`: Other arguments passed to the API.


### PR DESCRIPTION
Fixed comment typo.
```
intialized -> initialized
```

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.


