### PR TITLE
Support custom models in the registry

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include evals *.py
 recursive-include evals *.yaml
 recursive-include evals *.sql
+recursive-include evals *.jsonl

--- a/evals/api.py
+++ b/evals/api.py
@@ -71,6 +71,7 @@ def completion_query(
     if model_spec.is_chat:
         result = openai_chat_completion_create_retrying(
             model=model_spec.model,
+            engine=model_spec.engine,
             api_base=model_spec.api_base,
             api_key=model_spec.api_key,
             messages=openai_create_prompt,
@@ -79,6 +80,7 @@ def completion_query(
     else:
         result = openai_completion_create_retrying(
             model=model_spec.model,
+            engine=model_spec.engine,
             api_base=model_spec.api_base,
             api_key=model_spec.api_key,
             prompt=openai_create_prompt,

--- a/evals/base.py
+++ b/evals/base.py
@@ -21,6 +21,7 @@ class ModelSpec:
 
     name: str
     model: Optional[str] = None
+    engine: Optional[str] = None
     api_base: Optional[str] = None
 
     is_chat: bool = False
@@ -42,9 +43,6 @@ class ModelSpec:
             self.extra_options = {}
         if self.headers is None:
             self.headers = {}
-
-        if self.model is None:
-            raise ValueError(f"Must specify a model")
 
 
 @dataclass

--- a/evals/registry.py
+++ b/evals/registry.py
@@ -15,7 +15,7 @@ from typing import Any, Iterator, Sequence, Type, Union
 
 import yaml
 
-from evals.base import BaseEvalSpec, EvalSetSpec, EvalSpec
+from evals.base import BaseEvalSpec, EvalSetSpec, EvalSpec, ModelSpec
 from evals.utils.misc import make_object
 
 logger = logging.getLogger(__name__)
@@ -58,6 +58,9 @@ class Registry:
             return type(**spec)
         except TypeError as e:
             raise TypeError(f"Error while processing {object} {name}: {e}")
+
+    def get_model(self, name: str) -> ModelSpec:
+        return self._dereference(name, self._models, "model", ModelSpec)
 
     def get_modelgraded_spec(self, name: str) -> dict[str, Any]:
         assert name in self._modelgraded_specs, (
@@ -170,5 +173,8 @@ class Registry:
     def _modelgraded_specs(self):
         return self._load_registry([p / "modelgraded" for p in self._registry_paths])
 
+    @functools.cached_property
+    def _models(self):
+        return self._load_registry([p / "models" for p in self._registry_paths])
 
 registry = Registry()


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
[Insert Eval name here]

### Eval description

[Insert a short description of what your eval does here]

### What makes this a useful eval?

[Insert why this eval is worth including and any additional context]

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [ ] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [ ] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [ ] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [ ] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [ ] Check that your data is in `evals/registry/data/{name}`
- [ ] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [ ] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [ ] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [ ] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [ ] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [ ] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  INSERT_EVAL_HERE
  ```
</details>
