### PR TITLE
Famous shows image analyzer

### DIFF
--- a/evals/elsuite/famous-shows-images.py
+++ b/evals/elsuite/famous-shows-images.py
@@ -1,0 +1,48 @@
+import random
+import textwrap
+
+import evals
+import evals.metrics
+
+class FamousShowsImages(evals.Eval):
+    def __init__(self, train_jsonl, test_jsonl, train_samples_per_prompt=2, **kwargs):
+        super().__init__(**kwargs)
+        self.train_jsonl = train_jsonl
+        self.test_jsonl = test_jsonl
+        self.train_samples_per_prompt = train_samples_per_prompt
+
+    def run(self, recorder):
+        self.train_samples = evals.get_jsonl(self.train_jsonl)
+        test_samples = evals.get_jsonl(self.test_jsonl)
+        self.eval_all_samples(recorder, test_samples)
+
+        return {
+            "accuracy": evals.metrics.get_accuracy(recorder.get_events("match")),
+        }
+    def eval_sample(self, test_sample, rng: random.Random):
+        stuffing = rng.sample(self.train_samples, self.train_samples_per_prompt)
+
+        prompt = [
+            {"role": "system", "content": "Solve the following math problems"},
+        ]
+
+        for i, sample in enumerate(stuffing + [test_sample]):
+            if i < len(stuffing):
+                prompt += [
+                    {"role": "system", "content": sample[0]["content"], "name": "example_user"},
+                    {"role": "system", "content": sample[1]["content"], "name": "example_assistant"},
+                ]
+            else:
+                prompt += [{"role": "user", "content": sample[0]["content"]}]
+
+        result = self.completion_fn(
+            prompt=prompt,
+            temperature=0.0,
+        )
+        sampled = result.get_completions()[0]
+
+        return evals.record_and_check_match(
+            prompt=prompt,
+            sampled=sampled,
+            expected=sample[1]["content"],
+        )

--- a/evals/elsuite/famous-shows-images.py
+++ b/evals/elsuite/famous-shows-images.py
@@ -23,7 +23,7 @@ class FamousShowsImages(evals.Eval):
         stuffing = rng.sample(self.train_samples, self.train_samples_per_prompt)
 
         prompt = [
-            {"role": "system", "content": "Solve the following math problems"},
+            {"role": "system", "content": "Give the movie name from the image url"},
         ]
 
         for i, sample in enumerate(stuffing + [test_sample]):

--- a/evals/registry/data/famous_shows_images/test.jsonl
+++ b/evals/registry/data/famous_shows_images/test.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6ee123dda76cc27cb4f6eea4632b344cdbb13935ea304ea2d0c6d76958479ea
+size 6831

--- a/evals/registry/data/famous_shows_images/test.jsonl
+++ b/evals/registry/data/famous_shows_images/test.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d6ee123dda76cc27cb4f6eea4632b344cdbb13935ea304ea2d0c6d76958479ea
-size 6831
+oid sha256:e1a88b389aef6e97c2ee16f891adcefde17aa06e94bd61986df545d369861faa
+size 8350

--- a/evals/registry/data/famous_shows_images/train.jsonl
+++ b/evals/registry/data/famous_shows_images/train.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15c203fcf08fc1697e29f2e806bd6525f8bcd5f941e4e227143f6497e01151f5
-size 1002
+oid sha256:846f78b8769639ecbca344f4ec3aeb0d21b110d65c957ec29f21e5758d60ef5a
+size 894

--- a/evals/registry/data/famous_shows_images/train.jsonl
+++ b/evals/registry/data/famous_shows_images/train.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15c203fcf08fc1697e29f2e806bd6525f8bcd5f941e4e227143f6497e01151f5
+size 1002

