### PR TITLE
Ukrainian Grammatical Error Correction and Fluency evalset

### DIFF
--- a/evals/registry/data/README.md
+++ b/evals/registry/data/README.md
@@ -42,3 +42,5 @@ Another example of a Match eval is:
 ### Dataset attributions
 
 This work includes data from the Illinois Intentional Tort Qualitative Dataset, which was compiled by the Qualitative Reasoning Group at Northwestern University. The dataset is freely available under the Creative Commons Attribution 4.0 license from https://www.qrg.northwestern.edu/Resources/caselawcorpus.html
+
+This work includes data from the UA-GEC: Grammatical Error Correction and Fluency Corpus for the Ukrainian Language Dataset provided by Grammarly as opensource repository on GitHub. The dataset is freely available under the Creative Commons Attribution 4.0 license from https://github.com/grammarly/ua-gec

--- a/evals/registry/data/README.md
+++ b/evals/registry/data/README.md
@@ -42,5 +42,3 @@ Another example of a Match eval is:
 ### Dataset attributions
 
 This work includes data from the Illinois Intentional Tort Qualitative Dataset, which was compiled by the Qualitative Reasoning Group at Northwestern University. The dataset is freely available under the Creative Commons Attribution 4.0 license from https://www.qrg.northwestern.edu/Resources/caselawcorpus.html
-
-This work includes data from the UA-GEC: Grammatical Error Correction and Fluency Corpus for the Ukrainian Language Dataset provided by Grammarly as opensource repository on GitHub. The dataset is freely available under the Creative Commons Attribution 4.0 license from https://github.com/grammarly/ua-gec

--- a/evals/registry/data/ukraine_gec/README.md
+++ b/evals/registry/data/ukraine_gec/README.md
@@ -1,0 +1,3 @@
+### Dataset attributions
+
+This work includes data from the UA-GEC: Grammatical Error Correction and Fluency Corpus for the Ukrainian Language Dataset provided by Grammarly as opensource repository on GitHub. The dataset is freely available under the Creative Commons Attribution 4.0 license from https://github.com/grammarly/ua-gec

--- a/evals/registry/data/ukraine_gec/ukraine_gec_fluency_calque.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_fluency_calque.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d06d6747e599bbfcafe509ebaf05f974250fe1cd3900c14e077c2cd681107323
+size 1803870

--- a/evals/registry/data/ukraine_gec/ukraine_gec_fluency_other.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_fluency_other.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e22dc3c5a2453dd27a753d65ca60b3d69e01f26a19167551a16b3d3bdf2e2793
+size 196522

--- a/evals/registry/data/ukraine_gec/ukraine_gec_fluency_poorflow.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_fluency_poorflow.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06fc64795d8f128c0ae7744afc4d67eee1402517802b04621b81930bd55ea311
+size 2593243

--- a/evals/registry/data/ukraine_gec/ukraine_gec_fluency_repetition.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_fluency_repetition.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7431ab91383a7aaaa249e1b6e47ebf9fa9999b13084700598d742f8eb25476f
+size 397333

--- a/evals/registry/data/ukraine_gec/ukraine_gec_fluency_style.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_fluency_style.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8433e5015eaaa55ca5e1b766394514978dd956180055c61eec1a5f1d4d5dc03
+size 2461028

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_aspect.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_aspect.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da87d41c8be4f23fc17304181103465a76ff095319d0b22d52d0f74fdec2808d
+size 63243

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_case.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_case.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92e19f83679f1843be7fd225d3b428171d6e21ac6ca2e565ace4e7b00959b82f
+size 2037489

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_comparison.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_comparison.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4120b17fc25c405d0650f33a250a6a430d57e84025b8938f82e622367842330
+size 128297

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_conjunction.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_conjunction.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32bfe097e4c1907abc3392ebe5234618ede06e72b23990ad68301fdc7642d58c
+size 391095

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_gender.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_gender.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ffb47aa5b83e84ccccf82cd59dcf357adf0c78412ce461c0b182f6d70656729
+size 424727

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_number.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_number.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baed20793aabbd7d81d9c2728800bffadd6f9bc789329b001ffbe63090a19d20
+size 304786

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_other.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_other.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e81c28af9a25775b9e6bea8bddb514614b5ceb652c15e91f830434892cf663b7
+size 196351

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_partvoice.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_partvoice.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2228f3bbd22750203a34a9626c8908513f15505dc13038954245844a22eb9534
+size 80629

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_prep.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_prep.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0370eeb3e8ff9be42b68b0f59f51c5ef0b38d7a0a87fac13738c05bd67132db
+size 365666

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_tense.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_tense.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4012152ec52fb3fd1fad26cc9afee87d942b62d915be92734416545a733b3bd8
+size 132681

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_ungrammaticalstructure.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_ungrammaticalstructure.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75b403b4046f7aaabe75674605273f59f5bca3fc1332fc574fd0d1d495a0047e
+size 711733

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_verbaform.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_verbaform.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e14f39fa7cc966ce3e805978a6f48baecc31e23245f0fcf55a023263e5fffa0a
+size 37635

