### PR TITLE
Add Chess PGN sequence to Fen String conversion Eval

### DIFF
--- a/evals/registry/data/chess-pgn-to-fen/samples.jsonl
+++ b/evals/registry/data/chess-pgn-to-fen/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:753e3504f9e1e6c85daffff57b63124621409486576544c8ee4740f564870c32
+size 32317

--- a/evals/registry/evals/chess-pgn-to-fen.yaml
+++ b/evals/registry/evals/chess-pgn-to-fen.yaml
@@ -1,0 +1,9 @@
+chess-pgn-to-fen:
+  id: chess-pgn-to-fen.dev.v0
+  description: Test the model's ability to convert a given chess move sequence to its matching FEN string
+  metrics: [accuracy]
+
+chess-pgn-to-fen.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: chess-pgn-to-fen/samples.jsonl


### PR DESCRIPTION
The purpose of this eval is to test the model's ability to convert a given pgn move sequence to it's matching FEN string.

# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
chess-pgn-to-fen

### Eval description

This eval tests GPT-4's ability to convert a given PGN move sequence to a matching FEN string. The PGN (Portable Game Notation) is a standard format to represent chess games and their individual moves. The FEN (Forsyth-Edwards Notation) is a notation that describes a specific chess position on the board. The model should be able to understand and process PGN move sequences, and then convert them into FEN strings representing the resulting board positions after those moves have been played.

### What makes this a useful eval?

