### PR TITLE
go_board_count eval

### DIFF
--- a/evals/elsuite/basic/erf_score_match.py
+++ b/evals/elsuite/basic/erf_score_match.py
@@ -1,0 +1,65 @@
+import logging
+import math
+import re
+
+import evals
+from evals.elsuite.basic.match import Match
+
+logger = logging.getLogger(__name__)
+
+NUMBER_RE = re.compile(r"-?\d+(\.\d+)?")
+
+
+class ErfScoreMatch(Match):
+    """
+    If answers are distributed normally with mean m and standard deviation std, then a good way to score the accuracy of
+    an answer would be to ask "how much probability density is there between the given answer and the correct answer?"
+
+    Since the integral of the gaussian is math.erf, we're looking for abs(math.erf(given) - math.erf(expected)),
+    where given and expected are scaled to have mean 0 and standard deviation 1 (i.e. (x - m) / std).
+
+    Answer is expected to be given as a decimal number in data["sampled"].
+    data["sampled"] may contain other space-separated tokens as long as they don't parse as decimal numbers.
+
+    "ideal" is expected to contain a single decimal number (as a string).
+    """
+
+    def __init__(
+        self,
+        model_specs: evals.ModelSpecs,
+        *args,
+        mean: float,
+        std: float,
+        **kwargs,
+    ):
+        super().__init__(model_specs, *args, **kwargs)
+        self.mean = mean
+        self.std = std
+
+    def run(self, recorder):
+        samples = evals.get_jsonl(self.samples_jsonl)
+        self.eval_all_samples(recorder, samples)
+        events = recorder.get_events("match")
+        return {
+            "accuracy": self.calculate_accuracy(events),
+        }
+
+    def calculate_accuracy(self, events):
+        return sum(
+            self.calculate_erf_diff(self.parse(e.data["expected"]), self.parse(e.data["sampled"]))
+            for e in events
+        )
+
+    def parse(self, s):
+        numbers = [n for n in s.split() if NUMBER_RE.match(n)]
+        if len(numbers) == 1:
+            (number,) = numbers
+            return float(number)
+        logger.warn(f"Can't parse as number: {s}")
+        return float("inf")
+
+    def calculate_erf_diff(self, expected, picked):
+        return abs(math.erf(self.scale(expected)) - math.erf(self.scale(picked)))
+
+    def scale(self, x):
+        return (x - self.mean) / self.std

--- a/evals/registry/data/go_board_count/match.jsonl
+++ b/evals/registry/data/go_board_count/match.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc5fdfe45a3a24634e2ce9ffe0eae33cb7d8093968f1d495eca70f43359b5816
-size 38826
+oid sha256:e01f6a56e61fe862401a5eb2c419ab0eba7cb3c7e5bb5251140948340b7257ed
+size 172601

--- a/evals/registry/data/go_board_count/match.jsonl
+++ b/evals/registry/data/go_board_count/match.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc5fdfe45a3a24634e2ce9ffe0eae33cb7d8093968f1d495eca70f43359b5816
+size 38826

--- a/evals/registry/evals/go_board_count.yaml
+++ b/evals/registry/evals/go_board_count.yaml
@@ -1,0 +1,9 @@
+go_board_count:
+  id: go_board_count.dev.v0
+  metrics: [accuracy]
+go_board_count.dev.v0:
+  class: evals.elsuite.basic.erf_score_match:ErfScoreMatch
+  args:
+    samples_jsonl: go_board_count/match.jsonl
+    mean: 0.0
+    std: 18.42


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
go_board_count

### Eval description

Assistant is asked to read a Go game record (in standard SGF format), evaluate every move, and output the final score.

A custom metric was developed that rewards correctly for close but not exact guesses, based on measurement of Go game score distribution to be normal with mean 0 and stddev 18.42 (on ~1200 online-go.com games).

### What makes this a useful eval?

Since AlphaGo in 2016, Go is considered a very interesting AI problem.

This is a "checksum" of understanding of the rules and ability to follow a game, in a format that will later allow us to also test skill at the game.

We're testing:

- Full and correct understanding of the (simple) rules of the game, including, in some samples, edge cases (GPT-3 is ok at this)
- Understanding of standard notation (GPT-3 is great at this)
- Keeping a lot of state in memory - some games are on a 9x9 board, some on a 19x19
- In cases where the model isn't sure about something - estimation under uncertainty
- However, this problem is 100% deterministic and can be solved with 100% accuracy in a few hundred lines of python

