### PR TITLE
Power bonus on quiz bowl questions

### DIFF
--- a/evals/registry/data/qbpower/samples.jsonl
+++ b/evals/registry/data/qbpower/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b1e62d246648b77e8c12ff0ee08fe086879a85e5ceb1e50dea95334441a4220
+size 152044

--- a/evals/registry/evals/qbpower.yaml
+++ b/evals/registry/evals/qbpower.yaml
@@ -1,0 +1,8 @@
+qbpower:
+  id: qbpower.dev.v0
+  metrics: [accuracy]
+  description: Evaluate ability to answer factual questions from minimal distinguishing clues
+qbpower.dev.v0:
+  class: evals.elsuite.basic.fuzzy_match:FuzzyMatch
+  args:
+    samples_jsonl: qbpower/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
Quiz Bowl Power

### Eval description

This eval tests the ability of the model to answer quiz bowl questions given only the 'power' section of the question.

### What makes this a useful eval?

Quiz bowl questions have a pyramidal structure: they start with the most obscure and difficult clues, and progress to easier clues. Contestants can ring in at any time during the question. In some formats, there is a feature called 'power' where if you answer before a designated point in the question, you get extra points.

The power section of the question has been judged by experts (Quiz Bowl tournament writers and editors) to be the minimal set of facts that another expert (Quiz Bowl players) can use to uniquely determine the correct answer. As such, this task is a good test of the range of knowledge of the model and its ability to infer the answer from minimal information.

I found that GPT-3.5-Turbo got a 43% accuracy on this task.

The questions are derived from the 2022 Chicago Open, available [here](https://collegiate.quizbowlpackets.com/).

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "We are playing quiz bowl! I'll give you the first part of a quiz bowl question, and you need to identify the answer. Please answer as briefly as possible. DO NOT ANSWER IN THE FORM OF A QUESTION."}, {"role": "user", "content": "Raven Chacon dedicated his Three Points for this non-voice instrument to Dawn Avery, who repurposed a Baroque piece for this instrument in her Two Worlds. Women are indicated to sing, while men are asked to whistle a melody, in the Pianissimo second movement of The Book for this instrument by Peteris Vasks. A 24-element octahedral group forms the first of two layers of Xenakis's Nomos Alpha for this instrument, which followed his earlier Kottos. A serenade, march, and lament are interspersed between four iterations of a ANSWER:"}], "ideal": ["cello"]}
{"input": [{"role": "system", "content": "We are playing quiz bowl! I'll give you the first part of a quiz bowl question, and you need to identify the answer. Please answer as briefly as possible. DO NOT ANSWER IN THE FORM OF A QUESTION."}, {"role": "user", "content": "This kind of function can be applied to all sets of reals in a 1970 model of ZF-minus-Choice constructed by Robert Solovay. This kind of function can be used to cleave a set into two disjoint partitions in a Hahn decomposition. If one of these functions can be approximated using a supremum of compact subsets, then it is called \"inner regular;\" moreover, if it is locally finite, then it it is named for Johann Radon. These functions can be constructed from weaker \"pre-\" variants by ANSWER:"}], "ideal": ["measure"]}
{"input": [{"role": "system", "content": "We are playing quiz bowl! I'll give you the first part of a quiz bowl question, and you need to identify the answer. Please answer as briefly as possible. DO NOT ANSWER IN THE FORM OF A QUESTION."}, {"role": "user", "content": "In a book by this author, a cemetery watcher poses as a fortune teller to track down the two soldiers who had murdered his wife and daughter. This author may have plagiarized Steen Blicher's book The Rector of Veilbye for a novel in which Silas is falsely accused of killing a diamond thief. A mystery novel by this author follows Sherlock Holmes's nephew Fetlock, who blows up a cabin to kill his employer. This author wrote a story in which ANSWER:"}], "ideal": ["Twain"]}
{"input": [{"role": "system", "content": "We are playing quiz bowl! I'll give you the first part of a quiz bowl question, and you need to identify the answer. Please answer as briefly as possible. DO NOT ANSWER IN THE FORM OF A QUESTION."}, {"role": "user", "content": "A reference to this event may be inserted at any point in an otherwise unrelated story via a narrative technique called guriz. An exclamation whose second part refers to this event is the namesake of a linguistic process called the law of Hobson-Jobson. A person who recites stories that depict this event is called a rawda khwan. Literary depictions of this event include a book by Sayyed ibn Tawus titled Lohoof (\"lo-HOOFF\"), as well as a genre of poetry popularized in Lucknow by Mirza Dameer and Mir Anees; that genre of Urdu poetry is the ANSWER:"}], "ideal": ["Karbala"]}
{"input": [{"role": "system", "content": "We are playing quiz bowl! I'll give you the first part of a quiz bowl question, and you need to identify the answer. Please answer as briefly as possible. DO NOT ANSWER IN THE FORM OF A QUESTION."}, {"role": "user", "content": "The Isabella Stewart Gardner Museum owns a sarcophagus titled for this name that was discovered in Tivoli in 1535. Bradley Schaefer asserted that Hipparchus's lost star catalog was the basis for part of a sculpture titled for this name, the oldest extant sculpture of Atlas. A sculpture titled for this name was once restored because Michelangelo planned on using it for a fountain in a garden. That sculpture titled for this name is the largest single sculpture recovered from antiquity and includes a non-original dog and child at the base watching a woman and two men wrestle with a ANSWER:"}], "ideal": ["Farnese"]}
  ```
</details>
