### PR TITLE
Eval: generate names without compound words

### DIFF
--- a/evals/registry/data/non-compound-names/samples.jsonl
+++ b/evals/registry/data/non-compound-names/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d179a9c77d0ad1d8433b7c0671dfd1cb46c5d86741ed1de16536a75c66e88af5
+size 60559

--- a/evals/registry/evals/non-compound-names.yaml
+++ b/evals/registry/evals/non-compound-names.yaml
@@ -1,0 +1,12 @@
+non-compound-names:
+  id: non-compound-names.dev.v0
+  metrics: [accuracy]
+
+non-compound-names.dev.v0:
+  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
+  args:
+    samples_jsonl: non-compound-names/samples.jsonl
+    modelgraded_spec: closedqa
+    modelgraded_spec_args:
+      criteria:
+        incorrect: "correctness: A compound word is a word that is made up of two or more words, such as \"handbag\", \"Wealthsimple\", \"PureGain\" or \"airplane\". If you can take the word, such as \"Wealthsimple\", and split it up into two words, such as \"Wealth\" and \"simple\", then it is a compound word. To be correct, the answer should not contain any compound words. Is the answer correct?"


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
non-compound-names

### Eval description

Evaluates whether the model can follow instructions to provide example names for a company, product, or application (in a variety of sectors) which are not compound words.

### What makes this a useful eval?

Generating ideas for product, company or application names is a common use case of ChatGPT.  Additionally, providing non-compound-word name ideas is a very easy task for a human. This is a fundamental test of the model's ability to follow lexical instructions.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [ ] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [ ] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [ ] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [ ] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

While this is a fairly simple lexical instruction task, I have not been able to get ChatGPT-4 to complete it. Even when asking it to check and revise its answer, it continues to give compound word names for several iteration cycles. This failure is surprising.

The gpt-3.5-turbo model is not even able to identify compound words in many names (such as PureCare), and as a result this test is not helpful for gpt-3.5-turbo (the self-evaluation fails). I could add an evaluation of this task, but it would almost certainly pass for gpt-4, and based on ChatGPT-4's ability to identify these compound words (but not avoid generating them), I expect the evaluation should work well for the gpt-4 base model.

## Eval structure 🏗️

Your eval should
- [ ] Check that your data is in `evals/registry/data/{name}`
- [ ] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [ ] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [ ] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [ ] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [ ] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [ ] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  INSERT_EVAL_HERE
  ```
</details>
