### PR TITLE
[FIX] deps: openai>=0.27.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 requires-python = ">=3.8"
 dependencies = [
     "mypy",
-    "openai",
+    "openai >= 0.27.2",
     "tiktoken",
     "blobfile",
     "backoff",


### PR DESCRIPTION
# Fix

Running`oaieval` with `openai==0.26.5` results in error:

> AttributeError: module 'openai' has no attribute 'ChatCompletion'. Did you mean: 'Completion'?

To fix that, I added in `pyproject.toml` the current [OpenAI](https://github.com/openai/openai-python/) version as a requirement.
