### PR TITLE
Add evaluation for generating 2D rectangle coordinates

### DIFF
--- a/evals/elsuite/rectangles.py
+++ b/evals/elsuite/rectangles.py
@@ -1,0 +1,127 @@
+import re
+
+import evals
+import evals.metrics
+import evals.record
+
+task_description = """Give coordinates of 2D axis-aligned rectangles according to some specification, in a single code block with each rectangle on its own line, giving first the range of x coordinates, then the range of y coordinates.
+
+Note that every constraint should be strictly satisfied: for instance, two rectangles that just touch are considered neither disjoint nor overlapping. If the specification is satisfiable then respond with only one code block according to the format given above, and no other text. Otherwise respond with just the word "impossible"."""
+
+
+def anglicize_constr(constraint):
+    if constraint["kind"] == "contains":
+        return f"{constraint['big']} contains {constraint['small']}"
+    elif constraint["kind"] == "disjoint":
+        return f"{' and '.join(constraint['rects'])} are disjoint"
+    elif constraint["kind"] == "overlap":
+        return f"{' and '.join(constraint['rects'])} overlap"
+    elif constraint["kind"] == "uncovered":
+        return f"{constraint['cover']} does not fully cover {constraint['peek']}"
+
+
+def anglicize(sample):
+    names = ", ".join(sample["names"])
+    constraints = "; ".join(anglicize_constr(constraint) for constraint in sample["constraints"])
+    return f"Rectangles {names} where: {constraints}."
+
+
+float_regex = r"(-?\d+(?:\.\d+)?)"
+range_regex = rf"\[\s*{float_regex}\s*,\s*{float_regex}\s*\]"
+rect_regex = rf"\(\s*{range_regex}\s*,\s*{range_regex}\s*\)"
+regex = re.compile(rf"^\s*(\w+)\s*=\s*{rect_regex}\s*$")
+
+
+def parse(sampled):
+    rectangles = {}
+    for line in sampled.splitlines():
+        match = re.match(regex, line)
+        if match is not None:
+            name, x0, x1, y0, y1 = match.groups()
+            rectangles[name] = (float(x0), float(x1), float(y0), float(y1))
+    return rectangles
+
+
+def contains(big, small):
+    ax0, ax1, ay0, ay1 = big
+    bx0, bx1, by0, by1 = small
+    return ax0 < bx0 and bx1 < ax1 and ay0 < by0 and by1 < ay1
+
+
+def disjoint(rects):
+    (ax0, ax1, ay0, ay1), (bx0, bx1, by0, by1) = rects
+    return ax1 < bx0 or bx1 < ax0 or ay1 < by0 or by1 < ay0
+
+
+def overlap(rects):
+    (ax0, ax1, ay0, ay1), (bx0, bx1, by0, by1) = rects
+    return not (ax1 <= bx0 or bx1 <= ax0 or ay1 <= by0 or by1 <= ay0)
+
+
+def uncovered(cover, peek):
+    (ax0, ax1, ay0, ay1), (bx0, bx1, by0, by1) = cover, peek
+    return not (ax0 <= bx0 and bx1 <= ax1 and ay0 <= by0 and by1 <= ay1)
+
+
+def is_match(constraint, rectangles):
+    if constraint["kind"] == "contains":
+        return contains(rectangles[constraint["big"]], rectangles[constraint["small"]])
+    elif constraint["kind"] == "disjoint":
+        return disjoint([rectangles[name] for name in constraint["rects"]])
+    elif constraint["kind"] == "overlap":
+        return overlap([rectangles[name] for name in constraint["rects"]])
+    elif constraint["kind"] == "uncovered":
+        return uncovered(rectangles[constraint["cover"]], rectangles[constraint["peek"]])
+
+
+class Rectangles(evals.Eval):
+    def __init__(self, train_jsonl, test_jsonl, **kwargs):
+        super().__init__(**kwargs)
+        self.train_jsonl = train_jsonl
+        self.test_jsonl = test_jsonl
+
+    def eval_sample(self, sample, rng):
+        sat_example = rng.choice(self.sat_examples)
+        unsat_example = rng.choice(self.unsat_examples)
+
+        prompt = [
+            {"role": "system", "content": task_description},
+            {
+                "role": "system",
+                "content": anglicize(sat_example),
+                "name": "example_user",
+            },
+            {
+                "role": "system",
+                "content": sat_example["example"],
+                "name": "example_assistant",
+            },
+            {
+                "role": "system",
+                "content": anglicize(unsat_example),
+                "name": "example_user",
+            },
+            {"role": "system", "content": "impossible", "name": "example_assistant"},
+            {"role": "user", "content": anglicize(sample)},
+        ]
+
+        result, actual_prompt, metadata = evals.completion_query(self.model_spec, prompt)
+        sampled = result["choices"][0]["text"]
+        evals.record.record_sampling(prompt=actual_prompt, sampled=sampled, metadata=metadata)
+        if sample["satisfiable"]:
+            rectangles = parse(sampled)
+            correct = (
+                set(rectangles.keys()) == set(sample["names"])
+                and all(x0 < x1 and y0 < y1 for x0, x1, y0, y1 in rectangles.values())
+                and all(is_match(constraint, rectangles) for constraint in sample["constraints"])
+            )
+        else:
+            correct = "impossible" in sampled or "Impossible" in sampled
+        evals.record.record_match(correct, sampled=sampled)
+
+    def run(self, recorder):
+        train_samples = evals.get_jsonl(self.train_jsonl)
+        self.sat_examples = [x for x in train_samples if x["satisfiable"]]
+        self.unsat_examples = [x for x in train_samples if not x["satisfiable"]]
+        self.eval_all_samples(recorder, evals.get_jsonl(self.test_jsonl))
+        return {"accuracy": evals.metrics.get_accuracy(recorder.get_events("match"))}