Once we start getting good results on this, I will push an additional dataset of partial game records, with the exact same prompt, that will be a very thorough test of skill at the game as well as estimation under uncertainty.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

In addition to a great test of memory and calculation, this PR includes a very useful evaluation metric described above.

(If you insist on using only the given classes, it would be easy to adjust it into a classification problem that uses Match. However, I feel that a lot of value will be lost. Exact metrics are _nice_).

All games included were played by yours truly against opponents of varying levels.

## Eval structure 🏗️

Your eval should
- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [X] I have filled out all required fields in the evals PR form
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "TASK: What was the (possibly negative) margin of victory for black in the Go game described by this SGF file? For example, if black has 10 points and white has 5 points and a 6.5 komi, the answer is 10 - 5 - 6.5, or -1.5. If you're not sure, give your best estimate. Answer should be a single number with no explanation."}, {"role": "system", "content": "Q: (;FF[4]CA[UTF-8]GM[1]DT[2020-07-28]PGN[Friendly Match]PB[sonoflilit]PW[Spectral-10k]BR[11k]WR[10k]TM[0]OT[30 simple]SZ[19]KM[7.5]RU[Chinese];B[pd](;W[cp](;B[pp](;W[pq](;B[qq](;W[oq](;B[qp](;W[op](;B[pr](;W[or](;B[qr](;W[kq](;B[dd](;W[cf](;B[fc](;W[bd](;B[cc](;W[ci](;B[oo](;W[no](;B[pj](;W[on](;B[po](;W[nn](;B[qm](;W[nc](;B[lc](;W[qc](;B[pc](;W[qd](;B[qe](;W[re](;B[qf](;W[rf](;B[rh](;W[pb](;B[ob](;W[qb](;B[oc](;W[qg](;B[pg](;W[qh](;B[ph](;W[qi](;B[ri](;W[qj](;B[rg](;W[rj](;B[qk](;W[rk](;B[rl](;W[pk](;B[ql](;W[pi](;B[oj](;W[oi](;B[ni](;W[oh](;B[og](;W[nh](;B[ol](;W[nj](;B[ok](;W[mi](;B[ml](;W[ng](;B[of](;W[nf](;B[nd](;W[oe](;B[pf](;W[pe](;B[od](;W[fq](;B[kl](;W[kn](;B[ki](;W[im](;B[il](;W[hm](;B[ef](;W[kf](;B[lg](;W[lf](;B[jg](;W[kg](;B[kh](;W[lh](;B[li](;W[mg](;B[jf](;W[kd](;B[jd](;W[kc](;B[kb](;W[jc](;B[hc](;W[jb](;B[lb](;W[nb](;B[mc](;W[oa](;B[mb](;W[na](;B[ma](;W[pa](;B[ja](;W[ia](;B[ka](;W[hb](;B[ic](;W[ib](;B[ke](;W[le](;B[je](;W[ld](;B[gb](;W[md](;B[ei](;W[dk](;B[ek](;W[el](;B[fl](;W[fk](;B[ej](;W[fm](;B[gl](;W[gm](;B[hl](;W[dl](;B[gj](;W[dg](;B[eg](;W[dh](;B[eh](;W[bc](;B[bb](;W[cd](;B[dc](;W[de](;B[ee](;W[df](;B[dj](;W[cj](;B[pn](;W[lj](;B[kj](;W[lk](;B[ll](;W[kk](;B[jk](;W[jm](;B[mk](;W[mj](;B[ln](;W[lo](;B[mn](;W[mo](;B[km](;W[jl](;B[ij](;W[mm](;B[lm](;W[nl](;B[nm](;W[nk](;B[om](;W[mm](;B[ac](;W[ad](;B[ab](;W[ps](;B[qs](;W[os](;B[sk](;W[sj](;B[sl](;W[di](;B[ga](;W[la](;B[ha](;W[](;B[])))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))", "name": "user"}], "ideal": ["-124.5"]}
{"input": [{"role": "system", "content": "TASK: What was the (possibly negative) margin of victory for black in the Go game described by this SGF file? For example, if black has 10 points and white has 5 points and a 6.5 komi, the answer is 10 - 5 - 6.5, or -1.5. If you're not sure, give your best estimate. Answer should be a single number with no explanation."}, {"role": "system", "content": "Q: (;FF[4]CA[UTF-8]GM[1]DT[2020-08-04]PGN[antonio.fabio vs. sonoflilit]PB[antonio.fabio]PW[sonoflilit]BR[12k]WR[11k]TM[180]OT[30 fischer]SZ[9]KM[5.5]RU[Japanese];B[gg](;W[dd](;B[gc](;W[df](;B[ec](;W[ge](;B[eg](;W[ff](;B[cc](;W[dc](;B[ce](;W[cd](;B[cg](;W[cf](;B[bf](;W[be](;B[hd](;W[bg](;B[bh](;W[af](;B[dg](;W[db](;B[eb](;W[fd](;B[he](;W[fc](;B[fb](;W[fg](;B[fh](;W[hf](;B[gf](;W[hg](;B[gh](;W[hh](;B[hi](;W[ih](;B[eh](;W[gd](;B[hc](;W[ed](;B[ea](;W[da](;B[gb](;W[ef](;B[ah](;W[ag](;B[ch](;W[bc](;B[ie](;W[](;B[])))))))))))))))))))))))))))))))))))))))))))))))))))", "name": "user"}], "ideal": ["2.5"]}
{"input": [{"role": "system", "content": "TASK: What was the (possibly negative) margin of victory for black in the Go game described by this SGF file? For example, if black has 10 points and white has 5 points and a 6.5 komi, the answer is 10 - 5 - 6.5, or -1.5. If you're not sure, give your best estimate. Answer should be a single number with no explanation."}, {"role": "system", "content": "Q: (;FF[4]CA[UTF-8]GM[1]DT[2020-07-15]PGN[Ladder Challenge: sonoflilit(#688) vs proximus63(#446)]PB[sonoflilit]PW[proximus63]BR[11k]WR[16k]TM[259200]OT[86400 fischer]SZ[9]KM[5.5]RU[Japanese];B[fd](;W[ee](;B[fg](;W[eg](;B[ef](;W[df](;B[ff](;W[ed](;B[dg](;W[eh](;B[de](;W[cf](;B[dh](;W[ec](;B[fc](;W[fb](;B[gb](;W[ea](;B[fe](;W[ch](;B[fh](;W[cg](;B[ei](;W[cd](;B[ci](;W[bi](;B[di](;W[ah](;B[ga](;W[fa](;B[](;W[]))))))))))))))))))))))))))))))))", "name": "user"}], "ideal": ["-2.5"]}
{"input": [{"role": "system", "content": "TASK: What was the (possibly negative) margin of victory for black in the Go game described by this SGF file? For example, if black has 10 points and white has 5 points and a 6.5 komi, the answer is 10 - 5 - 6.5, or -1.5. If you're not sure, give your best estimate. Answer should be a single number with no explanation."}, {"role": "system", "content": "Q: (;FF[4]CA[UTF-8]GM[1]DT[2022-12-19]PGN[Topsi vs. sonoflilit]PB[Topsi]PW[sonoflilit]BR[9k]WR[8k]TM[1200]OT[5x30 byo-yomi]SZ[19]KM[6.5]RU[Japanese];B[pd](;W[dp](;B[pp](;W[dd](;B[nc](;W[qq](;B[pq](;W[qp](;B[qo](;W[ro](;B[qn](;W[rn](;B[qm](;W[fc](;B[hc](;W[jc](;B[jd](;W[kd](;B[je](;W[ke](;B[ic](;W[jb](;B[ib](;W[jf](;B[if](;W[ig](;B[hf](;W[hg](;B[gf](;W[gd](;B[kf](;W[jg](;B[kc](;W[kb](;B[lc](;W[lf](;B[lb](;W[id](;B[ie](;W[hd](;B[ka](;W[gg](;B[kg](;W[ql](;B[rm](;W[pr](;B[or](;W[qr](;B[lg](;W[oq](;B[op](;W[nq](;B[np](;W[mq](;B[qj](;W[rl](;B[pl](;W[pk](;B[qk](;W[pm](;B[ol](;W[om](;B[rk](;W[nl](;B[ok](;W[nm](;B[mp](;W[lp](;B[lo](;W[kp](;B[ko](;W[po](;B[pn](;W[oo](;B[mo](;W[on](;B[sl](;W[jo](;B[jn](;W[io](;B[nk](;W[ll](;B[km](;W[kl](;B[ml](;W[mm](;B[mk](;W[lm](;B[jl](;W[kk](;B[in](;W[jk](;B[ho](;W[il](;B[hp](;W[jp](;B[hm](;W[jm](;B[kn](;W[gn](;B[hn](;W[hl](;B[ep](;W[eo](;B[fp](;W[gm](;B[dq](;W[cp](;B[cq](;W[bq](;B[br](;W[bp](;B[fo](;W[en](;B[fn](;W[fm](;B[iq](;W[lr](;B[kq](;W[jq](;B[jr](;W[kr](;B[ir](;W[mg](;B[le](;W[mf](;B[mh](;W[nh](;B[mi](;W[lh](;B[kh](;W[li](;B[lj](;W[ki](;B[jh](;W[ji](;B[ih](;W[hi](;B[pg](;W[pj](;B[pi](;W[oj](;B[oi](;W[ff](;B[fg](;W[fh](;B[eg](;W[ef](;B[eh](;W[fi](;B[ei](;W[ej](;B[fj](;W[gj](;B[gh](;W[hh](;B[ld](;W[fk](;B[cg](;W[di](;B[df](;W[dg](;B[de](;W[ee](;B[ed](;W[dh](;B[cd](;W[dc](;B[cc](;W[ce](;B[cf](;W[be](;B[db](;W[ec](;B[bd](;W[cb](;B[bb](;W[ad](;B[ca](;W[ch](;B[bf](;W[bg](;B[ae](;W[bh](;B[eb](;W[fb](;B[ip](;W[lq](;B[qd](;W[ar](;B[bs](;W[eq](;B[er](;W[dr](;B[cr](;W[fq](;B[fr](;W[gq](;B[gr](;W[ds](;B[es](;W[aq](;B[hq](;W[as](;B[cs](;W[ea](;B[da](;W[ha](;B[ga](;W[gb](;B[ia](;W[fa](;B[ja](;W[og](;B[nj](;W[of](;B[pf](;W[od](;B[oc](;W[nd](;B[md](;W[me](;B[oe](;W[ne](;B[pe](;W[ii](;B[ke](;W[ge](;B[hb](;W[ga](;B[gc](;W[fd](;B[go](;W[sn](;B[sm](;W[rp](;B[im](;W[jl](;B[em](;W[dm](;B[do](;W[dn](;B[co](;W[bo](;B[cn](;W[cm](;B[bn](;W[bm](;B[ks](;W[ls](;B[nr](;W[ns](;B[os](;W[ps](;B[ms](;W[js](;B[is](;W[mr](;B[ks](;W[ns](;B[js](;W[lk](;B[kj](;W[jj](;B[mj](;W[ag](;B[af](;W[](;B[])))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))", "name": "user"}], "ideal": ["30.5"]}
{"input": [{"role": "system", "content": "TASK: What was the (possibly negative) margin of victory for black in the Go game described by this SGF file? For example, if black has 10 points and white has 5 points and a 6.5 komi, the answer is 10 - 5 - 6.5, or -1.5. If you're not sure, give your best estimate. Answer should be a single number with no explanation."}, {"role": "system", "content": "Q: (;FF[4]CA[UTF-8]GM[1]DT[2020-08-07]PGN[sonoflilit vs. DuncanFer]PB[sonoflilit]PW[DuncanFer]BR[11k]WR[9k]TM[180]OT[30 fischer]SZ[9]KM[3.5]RU[Japanese]AB[fd];W[ff](;B[dd](;W[de](;B[gf](;W[gg](;B[ge](;W[cc](;B[fg](;W[gh](;B[ef](;W[eg](;B[fe](;W[fh](;B[df](;W[cg](;B[ce](;W[dg](;B[dc](;W[cd](;B[bd](;W[be](;B[cf](;W[bc](;B[bf](;W[ad](;B[bg](;W[bh](;B[cb](;W[bb](;B[db](;W[gc](;B[gb](;W[hb](;B[fb](;W[hd](;B[he](;W[ha](;B[ic](;W[id](;B[ib](;W[hg](;B[if](;W[hf](;B[ie](;W[ca](;B[da](;W[ba](;B[ah](;W[bi](;B[ig](;W[ih](;B[af](;W[ae](;B[ag](;W[dh](;B[ai](;W[fc](;B[ec](;W[](;B[ff](;W[ga](;B[fa](;W[gd](;B[hc](;W[](;B[]))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))", "name": "user"}], "ideal": ["5.5"]}
  ```
</details>