This eval is useful because it demonstrates the model's ability to understand and process complex notations and sequential information, which extends beyond the realm of chess and board games. By testing the model's performance on this task, we can gain insights into how well the model can handle similar tasks that involve logical and sequential reasoning. Furthermore, it can help us identify potential areas of improvement in the model's understanding of sequential processes and its ability to analyze structured data.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 (50) high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> The unique value of this eval is that it tests the model's ability to work with notational systems and sequential data, which have broad real-world applications and are widely used by experts across various fields. Excelling in this task would demonstrate GPT-4's capability in assisting users with tasks that involve sequential reasoning and logic, such as programming, data analysis, and mathematical problem-solving. This, in turn, would extend its potential use cases to include diverse professional applications, making the model a valuable asset for a wide range of users.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/chess-pgn-to-fen`
- [x] Check that your yaml is registered at `evals/registry/evals/chess-pgn-to-fen.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e4 e5 2. f4 exf4 3. Bc4 Qh4+ 4. g3 fxg3 5. Nf3 Qxe4+ 6. Be2 d5 7. Nc3 g2 8. Rg1 Qe7 9. Nxd5 Qe4 10. Nxc7+ Kd7 11. Nxa8 Bd6 12. d3 Qg6 13. Be3 Bxh2 14. Ne5+ Bxe5 15. Qd2 Qg3+ 16. Bf2 Qh2 17. O-O-O Bf4 18. Be3 Bxe3 19. Qxe3 Qh6 20. Kd2 Qxe3+ 21. Kxe3 b6 22. Bg4+ Kd8 23. Rxg2 Bb7 24. Bf3 Nc6 25. Rxg7 Bxa8 26. Bxc6 Bxc6 27. Rxf7 Ne7 28. c4 Ng8 29. Rxa7 Ne7 30. d4 Nf5+ 31. Kf4 Bd7 32. Ra8+ Bc8 33. c5 bxc5 34. dxc5+ Kc7 35. Ke5 Re8+ 36. Kf4 Rf8 37. b4 Nd4+ 38. Ke3 Nc2+ 39. Kd2 Nxb4 40. Ra7+ Bb7 41. Rh1 Na6 42. Rxh7+ Kb8 43. Rhxb7+ Kc8 44. Ra8+ Kxb7 45. Rxf8 Nxc5 46. Rf7+ Ka6 47. Rf6+ Kb5 48. Rf5 Kc4 49. Kc2 Kd4 50. Kb2 Kc4 51. a3 Nd3+ 52. Ka2 Nc1+ 53. Kb1 Nb3 54. Rf4+ Nd4 55. a4 Kc5 56. a5"}], "ideal": "8/8/8/P1k5/3n1R2/8/8/1K6 b - - 0 56"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. d4 Nf6 2. Nc3 d5 3. Nf3 c5 4. g3 Nc6 5. Bg2 e6 6. O-O Bd6 7. dxc5 Bxc5 8. Be3 Bxe3 9. fxe3 Qb6 10. Nd4 Qxb2 11. Ncb5 O-O 12. Nd6 Ng4 13. e4 Qxd4+ 14. Qxd4 Nxd4 15. exd5 Nxe2+ 16. Kh1 exd5 17. Bxd5 Be6 18. Bxb7 Rad8 19. Ne4 f5 20. Ng5 Bd5+ 21. Bxd5+ Rxd5 22. Rae1 f4 23. gxf4 Nxf4 24. Rg1 Nf2#"}], "ideal": "5rk1/p5pp/8/3r2N1/5n2/8/P1P2n1P/4R1RK w - - 2 25"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e4 d5 2. exd5 Qxd5 3. Nc3 Qe6+ 4. Qe2 Qc6 5. Qb5 Bd7 6. Nf3 Qe6+ 7. Qe2 Qf5 8. Nb5 Kd8 9. Nfd4 Qg5 10. Qc4 c6 11. Qxf7 Nf6 12. d3 cxb5 13. Bxg5 Nc6 14. Ne6+ Bxe6 15. Qxe6 h6 16. Bxf6 gxf6 17. d4 Nb4 18. O-O-O Rc8 19. Bxb5 Rxc2+ 20. Kb1 Rc6 21. Bxc6 bxc6 22. d5 Nxd5 23. Rxd5+ cxd5 24. Qxd5+ Ke8 25. Rc1 e6 26. Qxe6+ Be7 27. Re1 Rh7 28. Qc8+ Kf7 29. Qd7 Kg6 30. Rxe7 Rxe7 31. Qxe7 f5 32. Qxa7 f4 33. Qb6+ Kg5 34. Qc5+ Kg4 35. Qe5 h5 36. h3+ Kh4 37. Qxf4#"}], "ideal": "8/8/8/7p/5Q1k/7P/PP3PP1/1K6 b - - 0 37"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. c3 d6 5. d4 exd4 6. cxd4 Bb4+ 7. Nbd2 Qf6 8. O-O Nxd4 9. Nxd4 Qxd4 10. Qf3 Nf6 11. Nb3 Qxc4 12. e5 dxe5 13. Qg3 O-O 14. Bh6 Nh5 15. Qxe5 gxh6 16. Qxh5 Bg4 17. Qh4 Qe4 18. f3 Qe3+ 19. Rf2 Be6 20. Qg3+ Kh8 21. Nc1 Qe1+ 22. Rf1 Bc5+ 23. Kh1 Qxf1#"}], "ideal": "r4r1k/ppp2p1p/4b2p/2b5/8/5PQ1/PP4PP/R1N2q1K w - - 0 24"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. d3 d6 5. Nc3 a6 6. O-O h6 7. a3 Nf6 8. b4 Ba7 9. Re1 Ng4 10. Be3 g5 11. Bxa7 Nxa7 12. d4 Qe7 13. dxe5 dxe5 14. Qd5 Bd7 15. Qxb7 Bc6 16. Bb5 axb5 17. Qa6 O-O 18. h3 Qe6 19. hxg4 Nc8 20. Qxa8 Bxa8 21. Nxb5 Qxg4 22. Nxe5 Qf4 23. Nxc7 Qxe5 24. Nxa8 g4 25. Nb6 Qb5 26. Nd5 Nd6 27. a4 Qc4 28. c3 Nxe4 29. Rxe4 Qxe4 30. Nf6+ Kg7 31. Nxe4 f5 32. Nd6 Rd8 33. Nxf5+ Kg6 34. Re1 Rd3 35. Ne7+ Kf7 36. Nc6 Rxc3 37. Re7+ Kf6 38. Rc7 Rc1+ 39. Kh2 h5 40. a5 h4 41. g3 h3 42. a6 Rc2 43. Kg1 h2+ 44. Kxh2 Rxf2+ 45. Kg1 Ra2 46. a7 Ke6 47. Rc8 Kf6 48. a8=Q Rxa8 49. Rxa8 Ke6 50. Rc8 Kd7 51. Na7 Kd6 52. b5 Kd7 53. b6"}], "ideal": "2R5/N2k4/1P6/8/6p1/6P1/8/6K1 b - - 0 53"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e3 e5 2. Bc4 d5 3. Bb3 Nf6 4. a3 Nc6 5. d3 Be6 6. Nf3 Qd7 7. O-O O-O-O 8. d4 e4 9. Ng5 Bg4 10. f3 Bh5 11. g4 Bg6 12. fxe4 dxe4 13. h3 h6 14. Bxf7 Bxf7 15. Nxf7 Qxf7 16. Nc3 Ne5 17. Qe2 Nf3+ 18. Kf2 Qg6 19. Bd2 Be7 20. Kg3 Bd6+ 21. Kg2 Nxg4 22. Rxf3 exf3+ 23. Qxf3 Ne5+ 24. Qg4+ Nxg4 25. hxg4 Qxg4+ 26. Kf2 Rdf8+ 27. Ke1 Qg1+ 28. Ke2 Qxa1 29. Ne4 Qf1#"}], "ideal": "2k2r1r/ppp3p1/3b3p/8/3PN3/P3P3/1PPBK3/5q2 w - - 2 30"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e4 e5 2. Nf3 Qf6 3. c3 Bc5 4. d4 exd4 5. cxd4 Bb6 6. Nc3 c5 7. Nd5 Qc6 8. Ne5 Ba5+ 9. Bd2 Bxd2+ 10. Qxd2 Qd6 11. Qf4 cxd4 12. Qxf7+ Kd8 13. Qxg7 Qf6 14. Nxf6 Nxf6 15. Qxf6+ Kc7 16. Qxh8 Nc6 17. Nxc6 bxc6"}], "ideal": "r1b4Q/p1kp3p/2p5/8/3pP3/8/PP3PPP/R3KB1R w KQ - 0 18"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Bxc6 dxc6 5. Nxe5 Qg5 6. d4 Qxg2 7. Qf3 Qxf3 8. Nxf3 Bg4 9. Nbd2 O-O-O 10. h3 Bxf3 11. Nxf3 Nf6 12. e5 Nd5 13. c4 c5 14. cxd5 cxd4 15. Ng5 Bb4+ 16. Bd2 Bxd2+ 17. Kxd2 Rxd5 18. Nxf7 Rf8 19. e6 Re8 20. Rae1 c6 21. Rhg1 Kc7 22. Rxg7 h5 23. Ne5+ Kd6 24. Nf7+ Ke7 25. Ng5+ Kf6 26. Rxb7 Kxg5 27. Rb6 Rb5 28. Rxc6 Rxb2+ 29. Rc2 Rxc2+ 30. Kxc2 Kf6 31. Kd3 Rxe6 32. Rxe6+ Kxe6 33. Kxd4 Kf5 34. Ke3 Kg5 35. f4+ Kh4 36. f5 Kxh3 37. f6 Kg2 38. f7 h4 39. f8=Q h3 40. Qf3+ Kh2 41. Qf2+ Kh1 42. Kf3 h2 43. Qg2#"}], "ideal": "8/8/p7/8/8/5K2/P5Qp/7k b - - 1 43"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. d3 Nf6 5. Nc3 O-O 6. Be3 Bxe3 7. fxe3 d6 8. d4 exd4 9. exd4 Qe8 10. Qd3 Bf5 11. Ng5 Nxe4 12. Ngxe4 Bxe4 13. Nxe4 Nb4 14. Qb3 Qxe4+ 15. Be2 Nxc2+ 16. Kd1 Nxa1 17. Bc4 Nxb3"}], "ideal": "r4rk1/ppp2ppp/3p4/8/2BPq3/1n6/PP4PP/3K3R w - - 0 18"}
{"input": [{"role": "system", "content": "Provide the FEN string for the current chess position after the following moves are played. Do not include anything but the FEN string in the output."}, {"role": "user", "content": "Moves: 1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. b4 Nxb4 5. c3 Nc6 6. d4 exd4 7. cxd4 Bb4+ 8. Bd2 Qe7 9. Bxb4 Qxe4+ 10. Qe2 Qxe2+ 11. Bxe2 Nxb4 12. Nc3 Nc2+ 13. Kd2 Nxa1 14. Rxa1 Nf6 15. Nb5 O-O 16. Nxc7 Rb8 17. Ne5 a6 18. Bg4 b5 19. Rc1 Nxg4 20. Nxg4 Bb7 21. f3 Bc6 22. Ne3 Rbc8 23. Ncd5 Bxd5 24. Rxc8 Rxc8 25. Nxd5 Rc4 26. Nb6 Rxd4+ 27. Ke3 Rd6 28. Nc8 Re6+ 29. Kf4 Re2 30. Kf5 Rxg2 31. h4 Rxa2 32. Ne7+ Kf8 33. Nd5 a5 34. Nc7 b4 35. Nb5 b3 36. Nc3 Rf2 37. f4 b2"}], "ideal": "5k2/3p1ppp/8/p4K2/5P1P/2N5/1p3r2/8 w - - 0 38"}

  ```
</details>
