### PR TITLE
fix custom-eval.md doc, toy datasets not match below script

### DIFF
--- a/docs/custom-eval.md
+++ b/docs/custom-eval.md
@@ -17,8 +17,8 @@ We will use the new chat format described [here](https://platform.openai.com/doc
 
 To create the toy datasets, in your terminal, type:
 ```bash
-echo -e '[{"role": "system", "content": "2+2=", "name": "example_user"}, {"role": "system", "content": "4", "name": "example_assistant"}]\n[{"role": "system", "content": "4*4=", "name": "example_user"}, {"role": "system", "content": "16", "name": "example_assistant"}]' > /tmp/train.jsonl
-echo -e '[{"role": "system", "content": "48+2=", "name": "example_user"}, {"role": "system", "content": "50", "name": "example_assistant"}]\n[{"role": "system", "content": "5*20=", "name": "example_user"}, {"role": "system", "content": "100", "name": "example_assistant"}]' > /tmp/test.jsonl
+echo -e '{"problem": "2+2=", "answer": "4"}\n{"problem": "4*4=", "answer": "16"}' > /tmp/train.jsonl
+echo -e '{"problem": "48+2=", "answer": "50"}\n{"problem": "5*20=", "answer": "100"}' > /tmp/test.jsonl
 ```
 
 ## Create an eval


### PR DESCRIPTION
toy datasets not match script, I found the easiest way is to rewrite the toy datasets

check result logs below

```
[2023-03-27 14:38:45,760] [data.py:78] Fetching /tmp/train.jsonl
[2023-03-27 14:38:45,761] [data.py:78] Fetching /tmp/test.jsonl
[2023-03-27 14:38:45,763] [eval.py:31] Evaluating 2 samples
[2023-03-27 14:38:45,779] [eval.py:149] Running in threaded mode with 10 threads!
  0%|                                                                                                                                                                                                                                                                         | 0/2 [00:00<?, ?it/s]sample {'problem': '4*4=', 'answer': '16'}
sample {'problem': '2+2=', 'answer': '4'}
sample {'problem': '5*20=', 'answer': '100'}
sample {'problem': '4*4=', 'answer': '16'}
sample {'problem': '2+2=', 'answer': '4'}
sample {'problem': '48+2=', 'answer': '50'}
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.37it/s]
[2023-03-27 14:38:47,248] [record.py:320] Final report: {'accuracy': 1.0}. Logged to /tmp/evallogs/2303270638454V2WPIGQ_gpt-3.5-turbo_arithmetic.jsonl
[2023-03-27 14:38:47,249] [oaieval.py:220] Final report:
[2023-03-27 14:38:47,249] [oaieval.py:222] accuracy: 1.0
[2023-03-27 14:38:47,251] [record.py:309] Logged 6 rows of events to /tmp/evallogs/2303270638454V2WPIGQ_gpt-3.5-turbo_arithmetic.jsonl: insert_time=1.651ms

```