### PR TITLE
Eval submission

### DIFF
--- a/evals/registry/data/transaction_grouping_matching/samples.jsonl
+++ b/evals/registry/data/transaction_grouping_matching/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ca61e2fc2367bb03ffe20bf884e661543c014c1d4cfc2f16ba0875a575c6f2b
+size 257201

--- a/evals/registry/evals/transaction-grouping-matching.yaml
+++ b/evals/registry/evals/transaction-grouping-matching.yaml
@@ -1,0 +1,8 @@
+transaction-grouping-matching:
+  id: transaction-grouping-matching.dev.v0
+  description: Match transactions using groups of transactions when needed 
+  metrics: [accuracy]
+character-count-numbers.dev.v0:
+  class: evals.elsuite.basic.includes:Includes
+  args:
+    samples_jsonl: transaction_grouping_matching/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
Transaction Grouping Matching

### Eval description

GPT4 is only good at grouping transactions under highly specific and bounded prompts. It starts failing when the prompts are less engineered. This eval shows a broad range of related grouping and matching basic scenarios.

### What makes this a useful eval?

This eval attempts to show a variety of related scenarios in which the GPT4 struggles with grouping/matching. Rather than focus on the unstructured results, where GPT4 fails but the results are harder to validate, this eval boils down its logic to multiple choice answers.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

Many-to-many matching is a problem that computers today fail at but humans are skilled. When passed highly engineered prompts, GPT4 sometimes does a good job, but most of the time it struggles and either leaves out a relevant transaction or does not consider all possibilities ... or gives a random response.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date Time) General treats 75 4\/14\/21 ,  Commerce: (Name Amount Date) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21 2PMET, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date Time) General treats 75 4\/14\/21 ,  Commerce: (Name Amount Date) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date Time) General treats 75 4\/14\/21 ,  Commerce: (Name Amount Date Time) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21 2PMET, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date Time) General treats 75 4\/14\/21 ,  Commerce: (Name Amount Date Time(optional)) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21 2PMET, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date Time(optional)) General treats 75 4\/14\/21 ,  Commerce: (Name Amount Date Time(optional)) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21 2PMET, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date) General treats 75 4\/14\/21 ,  Commerce: (Name Amount Date) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. Transactions may happen in different time zones. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date) General treats 75 4\/14\/21 ,  Commerce: (Name Amount Date) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. Transactions may happen in different time zones. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date) General treats 78 4\/14\/21 ,  Commerce: (Name Amount Date) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" d"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. Commerce transactions may have small fees added when transferred to banking. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date) General treats 78 4\/14\/21 ,  Commerce: (Name Amount Date) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
{"prompt":"[{'role': 'system', 'content': \"Return only the choice letter. Commerce transactions may have small fees added after transfer to banking. A. There are no combination of commerce transactions that match the banking transaction. B. There is 1 combination of commerce transactions that match the banking transaction. C. There are multiple combinations of commerce transactions that match the banking transaction. D. There isn't enough info.\"}, {'role': 'user', 'content': 'Banking: (Name Amount Date) General treats 78 4\/14\/21 ,  Commerce: (Name Amount Date) Rice krispie 25 4\/13\/21, Choco 110 4\/1\/21, PB 110 4\/1\/21, Candy bags 25 4\/14\/21, Random treats 25 4\/14\/21'}]","ideal":" b"}
  ```
</details>
