### PR TITLE
Fix basic.includes evals

### DIFF
--- a/evals/elsuite/utils.py
+++ b/evals/elsuite/utils.py
@@ -22,7 +22,7 @@ def get_answer(text, answer_prompt, ignore_case=False):
 
     if idx == -1:
         return None
-    return text[idx + len(answer_prompt) :]
+    return text[idx:idx + len(answer_prompt)]
 
 
 def get_consensus(answers):


### PR DESCRIPTION
This PR addresses an issue in `basic.includes` evals where samples are marked as incorrect if the sampled text ends with the reference text.

The issue stems from the `get_answer` function, which previously returned the substring of the sampled text occuring directly after the reference text's location, this will be an empty string if the sampled text ends with the reference text. This update returns the substring where the reference occured (i.e. the answer) instead.