--- a/evals/registry/data/ukraine_gec/ukraine_gec_grammar_verbvoice.jsonl
+++ b/evals/registry/data/ukraine_gec/ukraine_gec_grammar_verbvoice.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:395430afbb82ea9a8bf0989ee17f28aae39f19740f5f5a8be816d1b687ad77fd
+size 221857

--- a/evals/registry/eval_sets/ukraine-gec.yaml
+++ b/evals/registry/eval_sets/ukraine-gec.yaml
@@ -1,0 +1,21 @@
+ukraine-gec:
+  evals:
+  - ukraine-gec-fluency-style
+  - ukraine-gec-fluency-calque
+  - ukraine-gec-fluency-poorflow
+  - ukraine-gec-fluency-repetition
+  - ukraine-gec-fluency-other
+  - ukraine-gec-grammar-aspect
+  - ukraine-gec-grammar-case
+  - ukraine-gec-grammar-comparison
+  - ukraine-gec-grammar-conjunction
+  - ukraine-gec-grammar-gender
+  - ukraine-gec-grammar-number
+  - ukraine-gec-grammar-partvoice
+  - ukraine-gec-grammar-prep
+  - ukraine-gec-grammar-tense
+  - ukraine-gec-grammar-ungrammaticalstructure
+  - ukraine-gec-grammar-verbaform
+  - ukraine-gec-grammar-verbvoice
+  - ukraine-gec-grammar-other
+

--- a/evals/registry/evals/ukraine-gec.yaml
+++ b/evals/registry/evals/ukraine-gec.yaml
@@ -1,0 +1,198 @@
+ukraine-gec-fluency-style:
+  description: Fluency eval. Test the model's ability to detect and correct style
+    errors.
+  id: ukraine-gec-fluency-style.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-fluency-style.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_fluency_style.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-fluency-calque:
+  description: Fluency eval. Test the model's ability to detect and correct word-for-word
+    translation from other languages errors.
+  id: ukraine-gec-fluency-calque.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-fluency-calque.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_fluency_calque.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-fluency-poorflow:
+  description: Fluency eval. Test the model's ability to detect and correct unnatural
+    sentence flow errors.
+  id: ukraine-gec-fluency-poorflow.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-fluency-poorflow.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_fluency_poorflow.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-fluency-repetition:
+  description: Fluency eval. Test the model's ability to detect and correct repetition
+    of words errors.
+  id: ukraine-gec-fluency-repetition.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-fluency-repetition.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_fluency_repetition.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-fluency-other:
+  description: Fluency eval. Test the model's ability to detect and correct other
+    fluency errors errors.
+  id: ukraine-gec-fluency-other.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-fluency-other.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_fluency_other.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-aspect:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of verb aspect errors.
+  id: ukraine-gec-grammar-aspect.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-aspect.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_aspect.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-case:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of case of any notional part of speech errors.
+  id: ukraine-gec-grammar-case.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-case.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_case.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-comparison:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    formation of comparison degrees of adjectives and adverbs errors.
+  id: ukraine-gec-grammar-comparison.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-comparison.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_comparison.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-conjunction:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of conjunctions errors.
+  id: ukraine-gec-grammar-conjunction.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-conjunction.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_conjunction.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-gender:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of gender of any notional part of speech errors.
+  id: ukraine-gec-grammar-gender.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-gender.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_gender.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-number:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of number of any notional part of speech errors.
+  id: ukraine-gec-grammar-number.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-number.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_number.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-partvoice:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of participle voice errors.
+  id: ukraine-gec-grammar-partvoice.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-partvoice.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_partvoice.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-prep:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    preposition usage errors.
+  id: ukraine-gec-grammar-prep.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-prep.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_prep.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-tense:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of verb tense errors.
+  id: ukraine-gec-grammar-tense.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-tense.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_tense.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-ungrammaticalstructure:
+  description: Grammar eval. Test the model's ability to detect and correct digression
+    from syntactic norms errors.
+  id: ukraine-gec-grammar-ungrammaticalstructure.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-ungrammaticalstructure.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_ungrammaticalstructure.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-verbaform:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of an analytical verb form errors.
+  id: ukraine-gec-grammar-verbaform.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-verbaform.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_verbaform.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-verbvoice:
+  description: Grammar eval. Test the model's ability to detect and correct incorrect
+    usage of verb voice errors.
+  id: ukraine-gec-grammar-verbvoice.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-verbvoice.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_verbvoice.jsonl
+  class: evals.elsuite.basic.match:Match
+
+ukraine-gec-grammar-other:
+  description: Grammar eval. Test the model's ability to detect and correct other
+    grammatical errors errors.
+  id: ukraine-gec-grammar-other.dev.v0
+  metrics:
+  - accuracy
+ukraine-gec-grammar-other.dev.v0:
+  args:
+    samples_jsonl: ukraine_gec/ukraine_gec_grammar_other.jsonl
+  class: evals.elsuite.basic.match:Match
+


