### PR TITLE
Add map-electronic-component-part-to-fact evals

### DIFF
--- a/evals/registry/data/map-electronic-component-part-to-fact/samples.jsonl
+++ b/evals/registry/data/map-electronic-component-part-to-fact/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6755ce1b4d63f6c9f18e349ecde45cbcea4cd1c41e50d462bfa1cf990eeb8069
+size 32339

--- a/evals/registry/evals/map-electronic-component-part-to-fact.yaml
+++ b/evals/registry/evals/map-electronic-component-part-to-fact.yaml
@@ -1,0 +1,8 @@
+map-electronic-component-part-to-fact:
+  id: map-electronic-component-part-to-fact.dev.v0
+  metrics: [accuracy]
+
+map-electronic-component-part-to-fact.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: map-electronic-component-part-to-fact/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
map-electronic-component-part-to-fact

### Eval description

This eval asks specific technical questions about electronic components.  Answers can be found in PDF files on the open web, which are likely part of the training data.   

### What makes this a useful eval?

Lots of data in the training set is in hard to understand forms.   This asks questions about relatively obscure PDF files that are older than 2021.  The PDF files are scattered all over the open web, and consist of datasheets for electronic components.   The information to answer the question is often within a table or diagram.  Multiple parts of the document may need to be understood to find the correct answer.

Good performance on this eval shows that information can be extracted from non-trivial representations within the training set.

This also has a real world usecase:  Good performance on this eval would be a requirement to build a tool to automatically suggest alternative parts for an application.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "You are to answer each given question with a single number, with no extra characters or units.  Round every answer to one significant figure."}, {"role": "user", "content": "A FQA8N100C MOSFET has a drain current in amps of what, at a V_GS=9V and V_DS=10V?"}], "ideal": "8"}

{"input": [{"role": "system", "content": "You are to answer each given question with a single number, with no extra characters or units.  Round every answer to one significant figure."}, {"role": "user", "content": "An onsemi 2N3903 has a typical rise time of how many nanoseconds, with a collector current of 150mA?"}], "ideal": "20"}

{"input": [{"role": "system", "content": "You are to answer each given question with a single number, with no extra characters or units.  Round every answer to one significant figure."}, {"role": "user", "content": "An HDSP-5701 has a maximum continuous current per segment of how many mA?"}], "ideal": "80"}

{"input": [{"role": "system", "content": "You are to answer each given question with a single number, with no extra characters or units.  Round every answer to one significant figure."}, {"role": "user", "content": "A moog C23 C23-L33W10M00 motor has a rated power in watts of?"}], "ideal": "30"}

{"input": [{"role": "system", "content": "You are to answer each given question with a single number, with no extra characters or units.  Round every answer to one significant figure."}, {"role": "user", "content": "A DSD-90 motor speed controller weighs what, in kg?"}], "ideal": "0.2"}
  ```
</details>