--- a/evals/registry/data/rectangles/test.jsonl
+++ b/evals/registry/data/rectangles/test.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f212428c41096058af7bbc1fac787467933cf5802ba74eaa5d66ca0c993545a4
+size 45148

--- a/evals/registry/data/rectangles/train.jsonl
+++ b/evals/registry/data/rectangles/train.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5483fa32d7d22a5ce3c41168ed77274fcd02a5c4623aa1e94973296422b74ee8
+size 2515

--- a/evals/registry/evals/rectangles.yaml
+++ b/evals/registry/evals/rectangles.yaml
@@ -1,0 +1,9 @@
+rectangles:
+  id: rectangles.dev.v0
+  metrics: [accuracy]
+
+rectangles.dev.v0:
+  class: evals.elsuite.rectangles:Rectangles
+  args:
+    train_jsonl: rectangles/train.jsonl
+    test_jsonl: rectangles/test.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
`rectangles`

### Eval description

This evaluation asks the model to generate coordinates for a small number (two or three) of axis-aligned 2D rectangles satisfying simple constraints ("this contains that", "this is disjoint from that", etc), or say "impossible" if the constraints are inconsistent.

### What makes this a useful eval?

The "Building an eval" docs say that evals are wanted in the category of "Math / logical / physical reasoning". This eval is useful because it asks the model to do a simple task (a human would be able to very easily answer these questions) that ties together very basic quantitative reasoning (just inequalities) with basic logic in connection to basic geometry.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

This is a good eval because the task is straightforward/natural for humans, yet GPT-3.5 scores very low (28% accuracy). Its unique value is that, in comparison to existing match/fact evals with just one correct answer, this eval asks the model to produce one correct answer among multiple possible ones, where the correctness criterion is still unambiguous (codified here in Python).

Another unique value given by this eval is that it includes somewhat more unsatisfiable examples (63%) than satisfiable examples (37%), so GPT-3.5 would actually be able to more than double its accuracy by just always saying "impossible", and yet it doesn't. This is a nice concrete example of the model's overconfidence: doing better on this eval would align well with having the model be less overconfident in general.

<details>
<summary>I generated most of the data using a Python script using Z3; click here to see that script.</summary>

