### PR TITLE
Stats tests eval

### DIFF
--- a/evals/registry/data/stats-tests/samples.jsonl
+++ b/evals/registry/data/stats-tests/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:561752a511e40bdf58d1cc36964904c02b64803b293e7ca277bdc40a4eafc98e
+size 15621

--- a/evals/registry/evals/stats-tests.yaml
+++ b/evals/registry/evals/stats-tests.yaml
@@ -1,0 +1,8 @@
+stats-tests:
+  id: stats-tests.dev.v0
+  metrics: [accuracy]
+
+stats-tests.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: stats-tests/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
Stats Tests

### Eval description

Given a research situation, identify the correct statistical test needed to determine statistical significance (e.g. t-test, ANOVA, Kruskal-Wallis, etc).

### What makes this a useful eval?

Automating science, whether a good or bad idea, may require that LLMs can pass evals like this with high accuracy, as humans can.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'Bogton Council decide to see whether performance-related pay would improve morale amongst their lavatory cleaners. Each month, twenty lavatory cleaners are paid on the basis of the length of the bristles on their lavatory brush (on the assumption that the harder they have worked, the shorter their bristles will be). Another twenty are paid their usual near-subsistence-level wages, regardless of how hard they work. After 6 months, each worker is asked to rate how happy they are in their job, using a seven-point scale. Which test would you use to see if performance-related pay has affected workers' morale?' Answer Choices: A: Friedman's test B: Mann-Whitney test C: Wilcoxon test D: independent-measures t-test"}], "ideal": "B"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'An experimenter wants to know whether experience affects how well shop-keepers can identify children who ask for cigarettes but are under the legal age for purchasing them. Each of 30 tobacconists is shown a random sequence of 40 photographs of young faces, and asked to decide whether each face is younger or older than the legal age for buying cigarettes. (Half of the faces are aged above the legal age, and half below). The experimenter records the number of correct decisions per participant, and also asks each shop-keeper how long they have been selling cigarettes. (These latter data turn out to be heavily skewed). Which test should the experimenter use to decide whether experience leads to better age-estimation in this group?' Answer Choices: A: Pearson's r B: Spearman's rho C: Kruskal-Wallis test D: Friedman's test"}], "ideal": "B"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'It's often said that you're hungry again soon after a Chinese meal. An experimenter puts this to the test. There are four conditions, and each participant does each one, on a different day of the week (order of conditions is counterbalanced across participants). In the first, participants eat an Indian takeaway; in the second, they eat a pizza; in the third, they eat a Chinese takeaway; and in the fourth, they eat a Kentyukky Flayed Chicken takeaway. All the meals are equated for bulk of contents and calorific value. The dependent variable is the loudness of each participants' stomach rumblings (in decibels), measured one hour after they have eaten the meal. These measurements are normally distributed, but much more variable for the \"KFC\" condition than the others. Which test should be used to decide whether there is a difference between these meals in terms of how quickly people get hungry again after eating them?' Answer Choices: A: Friedman's test B: repeated-measures t-test C: one-way independent-measures ANOVA D: Friedman's test"}], "ideal": "A"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'Some TV viewers complain to the BBC that Jeremy Clarkson's programme \"Top Gear\" is a bad influence on young drivers, given that it extols the virtues of laddishness, speeding and high performance cars. To determine whether there is any foundation to these claims, a researcher uses a speed camera to measure the speeds of 400 drivers on an A-road, the morning before the programme is transmitted. He follows this procedure again, the morning afterwards. Each car is photographed, so that the experimenter can select only those drivers who travelled that route on both occasions, and hence whose speeds were measured twice. The experimenter subtracts each driver's first speed reading from their second, to get a \"difference score\": a positive score means a driver drove faster on the second occasion, and a negative score means they drove more slowly. The selected drivers were then contacted and asked whether or not they had watched \"Top Gear\" that week. Which test would you use to see whether drivers who watched \"Top Gear\" drove faster the following morning than drivers who did not watch it?' Answer Choices: A: Friedman's test B: repeated-measures t-test C: Pearson's r D: independent-measures t-test"}], "ideal": "D"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'A researcher is interested in factors affecting reproductive success in Homo canarywharfensis, an obscure species of proto-human that inhabits high-altitude habitats in a region of south-east London. Once she has acclimatised them to her presence, she traps a hundred of the males and records the price of their suits. She then releases them back into the wild and follows them for a fortnight, recording how many females each one mates with. Is there a relationship between wealth (as reflected in suit price) and reproductive success (as reflected in how many females each male mates with?) The data for reproductive success are heavily skewed, since most of the males attract no females.' Answer Choices: A: Mann-Whitney test B: repeated-measures t-test C: Spearman's rho D: independent-measures t-test"}], "ideal": "C"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'The local Sussex ale, Harvey's Best bitter, is reputed to be imbued with truly magical medicinal properties, as well as having an especially delicious flavour, a unique golden colour and a beautiful yeasty head. To investigate its effects, a researcher asks four groups of cyclists to cycle up Ditchling Beacon (the highest point on the South Downs). One group drink no Harvey's beforehand; another group drink one pint of Best each; a third group drink two pints each; and a fourth group drink four pints each. The dependent variable is how fast each cyclist gets from the bottom of the Beacon to the top. Which test would you use to see if drinking Harvey's affects the cyclists' speed of ascent?' Answer Choices: A: Pearson's r B: repeated-measures t-test C: one-way independent-measures ANOVA D: independent-measures t-test"}], "ideal": "C"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'It is said that every time someone prints off an email, a penguin dies. To put this to the test, a researcher flies to the South Pole and repeatedly counts the number of penguins, as her colleague at Sussex prints out his emails one at a time. Which test would you use to see if there is a relationship between printing off emails and penguin mortality?' Answer Choices: A: Wilcoxon test B: Kruskal-Wallis test C: Pearson's r D: Friedman's test"}], "ideal": "C"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'A researcher investigates four different methods for coping with extreme stress. Each person attempts to assemble an IKEA flat-pack wardrobe (the stress-induction phase of the study), and is then allocated randomly to one of four groups. Those in the first group practise yoga for twenty minutes; those in the second group engage in deep breathing for a similar amount of time; those in the third group spend twenty minutes in a Harvey's pub, drinking Best bitter; and those in the fourth group simply scream at the top of their voice for twenty minutes. Each participant then provides a rating on a 0-10 scale of how stressed they feel. Which test would you use to determine whether the four methods differ in their effectiveness for relieving stress?' Answer Choices: A: Kruskal-Wallis test B: Wilcoxon test C: Mann-Whitney test D: Spearman's rho"}], "ideal": "A"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'To determine whether young chldren find \"Dr. Who\" scary, a researcher asks the parents of thirty six-year olds to keep a record of how many nightmares each child has on Saturday night (after watching \"Dr. Who\") and Sunday night (after watching \"Songs of Praise\"). Which test would you use to see if watching \"Dr. Who\" is associated with more nightmares than watching \"Songs of Praise\"?' Answer Choices: A: Chi-Square test of association B: repeated-measures t-test C: Spearman's rho D: one-way independent-measures ANOVA"}], "ideal": "B"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'To determine whether young chldren find \"Dr. Who\" scary, a researcher asks the parents of thirty six-year olds to rate how frightened they think their child is on Saturday night (after watching \"Dr. Who\") and Sunday night (after watching \"Songs of Praise\"). Which test would you use to see if parents think their children are more frightened by watching \"Dr. Who\" than by watching \"Songs of Praise\"?' Answer Choices: A: Wilcoxon test B: independent-measures t-test C: Wilcoxon test D: Spearman's rho"}], "ideal": "A"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: '200 men and 150 women are asked to decide which one of the following features is most important to them when they choose a new car: price, performance, safety level, roominess, or colour. Which test would you use to see if men and women differ in their preferences?' Answer Choices: A: Kruskal-Wallis test B: Chi-Square test of association C: Chi-Square test of association D: repeated-measures t-test"}], "ideal": "B"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'An experimenter investigates the accuracy of fortune-tellers' predictions. She asks each of fifteen fortune-tellers, and each of twenty students, to make ten specific predictions about what will happen to her in the next month. She then records, for each of these people, how many of these predictions come true. Which test should she use to see if the fortune-tellers are more accurate in their predictions than the students?' Answer Choices: A: Chi-Square test of association B: Kruskal-Wallis test C: independent-measures t-test D: one-way independent-measures ANOVA"}], "ideal": "C"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'The experimenter from the previous study returns to each of the participants and tells them that none of their predictions came true. She then asks each of the participants to estimate their level of psychic ability on a seven-point scale. Which test should the experimenter use to determine whether this negative feedback about their performance affects the fortune-tellers and students differently?' Answer Choices: A: repeated-measures t-test B: Friedman's test C: Mann-Whitney test D: independent-measures t-test"}], "ideal": "C"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'A study looks at the effectiveness of TV adverts in relation to their position in the adbreak between programmes. There are three conditions. All participants see the same advert, for \"Churn Flakes\", but for one group the advert comes at the start of the adbreak; for a second group, it comes in the middle; and for the third group it comes at the end, just before the next program begins. A week later, each participant returns to the lab and sees a sequence of photographs of breakfast cereal boxes, including the box for \"Churn Flakes\". Their task is to rate each cereal in terms of how much they like it, using a seven-point scale.' Answer Choices: A: independent-measures t-test B: Friedman's test C: Kruskal-Wallis test D: Chi-Square test of association"}], "ideal": "C"}
{"input": [{"role": "system", "content": "TASK: Read the provided research situation and determine which statistical test is most appropriate for the situation from the list of answer choices. Respond only with one of the letters 'A', 'B', 'C', or 'D', and nothing else."}, {"role": "user", "content": "Situation: 'While sales of traditional classical music CD's are falling, \"cross-over\" classical performers who sacrifice their integrity for money by producing populist versions of tunes like \"Nessun Dorma\" are big business. The CD sales of twenty opera singers are examined: ten of these singers are rated as \"ugly\" by a panel of independent judges, and twenty are rated as \"highly attractive\". Is the success of these perfomers related to their physical attractiveness?' Answer Choices: A: one-way independent-measures ANOVA B: Spearman's rho C: Wilcoxon test D: independent-measures t-test"}], "ideal": "D"}

  ```
</details>
