### PR TITLE
more or less fixing sampling calls hanging

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ I changed my data but this isn't reflected when running my eval, what's going on
 
 - Your data may have been cached to `/tmp/filecache`. Try removing this cache and rerunning your eval.
 
+When I run an eval, it sometimes hangs at the very end (after the final report). What's going on?
+
+- This is a known issue, but you should be able to interrupt it safely and the eval should finish immediately after.
+
 There's a lot of code, and I just want to spin up a quick eval. Help? OR,
 
 I am a world-class prompt engineer. I choose not to code. How can I contribute my wisdom?

--- a/docs/run-evals.md
+++ b/docs/run-evals.md
@@ -25,11 +25,12 @@ oaievalset gpt-3.5-turbo test
 
 Similarly, `oaievalset` also expects a model name and an eval set name, for which the valid options are specified in the YAML files under `evals/registry/eval_sets`.
 
-By default we run with 10 threads. You can configure this, e.g.,
+By default we run with 10 threads, and each thread times out and restarts after 40 seconds. You can configure this, e.g.,
 
 ```sh
-EVALS_THREADS=42 oaievalset gpt-3.5-turbo test
+EVALS_THREADS=42 EVALS_THREAD_TIMEOUT=600 oaievalset gpt-3.5-turbo test
 ```
+Running with more threads will make the eval faster, though keep in mind the costs and your [rate limits](https://platform.openai.com/docs/guides/rate-limits/overview). Running with a higher thread timeout may be necessary if you expect each sample to take a long time, e.g., the data contain long prompts that elicit long responses from the model.
 
 If you have to stop your run or your run crashes, we've got you covered! `oaievalset` records the evals that finished in `/tmp/oaievalset/{model}.{eval_set}.progress.txt`. You can simply rerun the command to pick up where you left off. If you want to run the eval set starting from the beginning, delete this progress file.
 


### PR DESCRIPTION
This should mostly fix the issue of certain samples hanging due to the API call and blocking the eval from finishing. The solution is to have each thread time out and make a new API call if the original call was taking too long. This was surprisingly hard (for me) to implement correctly, and potentially this is just a hard problem to solve in Python since killing off threads is not supported or regarded as good practice. So it's a "partial" fix because the eval still hangs -- it just does so now at the very end, which is not blocking and (AFAICT) it's safe to interrupt it and you still get all your eval results. I added some docs to note this behavior as well as the environment variable that controls the timeout duration. Would be good to get another set of eyes on this.