### PR TITLE
Principle of Explosion: On the State of Open Math Problems, Heuristics, and False Inferences

### DIFF
--- a/evals/registry/data/open_math_problems/open_math_problems.jsonl
+++ b/evals/registry/data/open_math_problems/open_math_problems.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:333a51d0a0b4a2e6dc4608156c6fdd61b7adb70292d05ec8515ee9b79fa2bd2b
+size 7101

--- a/evals/registry/evals/open-math-problems.yaml
+++ b/evals/registry/evals/open-math-problems.yaml
@@ -1,0 +1,10 @@
+open-math-problems:
+  id: open-math-problems.s1.simple-v0
+  description: tet
+  disclaimer: test
+  metrics: [accuracy]
+open-math-problems.s1.simple-v0:
+  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
+  args:
+    samples_jsonl: open_math_problems/open_math_problems.jsonl
+    modelgraded_spec_file: open-math-problem

--- a/evals/registry/modelgraded/open-math-problem.yaml
+++ b/evals/registry/modelgraded/open-math-problem.yaml
@@ -1,0 +1,22 @@
+prompt: |-
+  You are comparing a submitted answer to an expert answer on a given question. Here is the data:
+  [BEGIN DATA]
+  ***
+  [Question]: {input}
+  ***
+  [Expert]: {ideal}
+  ***
+  [Submission]: {completion}
+  ***
+  [END DATA]
+
+  Compare the factual content of the submitted answer with the expert answer. Ignore any differences in style, grammar, or punctuation.
+  The submitted answer may either be fully consistent with the expert answer (in which case the submission is correct), or it may differ, in terms of facts, from the expert answer (in which case the submission is incorrect). Determine, in a step by step manner, your reasoning about which case applies to be sure that your conclusion is correct; avoid simply stating the correct answers at the outset. Then, print (without quotes or punctuation) only the single character "Y" (if the submission was correct) or "N" (if the submission was incorrect) on its own line. At the end, repeat just the letter again by itself on a new line.
+  Reasoning:
+eval_type: cot_classify
+choice_scores:
+  "Y": 1.0
+  "N": 0.0
+choice_strings: 'YN'
+input_outputs:
+  input: completion


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
Open Math Problems

### Eval description

Tests whether or not the AI language model can properly understand open (unresolved) math problems, and to only draw conclusions based on the available facts and findings.

### What makes this a useful eval?

Obviously, the goal here is not to expect an AI language model to perform the task that sophisticated number-crunching supercomputers perform in months and years; rather, it is to test whether or not the language model can detect the unresolved problems of mathematics (e.g., "can every integer be written as a sum of four perfect cubes?") and attempt to incorporate the previously known studies in its responses.  Currently, my tests with GPT-3.5-turbo yield logically absurd and contrary-to-facts conclusions from the language model; for instance, when GPT-3.5-turbo was asked the question `Can every integer be written as a sum of four perfect cubes (note that some of the cubes may be negative numbers)?` without any pre-prompts, this was part of its response:

> For example, consider the integer 4. We need to find four perfect cubes that add up to 4. However, the smallest perfect cube is 1, and 1+1+1+1=4, so we need at least four cubes of 1. But 1 is the only positive perfect cube that is less than 4, so we cannot write 4 as a sum of four perfect cubes.

It determines that `1+1+1+1=4` and that `1 is a perfect cube`, yet it somehow concludes, `[…] so we cannot write 4 as a sum of four perfect cubes.`; in another case, it determined that 4 is an odd number. As some of these mathematics problems have remained unsolved for decades, it is quite understandable if the AI language model is unable to arrive at a conclusion or, better yet, employs heuristics to arrive at a conjecture.  However, the way it responded in the previous excerpt, and how it built upon this already false statement in order to reach a _blanket conclusion_ that **no integer** can be written as a sum of four perfect cubes, makes an interesting issue for evaluation tests.

