### PR TITLE
BugFix: Fix type annoation error in evals/base.py

### DIFF
--- a/evals/base.py
+++ b/evals/base.py
@@ -122,7 +122,7 @@ class ModelSpecs:
         return self.completions_
 
     @property
-    def names(self) -> dict[str, Sequence[str]]:
+    def names(self) -> Dict[str, Sequence[str]]:
         dict = {}
         if self.completions_ is not None:
             dict["completions"] = [model.name for model in self.completions_]


### PR DESCRIPTION
Errors:
When running command: `oaievalset gpt-3.5-turbo test`, exception are thrown as below:
```
Traceback (most recent call last):
  File "/opt/anaconda3/bin/oaievalset", line 5, in <module>
    from evals.cli.oaievalset import main
  File "/evals/evals/__init__.py", line 1, in <module>
    from .api import check_sampled_text, completion_query, sample_freeform
  File "/evals/evals/api.py", line 9, in <module>
    from evals.base import ModelSpec
  File "/evals/evals/base.py", line 93, in <module>
    class ModelSpecs:
  File "/evals/evals/base.py", line 125, in ModelSpecs
    def names(self) -> dict[str, Sequence[str]]:
TypeError: 'type' object is not subscriptable
```

Troubleshooting：
![image](https://user-images.githubusercontent.com/24562285/226232011-b11f35a5-5b33-4b87-8c94-8983657c0203.png)

Modification:
rewrite dict -> Dict