### PR DESCRIPTION
## Eval details 📑
### Eval name

Evalset name: 
  - ukraine-gec

Evals included in set:
  - ukraine-gec-fluency-style
  - ukraine-gec-fluency-calque
  - ukraine-gec-fluency-poorflow
  - ukraine-gec-fluency-repetition
  - ukraine-gec-fluency-other
  - ukraine-gec-grammar-aspect
  - ukraine-gec-grammar-case
  - ukraine-gec-grammar-comparison
  - ukraine-gec-grammar-conjunction
  - ukraine-gec-grammar-gender
  - ukraine-gec-grammar-number
  - ukraine-gec-grammar-partvoice
  - ukraine-gec-grammar-prep
  - ukraine-gec-grammar-tense
  - ukraine-gec-grammar-ungrammaticalstructure
  - ukraine-gec-grammar-verbaform
  - ukraine-gec-grammar-verbvoice
  - ukraine-gec-grammar-other

### Eval description

This pull request introduces an evaluation model for grammatical error correction (GEC) and fluency improvement in the Ukrainian language, based on the [UA-GEC: Grammatical Error Correction and Fluency Corpus for the Ukrainian Language](https://github.com/grammarly/ua-gec). The evaluation model contains tests grouped by fluency-related and grammar-related error types, providing a comprehensive assessment of an AI model's performance in correcting Ukrainian text.

The evaluation tests cover the following error categories:

**Fluency-related evals:**
- `ukraine-gec-fluency-style`: style errors (2871 samples)
- `ukraine-gec-fluency-calque`: word-for-word translation from other languages (2029 samples)
- `ukraine-gec-fluency-poorflow`: unnatural sentence flow (2645 samples)
- `ukraine-gec-fluency-repetition`: repetition of words (438 samples)
- `ukraine-gec-fluency-other`: other fluency errors (230)

**Grammar-related evals:**
- `ukraine-gec-grammar-case`: incorrect usage of case of any notional part of speech ( samples)
- `ukraine-gec-grammar-gender`: incorrect usage of gender of any notional part of speech (456 samples)
- `ukraine-gec-grammar-number`: incorrect usage of number of any notional part of speech (323 samples)
- `ukraine-gec-grammar-aspect`: incorrect usage of verb aspect (70 samples)
- `ukraine-gec-grammar-tense`: incorrect usage of verb tense (138 samples)
- `ukraine-gec-grammar-verbvoice`: incorrect usage of verb voice (229 samples)
- `ukraine-gec-grammar-partvoice`:  incorrect usage of participle voice (85 samples)
- `ukraine-gec-grammar-verbaform`:  incorrect usage of an analytical verb form (42 samples)
- `ukraine-gec-grammar-prep`: incorrect preposition usage (412 samples)
- `ukraine-gec-grammar-ungrammaticalstructure`: digression from syntactic norms (753 samples)
- `ukraine-gec-grammar-comparison`: incorrect formation of comparison degrees of adjectives and adverbs (123 samples)
- `ukraine-gec-grammar-conjunction`: incorrect usage of conjunctions (358 samples)
- `ukraine-gec-grammar-other`: other grammatical errors (223 samples)

The evaluation set comprises 20,890 test samples, which have been generated based on the annotated source corpus of Ukrainian GEC and fluency data.

By using these evaluation tests, AI models can be assessed for their ability to correct grammatical errors and improve fluency in the Ukrainian language. The results of this evaluation can guide further development and refinements in ChatGPT, ultimately leading to more accurate and useful Ukrainian text correction systems.

Please consider incorporating this evaluation model into the project to provide a valuable resource for assessing and improving Ukrainian language support in ChatGPT.

### What makes this a useful eval?

This evaluation set provides a comprehensive and fine-grained assessment of Ukrainian grammatical error correction (GEC) and fluency performance for ChatGPT. By being based on a diverse and annotated corpus that covers various error categories and fluency-related aspects, the evaluation set allows for a thorough examination of model capabilities in these areas. Moreover, it helps identify strengths and weaknesses in model performance, enabling targeted improvements to enhance the overall quality of Ukrainian GEC and fluency in ChatGPT. Additionally, this evaluation set can be employed to track progress over time and detect possible performance regressions, ensuring continuous refinement and maintenance of current and next ChatGPT, which can handle a wide range of language tasks beyond text correction.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] Include at least 100 high quality examples (it is okay to only contribute 5-10 meaningful examples and have us test them with GPT-4 before adding all 100)

