### PR TITLE
improve error message on jsonl parsing errors

### DIFF
--- a/evals/data.py
+++ b/evals/data.py
@@ -74,10 +74,20 @@ def open_by_file_pattern(filename: str, mode: str = "r", **kwargs: Any) -> Any:
         raise RuntimeError(f"Failed to open: {filename}") from e
 
 
+def _decode_json(line, path, line_number):
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError as e:
+        custom_error_message = f"Error parsing JSON on line {line_number}: {e.msg} at {path}:{line_number}:{e.colno}"
+        logger.error(custom_error_message)
+        raise ValueError(custom_error_message) from None
+
 def _get_jsonl_file(path):
     logger.info(f"Fetching {path}")
+    data = []
     with open_by_file_pattern(path, mode="r") as f:
-        return list(map(json.loads, f.readlines()))
+        return [_decode_json(line, path, i + 1) for i, line in enumerate(f)]
+
 
 
 def _get_json_file(path):


### PR DESCRIPTION
This pull request improves the error messages in case of parsing failures on the jsonl test files. Currently it is quite cryptic, with a misleading message about the failure being on line number 1.

```
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 5338 (char 5337)
```

In this particular case, it turned out the error was actually on line 143!


With this commit, it should now give a much nicer message:
```
ValueError: Error parsing JSON on line 143: Expecting ',' delimiter at decompilation-func-recovery/samples-x86-musl.jsonl:143:5338
```