### PR TITLE
Update `check_sampled_text` to use `endswith` instead of `startswith`

### DIFF
--- a/docs/eval-templates.md
+++ b/docs/eval-templates.md
@@ -7,7 +7,7 @@ In using Evals, we have discovered several "templates" that accommodate many dif
 In cases where the desired model response has very little variation, such as answering multiple choice questions or simple questions with a straightforward answer, we have found the following templates to be useful.
 
 For a model completion `a` and a reference list of correct answers `B`, the following evals implement:
-- [`basic/match.py:Match`](../evals/elsuite/basic/match.py): `any([b.startswith(a) for b in B])`
+- [`basic/match.py:Match`](../evals/elsuite/basic/match.py): `any([b.endswith(a) for b in B])`
 - [`basic/includes.py:Includes`](../evals/elsuite/basic/includes.py): `any([(a in b) for b in B])`
 - [`basic/fuzzy_match.py:FuzzyMatch`](../evals/elsuite/basic/fuzzy_match.py): `any([(a in b or b in a) for b in B])`
 

--- a/docs/eval-templates.md
+++ b/docs/eval-templates.md
@@ -11,7 +11,7 @@ For a model completion `a` and a reference list of correct answers `B`, the foll
 - [`basic/includes.py:Includes`](../evals/elsuite/basic/includes.py): `any([(a in b) for b in B])`
 - [`basic/fuzzy_match.py:FuzzyMatch`](../evals/elsuite/basic/fuzzy_match.py): `any([(a in b or b in a) for b in B])`
 
-Which eval template you use will depend on your use case. It is always recommended that you inspect the completions from your model, as this will help you determine how and whether to tweak your prompt (or your reference answers) and pick your eval template. Academic benchmarks oftentimes fit the mold of these basic evals, and we have implemented several end-to-end examples of academic evals as Jupyter notebooks in the `examples` folder.
+Which eval template you use will depend on your use case. It is always recommended that you inspect the completions from your model, as this will help you determine how and whether to tweak your prompt (or your reference answers) and pick your eval template. Academic benchmarks oftentimes fit the mold of these basic evals, and we have implemented several end-to-end examples of academic evals as Jupyter notebooks in the `examples` folder. 
 
 Sometimes, [custom eval logic](custom-eval.md) will better suit your needs. One example of this is the [machine translation](../evals/elsuite/translate.py) [eval example](../examples/lafand-mt.ipynb), in which there is a unique and clearly defined metric that we wish to use in our eval. You should use your best judgment when deciding between custom eval logic, using a basic eval template, or using model-graded evals as described next.
 

--- a/evals/api.py
+++ b/evals/api.py
@@ -139,7 +139,7 @@ def check_sampled_text(
 
     picked = None
     for option in options:
-        if not sampled.startswith(option):
+        if not sampled.endswith(option):
             continue
         if (
             separator is not None


### PR DESCRIPTION
The current `check_sampled_text` method run during the `basic/match.py:Match` eval uses the `string.startswith` method to test for matches.

While this works just fine for simple evaluations where the expected response will be in a set of exact string matches, it doesn't allow for basic matching on a form of prompt that allows the model to approach a final answer by "reasoning" through a problem during generation.

For instance, in the Forth Stack Simulator evals the model fails to arrive at the correct end state of the stack after only a few transformation command, even when the transformations are outlined explicitly. However, if you ask the model to provide the state after each step it does a better job at arriving at the correct output, which appears on the final line of the output.  [See this eval PR](https://github.com/openai/evals/pull/452) for the specific use case.

If `check_sampled_text` is intended only to do full string matching, and isn't used specifically to test the beginning of a response, then replacing `startswith` with `endswith` will still meet that requirement, while also allowing for tests where the final output appears at the end of a generated response, which is where it would naturally be anyways.