### PR TITLE
Greek New Testament manuscript coding

### DIFF
--- a/evals/registry/data/greek_nt_manuscripts/codes-sigla-centuries.jsonl
+++ b/evals/registry/data/greek_nt_manuscripts/codes-sigla-centuries.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a8c6ffae20e0e5072b8cbadea3e03f70e8e4e99b978f827ec4640e74d968478
+size 57558

--- a/evals/registry/evals/greek-nt-manuscripts.yaml
+++ b/evals/registry/evals/greek-nt-manuscripts.yaml
@@ -1,0 +1,8 @@
+greek-nt-manuscripts:
+  id: greek-nt-manuscripts.v0
+  description: Test model's capability of providing Gregory-Aland coding, symbolic sigla, and common designated century for the most important Greek Uncial manuscripts of the New Testament
+  metrics: [accuracy]
+greek-nt-manuscripts.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: greek_nt_manuscripts/codes-sigla-centuries.jsonl


### PR DESCRIPTION
Implemented OpenAI eval for Greek New Testament manuscript coding, including Gregory-Aland (GA) codes, symbolic sigla, and assigned century.

# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
Greek New Testament manuscript coding

### Eval description

This eval tests the model's ability to correctly classify the most ancient Greek
manuscripts of the New Testament. Each has a Gregory-Aland number, a siglum or
identifying symbol, and a designated century.

### What makes this a useful eval?

This assesses the model's ability to correctly identify and describe these
ancient manuscripts, which are important for treatment of academic and
theological subject matter. Correctly identifying these results shows the models
capability for a strong understanding of New Testament textual criticism.

In my tests, the GPT-3.5-turbo model achieved an accuracy of 0.496, and text-davinci-003 scored only 0.209.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

