### PR TITLE
update manifest and pyproject to support fetching data on pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include evals *.py
 recursive-include evals *.yaml
 recursive-include evals *.sql
+recursive-include evals/registry/data *.jsonl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pyyaml",
     "sacrebleu",
     "matplotlib",
+    "setuptools_scm",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This supports downloading all data on pip install from git, e.g. `pip install git+https://github.com/openai/evals.git@main`