### PR TITLE
Implement --no-cache functionality

### DIFF
--- a/docs/custom-eval.md
+++ b/docs/custom-eval.md
@@ -45,8 +45,14 @@ class Arithmetic(evals.Eval):
         """
         Called by the `oaieval` CLI to run the eval. The `eval_all_samples` method calls `eval_sample`.
         """
-        self.train_samples = evals.get_jsonl(self.train_jsonl)
-        test_samples = evals.get_jsonl(self.test_jsonl)
+        self.train_samples = evals.get_jsonl(
+            self.train_jsonl,
+            create_cache=recorder.run_spec.run_config['create_cache']
+        )
+        test_samples = evals.get_jsonl(
+            self.test_jsonl,
+            create_cache=recorder.run_spec.run_config['create_cache']
+        )
         self.eval_all_samples(recorder, test_samples)
 
         # Record overall metrics

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -146,6 +146,7 @@ def run(args):
         "initial_settings": {
             "visible": visible,
         },
+        "create_cache": args.cache,
     }
 
     model_name = model_specs.completions_[0].name if len(model_specs.completions_) > 0 else "n/a"
@@ -170,9 +171,9 @@ def run(args):
     else:
         recorder = evals.record.Recorder(record_path, run_spec=run_spec)
 
-    api_extra_options = {}
-    if not args.cache:
-        api_extra_options["cache_level"] = 0
+    # api_extra_options = {}
+    # if not args.cache:
+    #     api_extra_options["cache_level"] = 0
 
     run_url = f"{run_spec.run_id}"
     logger.info(_purple(f"Run started: {run_url}"))

--- a/evals/data.py
+++ b/evals/data.py
@@ -128,7 +128,7 @@ def get_lines(path) -> list[dict]:
 
 
 @filecache
-def get_jsonl(path: str, cache_enabled: Optional[bool] = None) -> list[dict]:
+def get_jsonl(path: str, create_cache: Optional[bool] = None) -> list[dict]:
     """
     Extract json lines from the given path.
     If the path is a directory, look in subpaths recursively.
@@ -139,7 +139,7 @@ def get_jsonl(path: str, cache_enabled: Optional[bool] = None) -> list[dict]:
         result = []
         for filename in bf.listdir(path):
             if filename.endswith(".jsonl"):
-                result += get_jsonl(os.path.join(path, filename), cache_enabled)
+                result += get_jsonl(os.path.join(path, filename), create_cache=create_cache)
         return result
     return _get_jsonl_file(path)
 

--- a/evals/elsuite/basic/fuzzy_match.py
+++ b/evals/elsuite/basic/fuzzy_match.py
@@ -40,7 +40,9 @@ class FuzzyMatch(evals.Eval):
         )
 
     def run(self, recorder: RecorderBase):
-        samples = evals.get_jsonl(self.samples_jsonl)
+        samples = evals.get_jsonl(
+            self.samples_jsonl, create_cache=recorder.run_spec.run_config['create_cache']
+        )
         self.eval_all_samples(recorder, samples)
 
         return {

--- a/evals/elsuite/basic/includes.py
+++ b/evals/elsuite/basic/includes.py
@@ -30,7 +30,9 @@ class Includes(evals.Eval):
         return includes_answer
 
     def run(self, recorder):
-        samples = evals.get_jsonl(self.samples_jsonl)
+        samples = evals.get_jsonl(
+            self.samples_jsonl, create_cache=recorder.run_spec.run_config['create_cache']
+        )
         self.eval_all_samples(recorder, samples)
         events = recorder.get_scores("accuracy")
         return {

--- a/evals/elsuite/basic/match.py
+++ b/evals/elsuite/basic/match.py
@@ -23,7 +23,7 @@ class Match(evals.Eval):
         if self.num_few_shot > 0:
             assert few_shot_jsonl is not None, "few shot requires few shot sample dataset"
             self.few_shot_jsonl = few_shot_jsonl
-            self.few_shot = evals.get_jsonl(self.few_shot_jsonl)
+            self.few_shot = evals.get_jsonl(self.few_shot_jsonl, create_cache=False)
 
     def eval_sample(self, sample: Any, *_):
         prompt = sample["input"]
@@ -37,7 +37,9 @@ class Match(evals.Eval):
         return evals.check_sampled_text(self.model_spec, prompt, expected=sample["ideal"])
 
     def run(self, recorder):
-        samples = evals.get_jsonl(self.samples_jsonl)
+        samples = evals.get_jsonl(
+            self.samples_jsonl, create_cache=recorder.run_spec.run_config['create_cache']
+        )
         self.eval_all_samples(recorder, samples)
         events = recorder.get_events("match")
         return {

--- a/evals/elsuite/modelgraded/classify.py
+++ b/evals/elsuite/modelgraded/classify.py
@@ -286,7 +286,9 @@ class ModelBasedClassify(evals.Eval):
         return choice
 
     def run(self, recorder):
-        samples = evals.get_jsonl(self.samples_jsonl)
+        samples = evals.get_jsonl(
+            self.samples_jsonl, create_cache=recorder.run_spec.run_config['create_cache']
+        )
 
         self.eval_all_samples(recorder, samples)
         all_sample_metrics = recorder.get_metrics()

--- a/evals/elsuite/translate.py
+++ b/evals/elsuite/translate.py
@@ -26,7 +26,7 @@ class Translate(evals.Eval):
         if self.num_few_shot > 0:
             assert few_shot_jsonl is not None, "few shot requires few shot sample dataset"
             self.few_shot_jsonl = few_shot_jsonl
-            self.few_shot = evals.get_jsonl(self.few_shot_jsonl)
+            self.few_shot = evals.get_jsonl(self.few_shot_jsonl, create_cache=False)
 
         self.bleu = BLEU(effective_order=True)
 
@@ -61,7 +61,9 @@ class Translate(evals.Eval):
             return match
 
     def run(self, recorder):
-        samples = evals.get_jsonl(self.samples_jsonl)
+        samples = evals.get_jsonl(
+            self.samples_jsonl, create_cache=recorder.run_spec.run_config['create_cache']
+        )
         self.eval_all_samples(recorder, samples)
         events = recorder.get_events("match")
 


### PR DESCRIPTION
A simple fix for --no-cache arg to address issue #305 

- Added `create_cache` keyword argument to the `get_jsonl` function
- Modified the `filecache` decorator to support the `create_cache` kwarg
- Passed `create_cache` status through classes and functions as needed

This change allows users to control the caching behaviour of oaieval by passing the --cache / --no-cache argument to the existing file caching functionality, through the recorder config.