### PR TITLE
Change CI to use a dummy model call

### DIFF
--- a/.github/workflows/test_eval.yaml
+++ b/.github/workflows/test_eval.yaml
@@ -40,8 +40,6 @@ jobs:
         echo "new_files=$(cat new_files)" >> $GITHUB_ENV
 
     - name: Run oaieval command for each new YAML file
-      env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
         files="${{ env.new_files }}"
         if [ -n "$files" ]; then
@@ -49,9 +47,8 @@ jobs:
             echo "Processing $file"
             first_key=$(python .github/workflows/parse_yaml.py $file)
             echo "Eval Name: $first_key"
-            # Replace the following line with the actual oaieval command if needed
-            echo "Running: oaieval gpt-4 $first_key"
-            oaieval gpt-4 $first_key --max_samples 10
+            oaieval dummy-chat $first_key --max_samples 10
+            oaieval dummy-completion $first_key --max_samples 10
           done
         else
           echo "No new YAML files found in evals/registry/evals"

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -51,6 +51,7 @@ def n_ctx_from_model_name(model_name: str) -> Optional[int]:
     """Returns n_ctx for a given API model name. Model list last updated 2023-03-14."""
     # note that for most models, the max tokens is n_ctx + 1
     DICT_OF_N_CTX_BY_MODEL_NAME_PREFIX: dict[str, int] = {
+        "dummy-": 2048,
         "gpt-3.5-turbo-": 4096,
         "gpt-4-": 8192,
         "gpt-4-32k-": 32768,
@@ -92,9 +93,19 @@ class ModelResolver:
         "gpt-4-0314",
         "gpt-4-32k",
         "gpt-4-32k-0314",
+        "dummy-chat",
+    }
+
+    DUMMY_MODELS = {
+        "dummy-chat",
+        "dummy-completion",
     }
 
     def resolve(self, name: str) -> ModelSpec:
+        if name in self.DUMMY_MODELS:
+            result = ModelSpec(name=name, model=name, is_chat=(name in self.CHAT_MODELS))
+            return result
+
         if name in self.api_model_ids:
             result = ModelSpec(
                 name=name,

--- a/evals/elsuite/modelgraded/classify.py
+++ b/evals/elsuite/modelgraded/classify.py
@@ -46,8 +46,6 @@ Reasoning:""".strip(),
     """.strip(),
 }
 
-EVAL_MODELSPEC = ModelSpec(name="gpt-3.5-turbo", model="gpt-3.5-turbo", is_chat=True)
-
 
 def choice_to_str(choice_strings: Iterable[str]) -> str:
     """Return a string of choices, e.g. '"Yes" or "No" or "Maybe"'."""
@@ -118,6 +116,13 @@ class ModelBasedClassify(evals.Eval):
         self.multicomp_n = multicomp_n
         self.multicomp_temperature = multicomp_temperature
         self.samples_renamings = samples_renamings or {}
+
+        if self.model_spec.name == "dummy-completion" or self.model_spec.name == "dummy-chat":
+            self.eval_modelspec = self.model_spec
+        else:
+            self.eval_modelspec = ModelSpec(
+                name="gpt-3.5-turbo", model="gpt-3.5-turbo", is_chat=True
+            )
 
         """import prompt and set attributes"""
         modelgraded_specs = load_modelgraded_specs(modelgraded_spec_file)
@@ -254,7 +259,7 @@ class ModelBasedClassify(evals.Eval):
             metrics = {}
             evaluate = PromptFn(
                 self.prompt,
-                model_spec=EVAL_MODELSPEC,
+                model_spec=self.eval_modelspec,
                 max_tokens=self.max_tokens,
             )
             eval_kwargs = dict(**completions, **test_sample)

--- a/evals/utils/api_utils.py
+++ b/evals/utils/api_utils.py
@@ -7,6 +7,41 @@ import backoff
 import openai
 
 
+def generate_dummy_chat_completion():
+    return {
+        "id": "dummy-id",
+        "object": "chat.completion",
+        "created": 12345,
+        "model": "dummy-chat",
+        "usage": {"prompt_tokens": 56, "completion_tokens": 6, "total_tokens": 62},
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "This is a dummy response."},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+    }
+
+
+def generate_dummy_completion():
+    return {
+        "id": "dummy-id",
+        "object": "text_completion",
+        "created": 12345,
+        "model": "dummy-completion",
+        "choices": [
+            {
+                "text": "This is a dummy response.",
+                "index": 0,
+                "logprobs": None,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 6, "total_tokens": 11},
+    }
+
+
 @backoff.on_exception(
     wait_gen=backoff.expo,
     exception=(
@@ -24,6 +59,9 @@ def openai_completion_create_retrying(*args, **kwargs):
     Helper function for creating a completion.
     `args` and `kwargs` match what is accepted by `openai.Completion.create`.
     """
+    if kwargs["model"] == "dummy-completion":
+        return generate_dummy_completion()
+
     result = openai.Completion.create(*args, **kwargs)
     if "error" in result:
         logging.warning(result)
@@ -48,6 +86,9 @@ def openai_chat_completion_create_retrying(*args, **kwargs):
     Helper function for creating a chat completion.
     `args` and `kwargs` match what is accepted by `openai.ChatCompletion.create`.
     """
+    if kwargs["model"] == "dummy-chat":
+        return generate_dummy_chat_completion()
+
     result = openai.ChatCompletion.create(*args, **kwargs)
     if "error" in result:
         logging.warning(result)


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
[Insert Eval name here]

### Eval description

[Insert a short description of what your eval does here]

### What makes this a useful eval?

[Insert why this eval is worth including and any additional context]

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [ ] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [ ] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [ ] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [ ] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [ ] Check that your data is in `evals/registry/data/{name}`
- [ ] Check that your yaml is registered at `evals/registry/evals/{name}.jsonl`
- [ ] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [ ] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [ ] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [ ] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [ ] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  INSERT_EVAL_HERE
  ```
</details>
