### PR TITLE
add imagenet captions eval

### DIFF
--- a/evals/registry/data/imagenet_captions/samples.jsonl
+++ b/evals/registry/data/imagenet_captions/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5d1ee1d5e4d2e4381636f60121adc001df7a1ef1baadaedfdbb4ca81ed03c27
-size 281236
+oid sha256:9ba0dcea9c53167f7fcdaf5135ead6a089b3571556bdd520403c7db915a2d72f
+size 273819

--- a/evals/registry/data/imagenet_captions/samples.jsonl
+++ b/evals/registry/data/imagenet_captions/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5d1ee1d5e4d2e4381636f60121adc001df7a1ef1baadaedfdbb4ca81ed03c27
+size 281236

--- a/evals/registry/evals/imagenet-captions.yaml
+++ b/evals/registry/evals/imagenet-captions.yaml
@@ -1,0 +1,8 @@
+imagenet_captions:
+  id: imagenet-captions.dev.v0
+  metrics: [accuracy]
+
+imagenet-captions.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: imagenet_captions/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
ImageNet Captions Classification

### Eval description

Classify the *captions* of imagenet images as one of the thousand ImageNet classes (without giving an explicit list of ImageNet classes).

### What makes this a useful eval?

I think this tests the model's retrieval and understanding capabilities for a wide range of concepts (1000 ImageNet classes), and its something a linear model (with some training data) can do quite well.  Note the model already knows what the 1000 imagenet classes *are* (se photo below) but it really struggles matching that knowledge with these captions.

<img width="969" alt="Screen Shot 2023-03-18 at 9 10 51 AM" src="https://user-images.githubusercontent.com/1361040/226118432-3722264e-2eea-4209-935c-25db14f2db8b.png">


## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

Imagenet is an foundational benchmark for computer vision. ImageNet captions is a dataset introduced in https://arxiv.org/abs/2205.01397 that pairs true (flickr user generated) captions with imagenet image. This eval is to measure the ImageNet accuracy given ONLY the caption (for added difficulty the imagenet classes are not given, but this should be known by the model). Atleast when I ran it gpt3-turbo got 3% accuracy. As far as I know a linear model trained on some of this caption data can get 85% accuracy.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request. 

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "100_0042 Ancient Greek bronze cuirass and helemt"}], "ideal": "cuirass"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "breast plate "}], "ideal": "breastplate"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "IMG_0622 dead Sea snake Fraser Island"}], "ideal": "sea_snake"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "Moray eel Moray eel"}], "ideal": "eel"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "northern water snake My husband's photos weren't extremely clear.  He thought the snake was going to get him and since he wasn't sure of what it was at the time, he tried to carefully back up on the rocks as the snake kept approaching.  "}], "ideal": "water_snake"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "Diadophis punctatus 20050313_DSC_2847 Ring-necked snake"}], "ideal": "ringneck_snake"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "157-5776_IMG "}], "ideal": "tusker"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "Indian Elephant 4 "}], "ideal": "Indian_elephant"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "Elephant Maasai Mara, Kenya"}], "ideal": "African_elephant"}
{"input": [{"role": "system", "content": "Classify the following text as one of the 1000 ImageNet classes."}, {"role": "user", "content": "dessert! i had another paying photo gig!  cystic fibrosis foundation's yearly conference.  for two nights i shot cocktail hours, speakers at the podium, and an awards ceremony.  it was a complete success and i had a lot of fun doing it too.  it was hard work but i can't wait to do it again! :)\n\ni can't say enough how much of a great and strong foundation this is.  <a href=\"http://www.cff.org/\" rel=\"noreferrer nofollow\">www.cff.org/</a>\n\nonce again i got to eat because they didn't want me taking photos while people were eating and the awards ceremony was after dinner.  score!\n\ni had to get my creative fun in where i could.  unlike a wedding they weren't interested in shots like these, just head shots and groups of people in 2's &amp; 3's."}], "ideal": "chocolate_sauce"}
  ```
</details>
