### PR TITLE
refactor simple evals to not use result.prompt

### DIFF
--- a/evals/api.py
+++ b/evals/api.py
@@ -150,7 +150,6 @@ class OpenAIChatCompletionFn(CompletionFn):
 
 
 def record_and_check_match(
-    prompt: Union[OpenAICreatePrompt, OpenAICreateChatPrompt],
     sampled: str,
     expected: Union[str, list[str], tuple[str]],
     separator: Callable[[str], bool] = None,
@@ -177,7 +176,6 @@ def record_and_check_match(
         break
 
     result = {
-        "prompt": prompt,
         "sampled": sampled,
         "options": options,
         "picked": picked,
@@ -186,7 +184,7 @@ def record_and_check_match(
     result["expected"] = expected
     result["match"] = match
     record_sampling(**result)
-    record_match(match, expected=expected, picked=picked, sampled=sampled)
+    record_match(match, expected=expected, picked=picked, sampled=sampled, options=options)
     return picked
 
 

--- a/evals/elsuite/basic/fuzzy_match.py
+++ b/evals/elsuite/basic/fuzzy_match.py
@@ -30,7 +30,7 @@ class FuzzyMatch(evals.Eval):
             model_spec=self.model_spec,
         )
         sampled = result.get_completions()[0]
-        evals.record.record_sampling(prompt=result.prompt, sampled=sampled)
+        evals.record.record_sampling(prompt=prompt, sampled=sampled)
 
         matches = [utils.fuzzy_match(sampled, correct_answer) for correct_answer in correct_answers]
         evals.record.record_match(

--- a/evals/elsuite/basic/includes.py
+++ b/evals/elsuite/basic/includes.py
@@ -23,13 +23,14 @@ class Includes(evals.Eval):
         self._completion_fn = completion_fn
 
     def eval_sample(self, sample: Any, *_):
+        prompt = sample["input"]
         result = self._completion_fn(
-            prompt=sample["input"],
+            prompt=prompt,
             max_tokens=self.max_tokens,
             model_spec=self.model_spec,
         )
         sampled = result.get_completions()[0]
-        evals.record.record_sampling(prompt=result.prompt, sampled=sampled)
+        evals.record.record_sampling(prompt=prompt, sampled=sampled)
 
         includes_answer = any([utils.get_answer(sampled, ref) for ref in sample["ideal"]])
         evals.record.record_metrics(accuracy=float(includes_answer))

--- a/evals/elsuite/basic/match.py
+++ b/evals/elsuite/basic/match.py
@@ -45,8 +45,9 @@ class Match(evals.Eval):
         choice = result.get_completions()[0]
         sampled = choice.strip() if self.model_spec.strip_completion else choice
 
+        evals.record.record_sampling(prompt=prompt, sampled=sampled)
+
         return evals.record_and_check_match(
-            prompt=result.prompt,
             sampled=sampled,
             expected=sample["ideal"],
         )

--- a/evals/elsuite/translate.py
+++ b/evals/elsuite/translate.py
@@ -53,7 +53,7 @@ class Translate(evals.Eval):
             model_spec=self.model_spec,
         )
         sampled = result.get_completions()[0]
-        evals.record.record_sampling(prompt=result.prompt, sampled=sampled)
+        evals.record.record_sampling(prompt=prompt, sampled=sampled)
 
         score = None
         if expected is not None:


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. We encourage partial PR's with ~5-10 example that we can then run the evals on and share the results with you so you know how your eval does with GPT-4 before writing all 100 examples.

## Eval details 📑
### Eval name
[Insert Eval name here]

### Eval description

[Insert a short description of what your eval does here]

### What makes this a useful eval?

[Insert why this eval is worth including and any additional context]

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [ ] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [ ] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [ ] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [ ] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [ ] Check that your data is in `evals/registry/data/{name}`
- [ ] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [ ] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [ ] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [ ] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [ ] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [ ] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  INSERT_EVAL_HERE
  ```
</details>
