### PR TITLE
add chinese character and english words generation count evaluation (17% accuracy, 40 samples)

### DIFF
--- a/evals/elsuite/modelgraded/chinese_character_generation_count.py
+++ b/evals/elsuite/modelgraded/chinese_character_generation_count.py
@@ -1,0 +1,166 @@
+import random
+import textwrap
+import evals
+import evals.metrics
+import re
+from evals.api import *
+import string
+
+
+def count_zh_char(text):
+    pattern = re.compile(r'[\u4e00-\u9fa5]') 
+    results = re.findall(pattern, text)
+    count = 0
+    for result in results:
+        if not is_chinese_punctuation(result):
+            count += 1
+    return count
+
+
+def is_chinese_punctuation(char):
+    punctuation = '，。！？；：‘’“”【】（）<>《》『』［］｛｝〔〕〈〉「」「」﹂。、'
+    return char in punctuation
+
+
+def count_en_words(text):
+    # remove all symbols
+    text = text.translate(str.maketrans('', '', string.punctuation))
+
+    words = text.split() 
+    count = 0
+    for word in words:
+        if word.isalpha(): 
+            count += 1
+    return count
+
+
+def check_sampled_text_self(
+    model_spec: ModelSpec,
+    prompt: Union[OpenAICreatePrompt, OpenAICreateChatPrompt, Prompt],
+    expected: Union[str, list[str], tuple[str]],
+    *,
+    options: Optional[list[str]] = None,
+    separator: Callable[[str], bool] = None,
+    lang: str = None,
+) -> Optional[str]:
+    """
+    Generates a completion using the prompt, checks whether the completion is
+        one of the expected completions, and then records the result.
+
+    ARGS
+    ====
+    `model_spec`: See `completion_query`.
+    `prompt`: See `completion_query`.
+    `options`: The list of canonical options, defaults to `expected` if None.
+        The completion will be converted to one of these options.
+    `expected`: The desired completion or the list of desired completions.
+    `separator`: A callable which check the character sampled after the option
+        to see if it is a valid separator.
+
+    RETURNS
+    =======
+    The option that was picked, i.e., matched the completion, or None.
+    """
+    if isinstance(expected, tuple):
+        expected = list(expected)
+    elif not isinstance(expected, list):
+        expected = [expected]
+    if options is None:
+        options = expected
+
+    result, actual_prompt, metadata = completion_query(
+        prompt=prompt,
+        temperature=0.0,
+        model_spec=model_spec,
+    )
+    choice = result["choices"][0]
+
+    sampled = choice["text"].strip() if model_spec.strip_completion else choice["text"]
+
+    # Here we will count how many chinese characters / english words in the response.
+    count = 0
+    if lang == "zh":
+        count = count_zh_char(sampled)
+    elif lang == "en":
+        count = count_en_words(sampled)
+
+    sampled = str(count)
+    # Count OK.
+
+    picked = None
+    for option in options:
+        if not sampled.startswith(option):
+            continue
+        if (
+            separator is not None
+            and len(sampled) > len(option)
+            and not separator(sampled[len(option)])
+        ):
+            continue
+        picked = option
+        break
+
+    result = {
+        "prompt": actual_prompt,
+        "sampled": sampled,
+        "options": options,
+        "picked": picked,
+    }
+    match = picked in expected
+    result["expected"] = expected
+    result["match"] = match
+    result["metadata"] = metadata
+    record_sampling(**result)
+    record_match(match, expected=expected, picked=picked, sampled=sampled)
+    return picked
+
+
+class ChineseCharacterGenerationCount(evals.Eval):
+    """
+    Give an instruction containing how many Chinese characters to generate, 
+    and let model generate specific amount of chinese characters, 
+    finally evaluate the performance.
+    """
+    def __init__(self, jsonl, **kwargs):
+        super().__init__(**kwargs)
+        self.jsonl = jsonl
+
+    def run(self, recorder):
+        """
+        Called by the `oaieval` CLI to run the eval. The `eval_all_samples` method calls `eval_sample`.
+        """
+        samples = evals.get_jsonl(self.jsonl)
+        self.eval_all_samples(recorder, samples)
+
+        # Record overall metrics
+        return {
+            "accuracy": evals.metrics.get_accuracy(recorder.get_events("match")),
+        }
+    
+    
+    def eval_sample(self, test_sample, rng: random.Random):
+        """
+        Called by the `eval_all_samples` method to evaluate a single sample.
+
+        ARGS
+        ====
+        `test_sample`: a line from the JSONL test file
+        `rng`: should be used for any randomness that is needed during evaluation
+
+        This method does the following:
+        1. Generate a prompt that contains the task statement, a few examples, and the test question.
+        2. Check if the model generates the correct answer.
+        """
+
+        prompt = [
+            {"role": "system", "content": "Give an instruction containing how many Chinese characters to generate, you should generate specific amount of chinese characters."},
+        ]
+
+        prompt += [{"role": "user", "content": test_sample["problem"]}]
+
+        print(test_sample)
+
+        # Define a new 'check_sampled_text' function called 'check_sampled_text_self'
+        check_sampled_text_self(self.model_spec, prompt, expected=test_sample["count"], lang=test_sample["lang"])
+
+

--- a/evals/registry/data/chinese_character_generation_count/samples1.jsonl
+++ b/evals/registry/data/chinese_character_generation_count/samples1.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6f87bc539a337273c3fea21cc94fdc067eb660db88912654960a749eebfd078
+size 3542

--- a/evals/registry/evals/chinese-char-gen-count.yaml
+++ b/evals/registry/evals/chinese-char-gen-count.yaml
@@ -1,0 +1,7 @@
+chinese-char-gen-count:
+  id: chinese-char-gen-count.dev.v0
+  metrics: [accuracy]
+chinese-char-gen-count.dev.v0:
+  class: evals.elsuite.modelgraded.chinese_character_generation_count:ChineseCharacterGenerationCount
+  args:
+    jsonl: chinese_character_generation_count/samples1.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
Chinese Character and English Words Generation Count Evaluation

### Eval description

Ask the model to generate a Chinese sentence or English sentence with specific number of characters or words. Then evaluate if the model has generated satisfactory sentence.

### What makes this a useful eval?

This is useful for improving the reliability, as well as the ability to process according to human instructions.

The performance of gpt-3.5-turbo is only `0.175` out of `1`.

```
[2023-03-15 17:33:33,354] [record.py:320] Final report: {'accuracy': 0.175}. Logged to /tmp/evallogs/230315093325LCITSBUT_gpt-3.5-turbo_chinese-char-gen-count.jsonl
[2023-03-15 17:33:33,354] [oaieval.py:209] Final report:
[2023-03-15 17:33:33,354] [oaieval.py:211] accuracy: 0.175
[2023-03-15 17:33:33,367] [record.py:309] Logged 120 rows of events to /tmp/evallogs/230315093325LCITSBUT_gpt-3.5-turbo_chinese-char-gen-count.jsonl: insert_time=12.000ms
```

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"problem": "generate one English sentence composed of 10 words.", "count": "10", "lang": "en"}
{"problem": "写一句中文，由6个汉字组成", "count": "6", "lang": "zh"}
{"problem": "generate one English sentence composed of 19 words.", "count": "19", "lang": "en"}
{"problem": "写一句中文，由7个汉字组成", "count": "7", "lang": "zh"}
{"problem": "generate one English sentence composed of 16 words.", "count": "16", "lang": "en"}
  ```
</details>
