### PR TITLE
Clarify redirection using heredocs

### DIFF
--- a/docs/custom-eval.md
+++ b/docs/custom-eval.md
@@ -17,8 +17,13 @@ We will use the new chat format described [here](https://platform.openai.com/doc
 
 To create the toy datasets, in your terminal, type:
 ```bash
-echo -e '[{"role": "system", "content": "2+2=", "name": "example_user"}, {"role": "system", "content": "4", "name": "example_assistant"}]\n[{"role": "system", "content": "4*4=", "name": "example_user"}, {"role": "system", "content": "16", "name": "example_assistant"}]' > /tmp/train.jsonl
-echo -e '[{"role": "system", "content": "48+2=", "name": "example_user"}, {"role": "system", "content": "50", "name": "example_assistant"}]\n[{"role": "system", "content": "5*20=", "name": "example_user"}, {"role": "system", "content": "100", "name": "example_assistant"}]' > /tmp/test.jsonl
+cat > /tmp/train.jsonl << EOF
+[{"role": "system", "content": "2+2=", "name": "example_user"}, {"role": "system", "content": "4", "name": "example_assistant"}]\n[{"role": "system", "content": "4*4=", "name": "example_user"}, {"role": "system", "content": "16", "name": "example_assistant"}]
+EOF
+
+cat > /tmp/test.jsonl << EOF
+[{"role": "system", "content": "48+2=", "name": "example_user"}, {"role": "system", "content": "50", "name": "example_assistant"}]\n[{"role": "system", "content": "5*20=", "name": "example_user"}, {"role": "system", "content": "100", "name": "example_assistant"}]
+EOF
 ```
 
 ## Create an eval


### PR DESCRIPTION
In the original format, the redirection was hidden at the end of the line. Using heredocs, the redirection is explicit on the first line.
