### PR TITLE
Only cache files that take a long time to load

### DIFF
--- a/docs/build-eval.md
+++ b/docs/build-eval.md
@@ -44,7 +44,7 @@ Register the eval by adding a file to `evals/registry/evals/<eval_name>.yaml` us
     samples_jsonl: <eval_name>/samples.jsonl
 ```
 
-Upon running the eval, the data will be searched for in `evals/registry/data`, e.g. if `test_match/samples.jsonl` is the provided filepath the data is expected to be in `evals/registry/data/test_match/samples.jsonl`. 
+Upon running the eval, the data will be searched for in `evals/registry/data`, e.g. if `test_match/samples.jsonl` is the provided filepath the data is expected to be in `evals/registry/data/test_match/samples.jsonl`.
 
 The naming convention for evals is in the form `<eval_name>.<split>.<version>`.
 - `<eval_name>` is the eval name, used to group evals whose scores are comparable.
@@ -59,7 +59,7 @@ You can now run your eval on your data from the CLI with your choice of model:
 ```
 oaieval gpt-3.5-turbo <eval_name>
 ```
-Congratulations, you have built your eval! Keep iterating on it until you are confident in the results. Remember, if you change the data file, remove `/tmp/filecache` so that the eval is run with your updated data.
+Congratulations, you have built your eval! Keep iterating on it until you are confident in the results. If you change the data file, make sure to check that your data was not cached to `/tmp/filecache` (and if it was, remove this directory) so that the eval is run with your updated data.
 
 ## For model-graded evals: a step-by-step workflow
 

--- a/evals/data.py
+++ b/evals/data.py
@@ -103,7 +103,7 @@ def filecache(func):
         md5 = hashlib.md5((name + ":" + str((args, kwargs))).encode("utf-8")).hexdigest()
         pkl_path = f"{DIR}/{md5}.pkl"
         if os.path.exists(pkl_path):
-            logger.debug(f"Loading from file cache: {pkl_path}")
+            logger.info(f"Loading from file cache: {pkl_path}")
             with open(pkl_path, "rb") as f:
                 return pickle.load(f)
         start = time.time()


### PR DESCRIPTION
After thinking about it for a little while, here's my proposal for how to disable the default file caching behavior. Basically, only cache if the load takes longer than `FILECACHE_THRESHOLD` (environment variable, default 300) seconds. I also considered caching based on where we're loading from (e.g., local vs. cloud), but that's more complicated, and this seems like the most direct solution anyway. That is, the files that take a long time to load are precisely the ones we want to cache.

Does this seem hacky? I've been staring at it and it seems reasonable to me, but I'm interested in getting second opinions.