### PR TITLE
[eval] Add evaluation to trigger in-the-wild hallucinations of FaB Cards (<10% Accuracy on gpt-3.5-turbo)

### DIFF
--- a/evals/registry/data/card_hallucination/card_hallucination.jsonl
+++ b/evals/registry/data/card_hallucination/card_hallucination.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0112930b76f7b0f75471e5b1ba0809848e2f1afadcf88e05e13e2371dacd37ac
+size 1810

--- a/evals/registry/evals/card_hallucination.yaml
+++ b/evals/registry/evals/card_hallucination.yaml
@@ -1,0 +1,11 @@
+card_hallucination:
+  id: card_hallucination.dev.v0
+  description: Test the model's ability to determine if a Flesh and Blood card exists.
+  metrics: [accuracy]
+card_hallucination.dev.v0:
+  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
+  args:
+    samples_jsonl: card_hallucination/card_hallucination.jsonl
+    eval_type: cot_classify
+    match_fn: endswith
+    modelgraded_spec_file: fact


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
Card Hallucination

### Eval description

This eval tests the models capability to recount information of cards from the card game Flesh and Blood. The eval utilises a modelgraded approach to compare a generated response to a model solution. The eval utilises the fact framework, however a custom modelgraded framework (not included due to listed eval structure restrictions) provides higher quality answers. Accuracy on gpt-3.5-turbo consistently below 10%.

### What makes this a useful eval?

While the model is aware of many of the mechanics and structure of card, the model consistently hallucinates card effects and gives erroneous data. This is a consistent way to prompt in-the-wild hallucinations of GPT3.5 and could provide a resonable benchmark for improving accuracy and safety of responses.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

Note: I have crafted a custom modelgraded framework (not included due to listed eval structure restrictions) which provides more accurate and relevant data, as the template fact one does not pick up on when the model is hallucinating information and classifies it as a 'superset of the expert answer'.

This eval can be easily extended to include cards from other games to query different behaviour. For example, online card games have a unique property in which cards are often changed after their release, this may be an effective proxy to investigate how the model handles conflicting information within the dataset, or how it responds to change over time.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input":[{"role":"system","content":"In the card game Flesh and Blood, what does the card 'Snatch (Red)' do?"}],"ideal":"'Snatch (Red)' is a card from the 'Welcome to Rathe' set. It is a Generic Attack Action which costs 0 Resources to play, pitches for 1 Resource, defends for 2 and has the ability 'If Snatch hits, draw a card.'."}
{"input":[{"role":"system","content":"In the card game Flesh and Blood, what does the card 'Ancestral Empowerment' do?"}],"ideal":"'Ancestral Empowerment' is a card from the 'Welcome to Rathe' set. It is a Ninja Attack Reaction which costs 0 Resources to play, pitches for 1 Resource, defends for 3 and has the ability 'Target Ninja attack action card gains +1. Draw a card.'."}
{"input":[{"role":"system","content":"In the card game Flesh and Blood, what does the card 'Head Jab (Red)' do?"}],"ideal":"'Head Jab (Red)' is a card from the 'Welcome to Rathe' set. It is a Ninja Attack Action which costs 0 Resources to play, pitches for 1 Resource, defends for 2 and has the ability 'Go again'."}
{"input":[{"role":"system","content":"In the card game Flesh and Blood, what does the card 'Ironsong Determination' do?"}],"ideal":"'Ironsong Determination' is a card from the 'Welcome to Rathe' set. It is a Warrior Action which costs 0 Resources to play, pitches for 2 Resource, defends for 3 and has the ability 'Target weapon gains +1 and dominate until end of turn. Go again'."}
{"input":[{"role":"system","content":"In the card game Flesh and Blood, what does the card 'Anothos' do?"}],"ideal":"'Anothos' is a card from the 'Welcome to Rathe' set. It is a 2h Guardian Weapon with 4 power which has a once per turn action to spend 3 resources to attack with. It has the ability 'If you have 2 or more cards in your pitch zone with cost 3 or greater, Anothos gains +2.'."}
  ```
</details>
