### PR TITLE
Add common environment files and directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 __pycache__/
 evals.egg-info/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
This will be more pleasant for users using virtual environments since the downloaded dependencies won't appear in their git status. I followed the [template](https://github.com/github/gitignore/blob/main/Python.gitignore#L122) listed in https://github.com/github/gitignore for this.