### PR TITLE
add workflow_dispatch for manual triggering & add paths to target registry

### DIFF
--- a/.github/workflows/test_eval.yaml
+++ b/.github/workflows/test_eval.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'evals/registry/**'
 
 jobs:
   check_files:

--- a/.github/workflows/test_eval.yaml
+++ b/.github/workflows/test_eval.yaml
@@ -1,6 +1,7 @@
 name: Run new evals
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Currently, the workflow is triggered only with pull requests. Having a workflow_dispatch will allow people who clone the repository to manually run the workflow before making a PR (and allow you to manually trigger it as well).

Edit: Also modified the trigger so that the workflow is only ran for changes in `evals/registry` for PRs.