Additionally, some of the questions (e.g., "can every integer can be represented as a sum of three cubes of **rational** numbers?") appear to trick the AI language model, even though the question itself is trivial and all it takes for it to be proven is deducing that `n = (n^(1/3))^3 + 0^3 + 0^3`. Instead, the Model wrongly tries to relate the question to another problem (without the word highlighted word **rational**) and reason based on that: `[t]his is known as the \"sum of three cubes\" problem, and it is an open problem in mathematics. […]`

In order to satisfy the "good-eval" Criteria, I…

- Chose my evals in a thematically consistent way by choosing sample open problems from the number theory (i.e., arithmetic) branch of pure mathematics;
- Manually checked the responses of the AI language model against its model grader as well as my own reasonings, as to confirm it had failures where a human could do the task, but either GPT-4 or GPT-3.5-Turbo could not;
- Fine-tuned the default `fact.yaml` model grader into a custom evaluator that reduces down the choices of its comparison to a Yes/No answer to prevent inaccurate re-statements of the Model's own false inferences.  However, with GPT-4.0, a more robust criterion-based grader will be likely used, anyhow; and
- Included 10 modified examples from popular arithmetic questions, each with a different concept and task.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> The Model's accuracy was rather low—about 20% on average—in my tests; moreover, grading the evaluations was itself a challenging task (and perhaps one that was improved in GPT-4.0), as the fact-checking grader itself would oftentimes report a submission as correct (i.e., a subset or superset of the ideal answer) by simply repeating and re-stating some of the obviously false statements given by the language model, despite the mismatches with the expert answer.  So, as a workaround, I had to slightly modify `modelgraded/fact.yaml` to compare the Model's submissions with the ideal expert answer in a stricter way and without considering some of the false findings as just "supersets" of the expert answer.

## Eval structure 🏗️

