### PR TITLE
Add `decrypt-vigenere-cipher` eval

### DIFF
--- a/evals/registry/data/decrypt_vigenere_cipher/samples.jsonl
+++ b/evals/registry/data/decrypt_vigenere_cipher/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4df00ebda4bdb0ab8c20060afc5d09b0260d87aeab4cbc17d4d6e20e176ca9a
+size 2950

--- a/evals/registry/evals/decrypt-vigenere-cipher.yaml
+++ b/evals/registry/evals/decrypt-vigenere-cipher.yaml
@@ -1,0 +1,8 @@
+decrypt-vigenere-cipher:
+  id: decrypt-vigenere-cipher.dev.v0
+  metrics: [accuracy]
+
+decrypt-vigenere-cipher.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: decrypt_vigenere_cipher/samples.jsonl


### PR DESCRIPTION
## Eval details 📑
### Eval name
decrypt-vigenere-cipher

### Eval description

Test the models ability to decrypt with the [Vigenère cipher](https://en.wikipedia.org/wiki/Vigen%C3%A8re_cipher).

### What makes this a useful eval?

By testing a language model's ability to use Vigenère cipher we can evaluate the model's ability apply a cryptographic procedure, and recognize patterns required to decrypt a ciphertext. Additionally, since the Vigenère cipher has been a popular encryption method for centuries, it could ensure effectiveness in decoding historical documents or other text encrypted with classical ciphers.

> **Note**: Others in the community have shown interest in this kind of evaluation with #58 and #62.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input": [{"role": "system", "content": "You will be given a Vigenère cipher, only reply with the deciphered plaintext using the key 'goodbyemoon'"}, {"role": "user", "content": "nszopusdzr"}], "ideal": "helloworld"}
  {"input": [{"role": "system", "content": "You will be given a Vigenère cipher, only reply with the deciphered plaintext using the key 'ABCDABCDABCDABCDABCDABCDABCD'"}, {"role": "user", "content": "CSASTPKVSIQUTGQUCSASTPIUAQJB"}], "ideal": "cryptoisshortforcryptography"}
  {"input": [{"role": "system", "content": "You will be given a Vigenère cipher, only reply with the deciphered plaintext using the key 'Polyphia'"}, {"role": "user", "content": "Lvppt kw ydi hyca bo vc qmg scnrv?"}], "ideal": "Where do you want to go for lunch?"}
  {"input": [{"role": "system", "content": "You will be given a Vigenère cipher, only reply with the deciphered plaintext using the key 'AGI'"}, {"role": "user", "content": "Tnm fabuxm"}], "ideal": "The future"}
  {"input": [{"role": "system", "content": "You will be given a Vigenère cipher, only reply with the deciphered plaintext using the key 'THATFEELING'"}, {"role": "user", "content": "B'ce ejevymq zaht ijstwm joes fhwkie eugm fon xemo, xruise pnpp qwemxa wafx czc qow, ium uisatr cbsl gjzic nbxzlt ata czc zgwl tajq jpmy."}], "ideal": "I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel."}
  ```
</details>