If there is anything else that makes your eval worth including, please document it below.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Ти дуже корисний граматичний асистент з української мови. Обери найбільш коректну відповідь з запропонованих варіантів 1 або 2, щоби виправити дослівний переклад з інших мов на місці пропущеного слова. Вкажи номер відповіді та текст відповіді дослівно. Не додавай повне речення у відповідь."}, {"role": "user", "content": "Архітектурний комплекс вміщує стіни фортеці з вежами, прибрамний корпус та _______.\n\n1 - костьол.\n2 - костел."}], "ideal": "2 - костел."}
{"input": [{"role": "system", "content": "Ти дуже корисний граматичний асистент з української мови. Обери найбільш коректну відповідь з запропонованих варіантів 1 або 2, щоби виправити стилістичну помилку на місці пропущеного слова. Вкажи номер відповіді та текст відповіді дослівно. Не додавай повне речення у відповідь."}, {"role": "user", "content": "А _______ той, кому під колеса попаде.\n\n1 - присяде.\n2 - сяде."}], "ideal": "2 - сяде."}
{"input": [{"role": "system", "content": "Ти дуже корисний граматичний асистент з української мови. Обери найбільш коректну відповідь з запропонованих варіантів 1 або 2, щоби виправити некоректне вживання часової форми дієслова на місці пропущеного слова. Вкажи номер відповіді та текст відповіді дослівно. Не додавай повне речення у відповідь."}, {"role": "user", "content": "Студент, навчаючись, має знати, що він далі зможе продовжувати досліджувати штучний інтелект і не хвилюватися, де житиме, що _______ чи як підтримуватиме сім’ю.\n\n1 - їстиме.\n2 - їсти."}], "ideal": "1 - їстиме."}
{"input": [{"role": "system", "content": "Ти дуже корисний граматичний асистент з української мови. Обери найбільш коректну відповідь з запропонованих варіантів 1 або 2, щоби виправити некоректне вживання форми стану дієслова або дієприкметника на місці пропущеного слова. Вкажи номер відповіді та текст відповіді дослівно. Не додавай повне речення у відповідь."}, {"role": "user", "content": "Адже пошта — це така служба, в якій _______ швидкість.\n\n1 - цінується.\n2 - цінують."}], "ideal": "2 - цінують."}

  ```
</details>