```python
#!/usr/bin/env python3

import json
import random
import string

import z3


def contains(big, small):
    ax0, ax1, ay0, ay1 = big
    bx0, bx1, by0, by1 = small
    return z3.And(ax0 < bx0, bx1 < ax1, ay0 < by0, by1 < ay1)


def disjoint(rects):
    (ax0, ax1, ay0, ay1), (bx0, bx1, by0, by1) = rects
    return z3.Or(ax1 < bx0, bx1 < ax0, ay1 < by0, by1 < ay0)


def overlap(rects):
    (ax0, ax1, ay0, ay1), (bx0, bx1, by0, by1) = rects
    return z3.And(ax1 > bx0, bx1 > ax0, ay1 > by0, by1 > ay0)


def uncovered(cover, peek):
    (ax0, ax1, ay0, ay1), (bx0, bx1, by0, by1) = cover, peek
    return z3.Or(ax0 > bx0, bx1 > ax1, ay0 > by0, by1 > ay1)


def sat_constrs(rects, constr):
    kind, a, b = constr
    if kind == "contains":
        return contains(rects[a], rects[b])
    elif kind == "disjoint":
        return disjoint([rects[a], rects[b]])
    elif kind == "overlap":
        return overlap([rects[a], rects[b]])
    elif kind == "uncovered":
        return uncovered(rects[a], rects[b])


def sat(names, constrs):
    rects = {
        name: (
            z3.Real(f"{name}_x0"),
            z3.Real(f"{name}_x1"),
            z3.Real(f"{name}_y0"),
            z3.Real(f"{name}_y1"),
        )
        for name in names
    }
    s = z3.Solver()
    return (
        s.check(
            z3.And(
                *(
                    [z3.And(x0 < x1, y0 < y1) for x0, x1, y0, y1 in rects.values()]
                    + [sat_constrs(rects, constr) for constr in constrs]
                )
            )
        )
        == z3.sat
    )


def tup_to_constrs(tup):
    c, d, o, u = tup
    return (
        [("contains", a, b) for a, b in c]
        + [("disjoint", a, b) for a, b in d]
        + [("overlap", a, b) for a, b in o]
        + [("uncovered", a, b) for a, b in u]
    )


def constr_to_constraint(names, constr):
    kind, a, b = constr
    if kind == "contains":
        return {"kind": kind, "big": names[a], "small": names[b]}
    elif kind == "disjoint":
        return {"kind": kind, "rects": [names[a], names[b]]}
    elif kind == "overlap":
        return {"kind": kind, "rects": [names[a], names[b]]}
    elif kind == "uncovered":
        return {"kind": kind, "cover": names[a], "peek": names[b]}


all_names = list(string.ascii_uppercase)


def exhaust(n):
    done = {}
    todo = [((), (), (), ())]

    def attempt(tup):
        if tup not in done:
            is_sat = sat(range(n), tup_to_constrs(tup))
            done[tup] = is_sat

            names = all_names[:n]
            constrs = tup_to_constrs(tup)
            random.shuffle(names)
            random.shuffle(constrs)
            print(
                json.dumps(
                    {
                        "names": sorted(names),
                        "satisfiable": is_sat,
                        "constraints": [
                            constr_to_constraint(names, constr) for constr in constrs
                        ],
                    }
                )
            )

            if is_sat:
                todo.append(tup)

    def candidates(l):
        if l:
            a0, b0 = l[-1]
            return [(a0, b1) for b1 in range(b0 + 1, n)] + [
                (a1, b1) for a1 in range(a0 + 1, n - 1) for b1 in range(a1 + 1, n)
            ]
        else:
            return [(0, 1)]

    while todo:
        tup = todo.pop()
        c, d, o, u = tup
        for a, b in candidates(c):
            attempt((tuple([*c, (a, b)]), d, o, u))
        for a, b in candidates(d):
            attempt((c, tuple([*d, (a, b)]), o, u))
        for a, b in candidates(o):
            attempt((c, d, tuple([*o, (a, b)]), u))
        for a, b in candidates(u):
            attempt((c, d, o, tuple([*u, (a, b)])))


def main():
    random.seed(0)
    for n in range(2, 4):
        exhaust(n)


if __name__ == "__main__":
    main()
```
</details>

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"names": ["A", "B", "C"], "satisfiable": true, "constraints": [{"kind": "contains", "big": "A", "small": "C"}]}
  {"names": ["A", "B", "C"], "satisfiable": true, "constraints": [{"kind": "disjoint", "rects": ["B", "C"]}]}
  {"names": ["A", "B", "C"], "satisfiable": true, "constraints": [{"kind": "overlap", "rects": ["C", "B"]}]}
  {"names": ["A", "B", "C"], "satisfiable": true, "constraints": [{"kind": "uncovered", "cover": "B", "peek": "A"}]}
  {"names": ["A", "B", "C"], "satisfiable": false, "constraints": [{"kind": "contains", "big": "A", "small": "B"}, {"kind": "uncovered", "cover": "A", "peek": "B"}]}
  {"names": ["A", "B", "C"], "satisfiable": true, "constraints": [{"kind": "uncovered", "cover": "C", "peek": "B"}, {"kind": "disjoint", "rects": ["C", "B"]}]}
  {"names": ["A", "B", "C"], "satisfiable": true, "constraints": [{"kind": "uncovered", "cover": "B", "peek": "C"}, {"kind": "overlap", "rects": ["B", "C"]}]}
  {"names": ["A", "B", "C"], "satisfiable": true, "constraints": [{"kind": "uncovered", "cover": "C", "peek": "A"}, {"kind": "uncovered", "cover": "C", "peek": "B"}]}
  {"names": ["A", "B", "C"], "satisfiable": true, "constraints": [{"kind": "uncovered", "cover": "C", "peek": "B"}, {"kind": "uncovered", "cover": "B", "peek": "A"}]}
  ```
</details>
