### PR TITLE
Add run eval workflow

### DIFF
--- a/.github/workflows/run_eval.yaml
+++ b/.github/workflows/run_eval.yaml
@@ -1,0 +1,85 @@
+name: Run new evals on /run {MODEL_NAME} command
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check_files:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/run ')
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - name: Get user permission
+        id: check_permission
+        uses: actions/github-script@v5
+        env:
+          LOGIN: ${{ github.event.comment.user.login }}
+        with:
+          script: |
+            const { LOGIN } = process.env;
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: LOGIN
+            });
+            return permission.permission;
+          result-encoding: string
+      - name: Check user permission
+        if: steps.check_permission.outputs.result != 'admin' && steps.check_permission.outputs.result != 'write'
+        run: |
+          echo "User ${{ github.event.comment.user.login }} does not have write permission to this repository."
+          exit 1
+      - name: Extract command input
+        id: extract_input
+        run: |
+          model=$(echo "${{ github.event.comment.body }}" | sed -n 's/^\/run \(.*\)/\1/p')
+          echo "MODEL=$model" >> $GITHUB_ENV
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Checkout Pull Request
+        run: hub pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Git LFS
+        run: |
+          sudo apt-get install git-lfs
+          git lfs install
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+          pip install -e .
+      - name: Get list of new YAML files in evals/registry/evals
+        id: get_files
+        run: |
+          # Use environment files to store the output
+          git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '^evals/registry/evals/.*\.yaml$' | xargs > new_files
+          echo "new_files=$(cat new_files)" >> $GITHUB_ENV
+      - name: Run oaieval command for each new YAML file
+        run: |
+          files="${{ env.new_files }}"
+          if [ -n "$files" ]; then
+            for file in $files; do
+              echo "Processing $file"
+              first_key=$(python .github/workflows/parse_yaml.py $file)
+              echo "Eval Name: $first_key"
+              oaieval ${{ env.MODEL }} $first_key
+            done
+          else
+            echo "No new YAML files found in evals/registry/evals"
+          fi


### PR DESCRIPTION
Hi,
I have added a workflow to this repository based on [test_eval.yaml](https://github.com/openai/evals/blob/main/.github/workflows/test_eval.yaml). This workflow enables the detection of PR comments including /run {OPENAI_MODEL_NAME} and runs the new evals included in the PR on the given model. It is designed to run only for users with write/admin permissions.

The purpose of this workflow is to allow for public running of evaluations on GPT-4 and sharing the results with evaluation writers. Additionally, we could potentially expand this workflow to report the run results to the PR.

While I am unsure if this repository is currently accepting contributions other than evals, I believe this workflow could be a valuable addition. If there are any concerns, please do let me know and I will close this PR accordingly.
