### PR TITLE
Add q-learn eval

### DIFF
--- a/evals/registry/data/q-learn/q_learning_examples.jsonl
+++ b/evals/registry/data/q-learn/q_learning_examples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ccdc2aa434c66ad081b3d167f5303a7d6a725e4b02ef56c42a764348ea0a01a
+size 38949

--- a/evals/registry/evals/q-learn.yaml
+++ b/evals/registry/evals/q-learn.yaml
@@ -1,0 +1,8 @@
+q-learning:
+  id: q-learning.s1.simple-v0
+  description: Test the model's ability to understand Q-learning concepts, rules, and theory
+  metrics: [accuracy]
+q-learning.s1.simple-v0:
+  class: evals.elsuite.basic.fuzzy_match:FuzzyMatch
+  args:
+    samples_jsonl: q-learn/q_learning_examples.jsonl

--- a/scripts/q-learn/q-learn-generator1.py
+++ b/scripts/q-learn/q-learn-generator1.py
@@ -1,0 +1,62 @@
+import json
+import random
+
+import numpy as np
+
+# Q-learning parameters
+num_states = 10
+num_actions = 10
+num_examples = 50
+alpha = 0.1
+gamma = 0.9
+epsilon = 0.1
+q_table = np.zeros((num_states, num_actions))
+
+# Helper function to generate random action-value table
+def generate_action_value_table():
+    return [
+        [round(random.uniform(-1, 1), 2) for _ in range(num_actions)] for _ in range(num_states)
+    ]
+
+
+# Q-learning function to update the Q-table
+def q_learning(state, action, reward, next_state):
+    max_next_action = np.argmax(q_table[next_state])
+    q_table[state][action] += alpha * (
+        reward + gamma * q_table[next_state][max_next_action] - q_table[state][action]
+    )
+
+
+# Generate examples
+examples = []
+for i in range(num_examples):
+    state = random.randint(0, num_states - 1)
+    if random.random() < epsilon:
+        action = random.randint(0, num_actions - 1)
+    else:
+        action = np.argmax(q_table[state])
+    reward = random.uniform(-1, 1)
+    next_state = random.randint(0, num_states - 1)
+
+    q_learning(state, action, reward, next_state)
+
+    examples.append(
+        {
+            "input": [
+                {
+                    "role": "system",
+                    "content": "You are a Q-learning AI model. You have just finished training and the user wants to see the action-value table for a given state.",
+                },
+                {
+                    "role": "user",
+                    "content": f"Please provide the action-value table for the state '{state}'.",
+                },
+            ],
+            "ideal": [f"{json.dumps(q_table[state].tolist(), indent=2)}"],
+        }
+    )
+
+# Save JSONL file
+with open("q_learning_examples.jsonl", "w") as f:
+    for example in examples:
+        f.write(json.dumps(example) + "\n")

--- a/scripts/q-learn/q-learn-generator2.py
+++ b/scripts/q-learn/q-learn-generator2.py
@@ -1,0 +1,67 @@
+import json
+import random
+
+# Q-learning parameters
+num_states = 100
+num_actions = 100
+num_examples = 100
+
+# Helper function to generate random action-value table
+def generate_action_value_table():
+    return [
+        [round(random.uniform(-1, 1), 2) for _ in range(num_actions)] for _ in range(num_states)
+    ]
+
+
+# Generate positive examples
+positive_examples = []
+for _ in range(num_examples):
+    state = random.randint(0, num_states - 1)
+    action_value_table = generate_action_value_table()
+
+    positive_examples.append(
+        {
+            "input": [
+                {
+                    "role": "system",
+                    "content": "You are a Q-learning AI model. You have just finished training and the user wants to see the action-value table for a given state.",
+                },
+                {
+                    "role": "user",
+                    "content": f"Please provide the action-value table for the state '{state}'.",
+                },
+            ],
+            "ideal": [f"{json.dumps(action_value_table, indent=2)}"],
+        }
+    )
+
+# Generate negative examples
+negative_examples = []
+for _ in range(num_examples):
+    state = random.randint(0, num_states - 1)
+    action_value_table = generate_action_value_table()
+
+    negative_examples.append(
+        {
+            "input": [
+                {
+                    "role": "system",
+                    "content": "You are a Q-learning AI model. You have just finished training and the user wants to see the action-value table for a given state.",
+                },
+                {
+                    "role": "user",
+                    "content": f"Please provide the action-value table for the state '{state}'.",
+                },
+            ],
+            "ideal": [f"{json.dumps(action_value_table, indent=2)}"],
+        }
+    )
+
+# Save JSONL files
+with open("positive_examples_q_learning.jsonl", "w") as f:
+    for example in positive_examples:
+        f.write(json.dumps(example) + "\n")
+
+with open("negative_examples_q_learning.jsonl", "w") as f:
+    for example in negative_examples:
+        f.write(json.dumps(example) + "\n")


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
q-learn

