### PR TITLE
Add test for Korean Yamin-Jeongeum or leetspeak

### DIFF
--- a/evals/registry/data/korean_yaminjeongeum/samples.jsonl
+++ b/evals/registry/data/korean_yaminjeongeum/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ccbcc9fe602b5c7bb5280662932203e81f1ce60c4bde1fad0e6de95bb014819
+size 18348

--- a/evals/registry/evals/korean_yaminjeongeum.yaml
+++ b/evals/registry/evals/korean_yaminjeongeum.yaml
@@ -1,0 +1,8 @@
+korean_yaminjeongeum:
+  id: korean_yaminjeongeum.dev.v0
+  description: Yamin-Jeongeum is a leetspeak for Korean. Test your ability to translate it to proper Korean.
+  metrics: [accuracy]
+korean_yaminjeongeum.dev.v0:
+  class: evals.elsuite.basic.includes:Includes
+  args:
+    samples_jsonl: korean_yaminjeongeum/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
korean_yaminjeongeum

### Eval description

Yamin-Jeongeum (야민정음) is a type of leetspeak for Korean, used mostly between users of various video games, internet video broadcasting, forums, and more.

### What makes this a useful eval?

A lot of the posts written in Korean on the internet will use some from of the leetspeak. Being able to recognize this correctly is not only useful to GPT but also useful for the users of GPT when needing to parse large amount of text including the leetspeak.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> There is no Korean evals yet and this could kickstart the effort for other Korean related evals to be contributed.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "커엽다"}], "ideal": "귀엽다"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "팡머"}], "ideal": "광대"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "괄도 네넴띤"}], "ideal": "팔도비빔면"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "긋즈"}], "ideal": "굿즈"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "윾재석"}], "ideal": "유재석"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "머통령"}], "ideal": "대통령"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "순머국밥"}], "ideal": "순대국"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "머머리"}], "ideal": "대머리"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "머기업"}], "ideal": "대기업"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "뜨또"}], "ideal": "비버"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "kin"}], "ideal": "즐"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "𠃍𠃊匸己口廿人 "}], "ideal": "ㄱㄴㄷㄹㅁㅂㅅ"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "〇𠆣大刁巨立云 "}], "ideal": "ㅇㅈㅊㅋㅌㅍㅎ"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "刀比丗从双"}], "ideal": "ㄲㄸㅃㅆㅉ"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "金"}], "ideal": "숲"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "숲튽훈"}], "ideal": "김장훈"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "凸 "}], "ideal": "ㅗ"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "댕댕이"}], "ideal": "멍멍이"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "윾싀머튽"}], "ideal": "김유식대장"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "롬곡옾눞"}], "ideal": "폭풍눈물 "}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "머한민국"}], "ideal": "대한민국"}
{"input": [{"role": "system", "content": "당신은 야민정음 한국어를 번역하는 도움을 주는 조수 입니다. 사용자는 야민정음을 사용한 단어나 문장을 입력할 것입니다. 야민정음은 신조어로, 컴퓨터의 일부 글꼴에서 작은 크기로 보일 때 발생할 수 있으며, 악필, 서명, 필기체 등으로 인한 현상이 있습니다. 또한 글자를 압착하여 한 글자로 만든 경우, 90도 회전한 모습, 180도 회전한 모습, 좌우반전, 상하반전, 한자와 한글을 맞바꾼 경우, 가타카나와 한글을 맞바꾼 경우 등이 포함됩니다. 정확한 문법으로 한국어로 번역해 주세요. 추가 문장 없이 입력된 내용만 번역하여 출력해주세요."}, {"role": "user", "content": "띵곡"}], "ideal": "명곡"}

  ```
</details>
