### PR TITLE
Water Volume and Density Eval

### DIFF
--- a/evals/registry/data/test_water_density/questions.jsonl
+++ b/evals/registry/data/test_water_density/questions.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d775ddebbee80fe3a6a7f05501e08670ffe945c92fbfd8a91294eed79badb68
-size 3154
+oid sha256:9e6b43791dee636b6d33ad71a50014de1fcaa8d628f5e8374e95c713b28b4c10
+size 4138

--- a/evals/registry/data/test_water_density/questions.jsonl
+++ b/evals/registry/data/test_water_density/questions.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbc9c63cc4a55506ea8d7fcc52de126d7dae07d38f3dc54411130d64b05386fe
-size 3166
+oid sha256:1d775ddebbee80fe3a6a7f05501e08670ffe945c92fbfd8a91294eed79badb68
+size 3154

--- a/evals/registry/data/test_water_density/questions.jsonl
+++ b/evals/registry/data/test_water_density/questions.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbc9c63cc4a55506ea8d7fcc52de126d7dae07d38f3dc54411130d64b05386fe
+size 3166

--- a/evals/registry/evals/test-water-volume-density.yaml
+++ b/evals/registry/evals/test-water-volume-density.yaml
@@ -1,0 +1,9 @@
+water-volume-density:
+  id: water-volume-density.s1.simple-v0
+  description: Testing the models ability to answer multiple choice questions about the physical properties of water.
+  disclaimer:  The density of water is at its greatest at 4°C. The formula for calculating density is p = m/V, where p is the density, m is the mass and V is the volume.
+  metrics: [accuracy]
+water-volume-density.s1.simple-v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: test_water_density/questions.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
water-volume-density

### Eval description
Evaluates the model's ability to answer questions regarding the density and volume of water at various temperatures.

### What makes this a useful eval?

This can help evaluate the model's understanding of the inverse relationship of volume and density in science. Additionally, the model seems to get density and volume mixed up in some questions- especially when the temperature of 4°C is thrown in, so this PR attempts to address this issue. 

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input":[{"role":"system","content":"Choose the best multiple choice answer to this question. Reply ONLY with the single letter of the answer you have chosen."},{"role":"user","content":"The volume of water is maximum at A) 0°C B) 4°C C) 100°C D) 300°C"}],"ideal":"d"}
{"input":[{"role":"system","content":"Choose the best multiple choice answer to this question. Reply ONLY with the single letter of the answer you have chosen."},{"role":"user","content":"The density of water is maximum at A) 0°C B) 4°C C) 100°C D) 300°C"}],"ideal":"b"}
{"input":[{"role":"system","content":"Choose the best multiple choice answer to this question. Reply ONLY with the single letter of the answer you have chosen."},{"role":"user","content":"The volume of water is least at A) 10°C B) 20°C C) 4°C"}],"ideal":"c"}
{"input":[{"role":"system","content":"Choose the best multiple choice answer to this question. Reply ONLY with the single letter of the answer you have chosen."},{"role":"user","content":"The density of water is least at A) 10°C B) 20°C C) 4°C D) 0°C"}],"ideal":"b"}
{"input":[{"role":"system","content":"Choose the best multiple choice answer to this question. Reply ONLY with the single letter of the answer you have chosen."},{"role":"user","content":"The density of water is less at A) 10°C B) 20°C"}],"ideal":"b"}
  ```
</details>