### Eval description

This eval is about q-learning, a type of reinforcement learning algorithm that aims to find the optimal policy for an agent to take actions in an environment, based on maximizing the expected cumulative reward. It uses a Q-value function to estimate the expected cumulative reward of taking an action in a given state.

### What makes this a useful eval?

An evaluation on Q-Learning may be important for GPT because it can help determine the effectiveness of using this algorithm for tasks related to reinforcement learning, such as generating text or completing tasks in virtual environments. By evaluating the performance of Q-Learning on a given task, GPT may be able to determine whether it is an appropriate algorithm to use, or if another reinforcement learning algorithm may be more effective. Additionally, the evaluation may provide insight into how to optimize Q-Learning for GPT's specific use cases.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

Disclaimer: One of the Q-Learning generators produced data with a score of 1.0 on the oaieval.py evaluation, while the other Q-Learning generator produced data with a score of 0.0. I suggest to check them both out. I can remove the generators or improve them to save the files in the right location and so on if requested.


### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  $ oaieval gpt-3.5-turbo q-learning.s1.simple-v0
[2023-03-19 22:27:59,287] [registry.py:145] Loading registry from /home/mmtmn/evals/evals/registry/evals
[2023-03-19 22:27:59,310] [registry.py:145] Loading registry from /home/mmtmn/.evals/evals
[2023-03-19 22:28:00,164] [oaieval.py:189] Run started: 230320012800Y4AKEVDN
[2023-03-19 22:28:00,164] [data.py:78] Fetching q-learn/q_learning_examples.jsonl
[2023-03-19 22:28:00,165] [eval.py:30] Evaluating 100 samples
[2023-03-19 22:28:00,170] [eval.py:136] Running in threaded mode with 10 threads!
 92%|██████████████████████████████████████████████████████████████████▏     | 92/100 [00:09<00:00, 15.46it/s][2023-03-19 22:28:10,217] [record.py:309] Logged 377 rows of events to /tmp/evallogs/230320012800Y4AKEVDN_gpt-3.5-turbo_q-learning.s1.simple-v0.jsonl: insert_time=16.296ms
100%|███████████████████████████████████████████████████████████████████████| 100/100 [00:10<00:00,  9.69it/s]
[2023-03-19 22:28:10,494] [record.py:320] Final report: {'accuracy': 0.0, 'f1_score': 0.0}. Logged to /tmp/evallogs/230320012800Y4AKEVDN_gpt-3.5-turbo_q-learning.s1.simple-v0.jsonl
[2023-03-19 22:28:10,494] [oaieval.py:220] Final report:
[2023-03-19 22:28:10,494] [oaieval.py:222] accuracy: 0.0
[2023-03-19 22:28:10,494] [oaieval.py:222] f1_score: 0.0
[2023-03-19 22:28:10,496] [record.py:309] Logged 23 rows of events to /tmp/evallogs/230320012800Y4AKEVDN_gpt-3.5-turbo_q-learning.s1.simple-v0.jsonl: insert_time=1.967ms
  ```
</details>