Accurately identifying and categorizing these manuscripts is fundamental to the academic study of textual criticism, and I've noticed significant hallucinating by AI's in this space, including OpenAI's. Hopefully ChatGPT4 improves on this.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Sinaiticus\" or \"Codex Sinaiticus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 01"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Sinaiticus\" or \"Codex Sinaiticus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "א"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Sinaiticus\" or \"Codex Sinaiticus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "4th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Alexandrinus\" or \"Codex Alexandrinus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 02"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Alexandrinus\" or \"Codex Alexandrinus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "A"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Alexandrinus\" or \"Codex Alexandrinus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "5th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Vaticanus\" or \"Codex Vaticanus\" using the following specific format. For example, for \"Ephraimi Rescriptus\" the answer would be \"GA 04\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 03"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Vaticanus\" or \"Codex Vaticanus\". For example, for \"Ephraimi Rescriptus\" the answer would be \"C\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "B"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Vaticanus\" or \"Codex Vaticanus\". For example, for \"Ephraimi Rescriptus\" the answer would be \"5th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "4th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Ephraemi Rescriptus\" or \"Codex Ephraemi Rescriptus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 04"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Ephraemi Rescriptus\" or \"Codex Ephraemi Rescriptus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "C"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Ephraemi Rescriptus\" or \"Codex Ephraemi Rescriptus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "5th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Bezae\" or \"Codex Bezae\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 05"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Bezae\" or \"Codex Bezae\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Dᵉᵃ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Bezae\" or \"Codex Bezae\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "5th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Claromontanus\" or \"Codex Claromontanus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 06"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Claromontanus\" or \"Codex Claromontanus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Dᵖ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Claromontanus\" or \"Codex Claromontanus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Basilensis\" or \"Codex Basilensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 07"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Basilensis\" or \"Codex Basilensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Eᵉ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Basilensis\" or \"Codex Basilensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "8th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Laudianus\" or \"Codex Laudianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 08"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Laudianus\" or \"Codex Laudianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Eᵃ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Laudianus\" or \"Codex Laudianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Boreelianus\" or \"Codex Boreelianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 09"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Boreelianus\" or \"Codex Boreelianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Fᵉ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Boreelianus\" or \"Codex Boreelianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Augiensis\" or \"Codex Augiensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 010"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Augiensis\" or \"Codex Augiensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Fᵖ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Augiensis\" or \"Codex Augiensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Seidelianus I\" or \"Codex Seidelianus I\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 011"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Seidelianus I\" or \"Codex Seidelianus I\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Gᵉ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Seidelianus I\" or \"Codex Seidelianus I\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Boernerianus\" or \"Codex Boernerianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 012"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Boernerianus\" or \"Codex Boernerianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Gᵖ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Boernerianus\" or \"Codex Boernerianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Seidelianus II\" or \"Codex Seidelianus II\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 013"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Seidelianus II\" or \"Codex Seidelianus II\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Hᵉ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Seidelianus II\" or \"Codex Seidelianus II\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Mutinensis\" or \"Codex Mutinensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 014"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Mutinensis\" or \"Codex Mutinensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Hᵃ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Mutinensis\" or \"Codex Mutinensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Coislinianus\" or \"Codex Coislinianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 015"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Coislinianus\" or \"Codex Coislinianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Hᵖ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Coislinianus\" or \"Codex Coislinianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Freerianus\" or \"Codex Freerianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 016"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Freerianus\" or \"Codex Freerianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "I"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Freerianus\" or \"Codex Freerianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "5th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Cyprius\" or \"Codex Cyprius\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 017"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Cyprius\" or \"Codex Cyprius\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Kᵉ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Cyprius\" or \"Codex Cyprius\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Mosquensis\" or \"Codex Mosquensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 018"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Mosquensis\" or \"Codex Mosquensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Kᵃᵖ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Mosquensis\" or \"Codex Mosquensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Regius\" or \"Codex Regius\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 019"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Regius\" or \"Codex Regius\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Lᵉ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Regius\" or \"Codex Regius\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "8th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Angelicus\" or \"Codex Angelicus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 020"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Angelicus\" or \"Codex Angelicus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Lᵃᵖ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Angelicus\" or \"Codex Angelicus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Campianus\" or \"Codex Campianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 021"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Campianus\" or \"Codex Campianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "M"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Campianus\" or \"Codex Campianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Petropolitanus Purpureus\" or \"Codex Petropolitanus Purpureus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 022"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Petropolitanus Purpureus\" or \"Codex Petropolitanus Purpureus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "N"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Petropolitanus Purpureus\" or \"Codex Petropolitanus Purpureus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Sinopensis\" or \"Codex Sinopensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 023"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Sinopensis\" or \"Codex Sinopensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "O"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Sinopensis\" or \"Codex Sinopensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Guelferbytanus A\" or \"Codex Guelferbytanus A\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 024"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Guelferbytanus A\" or \"Codex Guelferbytanus A\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Pᵉ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Guelferbytanus A\" or \"Codex Guelferbytanus A\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Porphyrianus\" or \"Codex Porphyrianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 025"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Porphyrianus\" or \"Codex Porphyrianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Pᵃᵖʳ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Porphyrianus\" or \"Codex Porphyrianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Guelferbytanus B\" or \"Codex Guelferbytanus B\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 026"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Guelferbytanus B\" or \"Codex Guelferbytanus B\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Q"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Guelferbytanus B\" or \"Codex Guelferbytanus B\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "5th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Nitriensis\" or \"Codex Nitriensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 027"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Nitriensis\" or \"Codex Nitriensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "R"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Nitriensis\" or \"Codex Nitriensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Nanianus\" or \"Codex Nanianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 030"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Nanianus\" or \"Codex Nanianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "U"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Nanianus\" or \"Codex Nanianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Mosquensis II\" or \"Codex Mosquensis II\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 031"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Mosquensis II\" or \"Codex Mosquensis II\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "V"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Mosquensis II\" or \"Codex Mosquensis II\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Washingtonianus\" or \"Codex Washingtonianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 032"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Washingtonianus\" or \"Codex Washingtonianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "W"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Washingtonianus\" or \"Codex Washingtonianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "5th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Monacensis\" or \"Codex Monacensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 033"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Monacensis\" or \"Codex Monacensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "X"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Monacensis\" or \"Codex Monacensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "10th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Macedoniensis\" or \"Codex Macedoniensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 034"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Macedoniensis\" or \"Codex Macedoniensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Y"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Macedoniensis\" or \"Codex Macedoniensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Dublinensis\" or \"Codex Dublinensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 035"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Dublinensis\" or \"Codex Dublinensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Z"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Dublinensis\" or \"Codex Dublinensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Tischendorfianus IV\" or \"Codex Tischendorfianus IV\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 036"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Tischendorfianus IV\" or \"Codex Tischendorfianus IV\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Γ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Tischendorfianus IV\" or \"Codex Tischendorfianus IV\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "10th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Sangallensis\" or \"Codex Sangallensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 037"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Sangallensis\" or \"Codex Sangallensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Δ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Sangallensis\" or \"Codex Sangallensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Coridethianus\" or \"Codex Coridethianus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 038"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Coridethianus\" or \"Codex Coridethianus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Θ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Coridethianus\" or \"Codex Coridethianus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Tischendorfianus III\" or \"Codex Tischendorfianus III\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 039"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Tischendorfianus III\" or \"Codex Tischendorfianus III\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Λ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Tischendorfianus III\" or \"Codex Tischendorfianus III\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Zacynthius\" or \"Codex Zacynthius\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 040"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Zacynthius\" or \"Codex Zacynthius\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Ξ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Zacynthius\" or \"Codex Zacynthius\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Petropolitanus\" or \"Codex Petropolitanus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 041"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Petropolitanus\" or \"Codex Petropolitanus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Π"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Petropolitanus\" or \"Codex Petropolitanus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Rossanensis\" or \"Codex Rossanensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 042"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Rossanensis\" or \"Codex Rossanensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Σ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Rossanensis\" or \"Codex Rossanensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Beratinus\" or \"Codex Beratinus\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 043"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Beratinus\" or \"Codex Beratinus\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Φ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Beratinus\" or \"Codex Beratinus\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "6th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Athous Lavrensis\" or \"Codex Athous Lavrensis\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 044"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Athous Lavrensis\" or \"Codex Athous Lavrensis\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Ψ"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Athous Lavrensis\" or \"Codex Athous Lavrensis\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th/10th"}
{"input": [{"role": "system", "content": "Provide the Gregory-Aland, or \"GA\" code for the New Testament Greek Manuscript known as \"Athous Dionysiou\" or \"Codex Athous Dionysiou\" using the following specific format. For example, for \"Vaticanus\" the answer would be \"GA 03\". Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "GA 045"}
{"input": [{"role": "system", "content": "Provide the common siglum for the New Testament Greek Manuscript known as \"Athous Dionysiou\" or \"Codex Athous Dionysiou\". For example, for \"Vaticanus\" the answer would be \"A\". If there is a superscript, use a Unicode superscripted letter for it, for example \"ᵉ\" for the letter \"e\" superscripted. Provide the answer exactly as specified without explanations or punctuation marks."}], "ideal": "Ω"}
{"input": [{"role": "system", "content": "Provide the commonly designated century for the New Testament Greek Manuscript known as \"Athous Dionysiou\" or \"Codex Athous Dionysiou\". For example, for \"Vaticanus\" the answer would be \"4th\". Provide the answer exactly as specified without explanations or punctuation marks. Abbreviate the century \"1st\", \"2nd\", \"3rd\", and so on. If the answer is a range, present both answers separated by a hyphen and no spaces, for example: \"1st-2nd\"."}], "ideal": "9th"}
  ```
</details>