--- a/evals/registry/evals/famous-shows-images.yaml
+++ b/evals/registry/evals/famous-shows-images.yaml
@@ -1,0 +1,9 @@
+famous-shows-images:
+  id: famous-shows-images.dev.match-v1
+  metrics: [accuracy]
+  description: Evaluate image url to check what shows inside those.
+famous-shows-images.dev.match-v1:
+  class: evals.elsuite.famous-shows-images:FamousShowsImages
+  args:
+    train_jsonl: famous_shows_images/train.jsonl
+    test_jsonl: famous_shows_images/test.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
Famous shows image analyzer

### Eval description

A simple eval that accepts image url then will return the show description

### What makes this a useful eval?

For SEO purpose of movie websites.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  [
   {
      "role":"system",
      "content":"https://images.gmanews.tv/webpics/2022/09/maria_clara_at_ibarra_2022_09_29_17_30_20.jpg",
      "name":"example_user"
   },
   {
      "role":"system",
      "content":"'Maria Clara and Ibarra' tells the story of Klay, a Gen Z nursing student who is apathetic about societal issues and even more uninterested in her Rizal studies class, a required subject for graduation.",
      "name":"example_assistant"
   }
]
[
   {
      "role":"system",
      "content":"https://m.media-amazon.com/images/M/MV5BMDI3ZDY4MDgtN2U2OS00Y2YzLWJmZmYtZWMzOTM3YWFjYmUyXkEyXkFqcGdeQXVyNjAwNDUxODI@._V1_FMjpg_UX1000_.jpg",
      "name":"example_user"
   },
   {
      "role":"system",
      "content":"'Naruto is a Japanese manga series written and illustrated by Masashi Kishimoto. It tells the story of Naruto Uzumaki, a young ninja who seeks recognition from his peers and dreams of becoming the Hokage, the leader of his village.",
      "name":"example_assistant"
   }
]
[
   {
      "role":"system",
      "content":"https://www.google.com/url?sa=i&url=https%3A%2F%2Faquamermaid.com%2Fblogs%2Fnews%2Fthe-little-mermaid-live-action-movie&psig=AOvVaw0Ab9u-JCs8inW3ECv21bM3&ust=1681822786093000&source=images&cd=vfe&ved=0CA4QjRxqFwoTCKji-aH8sP4CFQAAAAAdAAAAABAH",
      "name":"example_user"
   },
   {
      "role":"system",
      "content":"'The Little Mermaid, a tale that endured over the centuries
Ariel, a young mermaid, dreams of becoming human and living on the surface herself. With the help of her friend, she disobeys her father King Triton, and trades her precious voice for a pair of legs with the witch Ursula.",
      "name":"example_assistant"
   }
]
[
   {
      "role":"system",
      "content":"https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.preview.ph%2Fculture%2Fdisney-encanto-movie-life-lessons-a2164-20220128-lfrm&psig=AOvVaw0UO3Hi2IX9i2P2wzq1OknO&ust=1681822923058000&source=images&cd=vfe&ved=0CA4QjRxqFwoTCLDA6eb8sP4CFQAAAAAdAAAAABAD",
      "name":"example_user"
   },
   {
      "role":"system",
      "content":"Encanto follows a multigenerational Colombian family, the Madrigals, led by a matriarch (Botero) whose children and grandchildren—except for Mirabel Madrigal (Beatriz)—receive magical gifts from a miracle that helps them serve the people in their rural community called the Encanto.",
      "name":"example_assistant"
   }
]
[
   {
      "role":"system",
      "content":"https://www.google.com/url?sa=i&url=https%3A%2F%2Fmydramalist.com%2Farticle%2Fnetflix-releases-the-trailer-of-upcoming-korean-movie-unlocked&psig=AOvVaw3xjiUrh9eJijZoA1dAsTYj&ust=1681823151777000&source=images&cd=vfe&ved=0CA4QjRxqFwoTCNC9kuj9sP4CFQAAAAAdAAAAABAD",
      "name":"example_user"
   },
   {
      "role":"system",
      "content":"UNLOCKED is a new Netflix thriller from South Korea about a serial killer who stalks his victims via their smartphones. In fact, he even seems to choose his victims at random; If they lose their phone and he finds it, then they're his next victim.",
      "name":"example_assistant"
   }
]
  ```
</details>
