### PR TITLE
Add Korean lexicon eval

### DIFF
--- a/evals/registry/data/korean_lexicon/samples.jsonl
+++ b/evals/registry/data/korean_lexicon/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7804bbe1813dbe36dc41e912dc1b5e3aba438516a3c53065a0e1128d56df676
+size 2243898

--- a/evals/registry/data/korean_lexicon/samples.jsonl
+++ b/evals/registry/data/korean_lexicon/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7804bbe1813dbe36dc41e912dc1b5e3aba438516a3c53065a0e1128d56df676
-size 2243898
+oid sha256:d1b4097f17d7126bd6fe108cb5b2f09d851c7b95ad2cf0da8e3b750ec26f090d
+size 1812094

--- a/evals/registry/evals/korean_lexicon.yaml
+++ b/evals/registry/evals/korean_lexicon.yaml
@@ -1,0 +1,9 @@
+korean_lexicon:
+  id: korean_lexicon.dev.v0
+  description: Test the model's ability to distinguish between existing and hallucinated Korean words.
+  metrics: [accuracy]
+
+korean_lexicon.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: korean_lexicon/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
korean_lexicon

### Eval description

Test the model's ability to distinguish between existing and hallucinated Korean words.

### What makes this a useful eval?

Being able to differentiate between real Korean words and hallucinated ones is an important feat. The words here are from https://www.korean.go.kr/front/etcData/etcDataView.do?mn_id=46&etc_seq=71 which are the most used words according to the census in 2004 in Korea. Being able to pass this eval with high accuracy would mean that it is able to correctly differentiate between the most used words and made up ones.

The samples include about 4000 words from the official Korean lexicon. 
And about 4000 made up words that are not real words or with typos.


## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> The dataset is from the official korean.co.kr, ranked by the most commonly used.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"놓치다"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"대기"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"독립"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"돌아보다"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"또다시"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"머릿속"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"북쪽"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"불안하다"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"쇠고기"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"위반"}],"ideal":"Y"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"엻덟"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"욇괋"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"제체험과점"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"켸쳢"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"편의겸"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"갈체험비탕"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"미용씰"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"앓흔"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"일씪"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"작체험은딸"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"쪄꾰"}],"ideal":"N"}
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Korean language? Answer with exactly one letter: Y or N."},{"role":"user","content":"초체험등학생"}],"ideal":"N"}
  ```
</details>
