### PR TITLE
[bugfix] fix includes eval

### DIFF
--- a/evals/elsuite/basic/includes.py
+++ b/evals/elsuite/basic/includes.py
@@ -24,7 +24,7 @@ class Includes(evals.Eval):
             self.model_spec, sample["input"], max_tokens=self.max_tokens
         )
         includes_answer = any(
-            [evals.elsuite.utils.get_answer(sampled, ref) for ref in sample["ideal"]]
+            [evals.elsuite.utils.get_answer(sampled, ref) is not None for ref in sample["ideal"]]
         )
         evals.record.record_metrics(accuracy=float(includes_answer))
         return includes_answer


### PR DESCRIPTION
Bug fix to the basic.includes eval:  

If a ref in sample["ideal"] is a single character, `evals.elsuite.utils.get_answer` can return an empty string if the ref is found in the last character of the prompt. `any(...)` then treats the empty string as false and reports a no-match.

Fix: check explicitly for `None`, as that is what `get_answer` returns in case of failure.

Alternatively, one can return a bool from `get_answer`, currently its only used in the includes (as far as i can see) and that would work there.