Your eval should
- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [X] I have filled out all required fields in the evals PR form
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input":[{"role":"system","content":"Can every integer be written as a sum of four perfect cubes (note that some of the cubes may be negative numbers)?"}],"ideal":"The sum of four cubes problem asks whether every integer is the sum of four cubes of integers. It is conjectured the answer is affirmative, but this conjecture has been neither proved nor disproved. Some of the cubes may be negative numbers, in contrast to Waring's problem on sums of cubes, where they are required to be positive."}
{"input":[{"role":"system","content":"Can every integer can be represented as a sum of three cubes of rational numbers?"}],"ideal":"Yes, every integer can be represented as a sum of three cubes of rational numbers (rather than as a sum of cubes of integers).  In the equation n = x^3 + y^3 + z^3, such that n is an integer and x, y, and z are rational numbers, it can simply be deduced that y and z could equal zero and x equal n^(1/3), so that n = (n^(1/3))^3 + 0^3 + 0^3; then, n = n^(3*(1/3)) = n^(3/3) = n^1."}
{"input":[{"role":"system","content":"A perfect number is a positive integer that is equal to the sum of its positive divisors, excluding the number itself. For instance, 6 has divisors 1, 2 and 3 (excluding itself), and 1 + 2 + 3 = 6, so 6 is a perfect number. By this definition, are there any odd perfect numbers?"}],"ideal":"It is not known whether there are any odd perfect numbers, nor whether infinitely many perfect numbers exist."}
{"input":[{"role":"system","content":"A twin prime is a prime number that is either 2 less or 2 more than another prime number, like either member of the twin prime pair (41, 43). In other words, a twin prime is a prime that has a prime gap of two. By this definition, does there exist infinitely many twin primes?"}],"ideal":"Twin primes become increasingly rare as one examines larger ranges. The question of whether there exist infinitely many twin primes has been one of the great open questions in number theory for many years. This is the content of the twin prime conjecture, which states that there are infinitely many primes p such that p + 2 is also prime. A strengthening of the conjecture, if proved, would also prove there is an infinite number of twin primes."}
{"input":[{"role":"system","content":"A quasiperfect number is a natural number n for which the sum of all its divisors is equal to 2n + 1. Equivalently, n is the sum of its non-trivial divisors (that is, its divisors excluding 1 and n). What is the smallest quasiperfect number?"}],"ideal":"No quasiperfect numbers have been found so far, though if a quasiperfect number exists, it must be an odd square number greater than 1035 and have at least seven distinct prime factors."}
{"input":[{"role":"system","content":"An almost perfect number is a natural number n such that the sum of all divisors of n is equal to 2n - 1. How many odd almost perfect numbers are there?"}],"ideal":"The only known almost perfect numbers are powers of 2 with non-negative exponents. Therefore, the only known odd almost perfect number is 2^0 = 1, and the only known even almost perfect numbers are those of the form 2k for some positive integer k; however, it has not been shown that all almost perfect numbers are of this form. It is known that an odd almost perfect number greater than 1 would have at least six prime factors."}
{"input":[{"role":"system","content":"A strictly semiperfect number is a natural number n that is equal to the sum of some of its proper divisors; for example, 6 is not a strictly semiperfect number because its proper divisors (1, 2 and 3) ALL need to be added together in order to equal 6, but 12 is a strictly semiperfect number, because only SOME of its proper divisors (i.e., 1, 2, 3, 4, 6, and 12) need to be added together to equal 12 (e.g., 6 + 1 + 2 + 3 = 12, or 6 + 4 + 2 = 12). The first strictly semiperfect numbers are 20, 88, 104, 272, 304, 350, and so on. Based on this definition, can there be any odd strictly semiperfect numbers?"}],"ideal":"Yes, the smallest odd semiperfect number is 945 where the sum of some of its proper divisors can equal 945: 135 + 189 + 315 + 105 + 35 + 45 + 63 + 21 + 27 + 3 + 7 = 945."}
{"input":[{"role":"system","content":"A semiperfect number is a natural number n that is equal to the sum of all or some of its proper divisors. Furthermore, an abundant number is a natural number n for which the sum of its proper divisors is greater than the number. A weird number is a natural number that is abundant but not semiperfect. In other words, the sum of the proper divisors (divisors including 1 but not the number itself) of the number is greater than the number, but no subset of those divisors sums to the number itself. Can any odd weird number based on this definition exist?"}],"ideal":"Infinitely many weird numbers exist. For example, 70p is weird for all primes p >= 149. In fact, the set of weird numbers has positive asymptotic density. However, it is neither known nor proven if any odd weird numbers exist or do not exist, though if they do, they must be greater than 1021."}
{"input":[{"role":"system","content":"An untouchable number is a positive integer that cannot be expressed as the sum of all the proper divisors of any positive integer (including the untouchable number itself). For example, the number 4 is not untouchable as it is equal to the sum of the proper divisors of 9: 1 + 3 = 4. On the other hand, the number 52 is untouchable as it is not the sum of the proper divisors of any positive integer. Based on this definition, can there be an odd untouchable number?"}],"ideal":"Yes, there is an odd untouchable number. The number 5 is untouchable as it is not the sum of the proper divisors of any positive integer: 5 = 1 + 4 is the only way to write 5 as the sum of distinct positive integers including 1, but if 4 divides a number, 2 does also, so 1 + 4 cannot be the sum of all of any number's proper divisors (since the list of factors would have to contain both 4 and 2). However, even though it is a proven fact that there are infinitely many untouchable numbers, the number 5 is believed to be the only odd untouchable number, though it has not been proven whether more odd untouchable numbers exist or not."}
{"input":[{"role":"system","content":"A Lychrel number is a natural number that cannot form a palindrome (a number such as 16461 that remains the same when its digits are reversed. In other words, it has reflectional symmetry across a vertical axis) through the iterative process of repeatedly reversing its digits and adding the resulting numbers. Are there any Lychrel numbers in base-2?"}],"ideal":"In base-2, the binary number 10110 (22 in decimal) has been proven to be a Lychrel number, since after 4 steps it reaches 10110100, after 8 steps it reaches 1011101000, after 12 steps it reaches 101111010000, and in general after 4n steps it reaches a number consisting of 10, followed by n + 1 ones, followed by 01, followed by n + 1 zeros. This number obviously cannot be a palindrome, and none of the other numbers in the sequence are palindromes."}

  ```
</details>
