### PR TITLE
feat: add airports by country evals

### DIFF
--- a/evals/registry/data/airports-by-country/samples.jsonl
+++ b/evals/registry/data/airports-by-country/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f7151bd2aabce889153315747508be84707c2107edaba8ce5797abb75fc480
+size 16309

--- a/evals/registry/evals/airports-by-country.yaml
+++ b/evals/registry/evals/airports-by-country.yaml
@@ -1,0 +1,8 @@
+airports-by-country:
+  id: airports-by-country.dev.v0
+  metrics: [accuracy]
+
+airports-by-country.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: airports-by-country/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
airports-by-country

### Eval description

Provides a country name and requirement to list all airports iata codes in this country, formatted as json array. Expecting completed json array with iata codes without any extra information and text. IATA code - unified world agreed airports and cities ID.
The list of country airports changes very rarely, and all samples actually not affected by new airports appeared after September 2021.

### What makes this a useful eval?

GPT4 shows a cool level of reasoning for different types of tasks, but for this task for some reason it has high level of inaccuracy. I saw it returning a lot of wrong airports from different countries and even not existing airports. With a high probability GPT saw all these data during learning stage, because this data often related to history, geography, finance and texts from forums. Also I was able to help GPT find it's mistakes, so it actually knows which countries these airports belong to. Task itself should be simple (compared to other which gpt solves well): find all occurrences of airports in memory, find out which country is this airport related to and what is the iata code of airport, filter out airports without iata, transform list to json array.
I guess the problem might be with the iata/icao codes themselves, they are easy to confuse with other abbreviations. So I expect this eval will improve accuracy of gpt4 not only for airports, may be GPT can understand better how to work with abbreviations tokens.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

I cannot paste samples here because they are too big.
You can get actual list of iata codes in https://iata.org by request, or in wikipedia iata codes list by countries (https://en.wikipedia.org/wiki/List_of_airports_in_Europe) (very close to actual data). I used iata.org data.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Spain."}],"ideal":"['ABC','ACE','AGP','ALC','BCN','BIO','BJZ','CDT','EAS','FUE','GMZ','GRO','GRX','HSK','IBZ','ILD','LCG','LEI','LEN','LEU','LPA','MAD','MAH','MJV','MLN','ODB','OVD','OZP','PMI','PNA','REU','RGS','RJL','RMU','ROZ','SCQ','SDR','SLM','SPC','SVQ','TEV','TFN','TFS','TOJ','VDE','VGO','VIT','VLC','VLL','XRY','ZAZ']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in France."}],"ideal":"['AGF','AHZ','AJA','ANE','ANG','AUF','AUR','AVN','BAE','BES','BIA','BIQ','BOD','BOR','BOU','BVA','BVE','BYF','BZR','CCF','CDG','CEQ','CER','CET','CFE','CFR','CHR','CLY','CMF','CMR','CNG','CQF','CSF','CTT','CVF','DCM','DIJ','DLE','DNR','DOL','DPE','EBU','EDM','EGC','ENC','EPL','ETZ','EVX','FNI','FSC','GAT','GFR','GNB','HZB','IDY','IFR','JAH','JCA','JDP','JEV','JLP','JPU','JSZ','LAI','LBG','LBI','LBY','LDE','LDV','LEH','LIG','LIL','LME','LPY','LRH','LRT','LSO','LTQ','LTT','LVA','LYN','LYS','MCU','MEN','MFX','MLH','MPL','MRS','MVV','MXN','MZM','NCE','NCY','NIT','NTE','NVS','OBS','ORY','PGF','PGX','PIS','POX','PRP','PUF','QAM','QBQ','QNJ','QNX','QTJ','QXB','QYR','QZE','RCO','RDZ','RHE','RNE','RNS','RYN','SBK','SCP','SNR','SOZ','SXB','SYT','TLN','TLS','TNF','TUF','UIP','URO','VAF','VHY','VIY','VNE','VTL','XAB','XAC','XAM','XAN','XAV','XBD','XBF','XBK','XBQ','XBV','XBX','XCB','XCD','XCP','XCR','XCW','XCX','XCY','XDA','XDK','XEP','XGT','XLE','XLG','XLL','XLN','XLR','XME','XMF','XMJ','XMK','XMU','XMW','XOG','XRN','XSB','XSG','XSL','XSN','XSS','XST','XSU','XSW','XTC','XTD','XTH','XVF','XVI','XVN','XVS','XVZ','XWA','XXG','XXY','XYB','XYP','XYT','XZB','XZX','ZAO']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Austria."}],"ideal":"['GRZ','HOH','INN','KLU','LNZ','SZG','VIE']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Cyprus."}],"ideal":"['AKT','ECN','GEC','KIN','LCA','NIC','PFO']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Finland."}],"ideal":"['ENF','HEL','HEM','HYV','IVL','JOE','JYV','KAJ','KAO','KAU','KEM','KEV','KHJ','KOK','KTQ','KTT','KUO','LPP','MHQ','MIK','OUL','POR','RVN','SJY','SOT','SVL','TKU','TMP','UTI','VAA','VRK']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Germany."}],"ideal":"['AAH','AGB','AGE','AOC','BBH','BBJ','BER','BMK','BRE','BRV','BWE','BYU','CGN','CSO','DRS','DTM','DUS','EME','ERF','FCN','FDH','FEL','FKB','FMM','FMO','FNB','FRA','FRZ','GHF','GKE','GWT','HAJ','HAM','HDF','HEI','HGL','HHN','HOQ','IGS','KEL','KSF','LBC','LEJ','LHA','MGL','MHG','MUC','NDZ','NRN','NUE','PAD','QFB','QOE','REB','RLG','RMS','SCN','SGE','SPM','STR','SXF','THF','TXL','WBG','WIE','XFW','ZCD','ZCN','ZPQ','ZQW']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in China."}],"ideal":"['AAT','ACF','ACX','AEB','AHJ','AKA','AKU','AOG','AQG','AVA','AXF','BAR','BAV','BFJ','BHY','BPE','BPL','BPX','BSD','BZX','CAN','CDE','CGD','CGO','CGQ','CHG','CIF','CIH','CKG','CNI','CQW','CSX','CTU','CWJ','CZX','DAT','DBC','DCY','DDG','DIG','DLC','DLU','DNH','DOY','DQA','DSN','DTU','DYG','DZH','EHU','EJN','ENH','ENY','ERL','FOC','FUG','FUO','FYJ','FYN','GMQ','GOQ','GXH','GYS','GYU','GZG','HAK','HBQ','HCJ','HCZ','HDG','HEK','HET','HFE','HGH','HIA','HJJ','HLD','HLH','HMI','HNY','HPG','HQL','HRB','HSC','HSN','HTN','HTT','HUO','HUZ','HXD','HYN','HZA','HZG','HZH','INC','IQM','IQN','JDZ','JGD','JGN','JGS','JHG','JIC','JIQ','JIU','JJN','JMJ','JMU','JNG','JNZ','JSJ','JUH','JUZ','JXA','JZH','KCA','KGT','KHG','KHN','KJH','KJI','KMG','KOW','KRL','KRY','KWE','KWL','LCX','LDS','LFQ','LGZ','LHW','LJG','LLB','LLF','LLV','LNJ','LNL','LPF','LUM','LXA','LYA','LYG','LYI','LZH','LZO','LZY','MDG','MIG','MXZ','NAO','NBS','NDG','NGB','NGQ','NKG','NLH','NLT','NNG','NNY','NTG','NZH','NZL','OHE','PEK','PKX','PVG','PZI','QSZ','RHT','RIZ','RKZ','RLK','RQA','SHA','SHE','SHF','SHS','SJW','SQD','SQJ','SWA','SYM','SYX','SZX','TAO','TCG','TCZ','TEN','TFU','TGO','THQ','TLQ','TNA','TNH','TSN','TVS','TWC','TXN','TYN','UCB','URC','UYN','WDS','WEF','WEH','WGN','WHA','WMT','WNH','WNZ','WSK','WUA','WUH','WUS','WUT','WUX','WUZ','WXN','XAI','XFN','XIC','XIL','XIY','XMN','XNN','XUZ','YBP','YCU','YIC','YIE','YIH','YIN','YIW','YKH','YLX','YNJ','YNT','YNZ','YSQ','YTW','YTY','YUS','YYA','YZY','ZAT','ZFL','ZHA','ZHY','ZQZ','ZUH','ZYI']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in South Korea."}],"ideal":"['CHF','CHN','CJJ','CJU','GMP','HIN','ICN','JDG','KAG','KPO','KUV','KWJ','MPK','MWX','OSN','PUS','RSU','SHO','SSN','SWU','TAE','UJN','USN','WJU','YEC','YNY']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Singapore."}],"ideal":"['SIN','XSP','QPG','TGA']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Malaysia."}],"ideal":"['AOR','BBN','BKI','BKM','BLG','BSE','BTU','BWH','GSA','IPH','JHB','KBR','KCH','KGU','KPI','KTE','KUA','KUD','KUL','LAC','LBP','LBU','LDU','LGK','LGL','LKH','LMN','LSM','LSU','LWY','MEP','MKM','MKZ','MUR','MYY','MZV','ODN','PAY','PEN','PKG','RDN','RNU','SBW','SDK','SGG','SMM','SPE','SWY','SXS','SZB','TGG','TMG','TOD','TPG','TWU']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Kazakhstan."}],"ideal":"['AKX','ALA','ATX','AYK','BXH','BXJ','CIT','DMB','DZN','EKB','GUW','HSA','KGF','KOV','KSN','KZO','NQZ','PLX','PPK','PWQ','SCO','SZI','TDK','UKK','URA','USJ','UZR']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Qatar."}],"ideal":"['DIA','DOH','XJD']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Argentina."}],"ideal":"['AEP','AFA','AOL','APZ','ARR','BHI','BRC','CCT','CLX','CNQ','CNT','COC','COR','CPC','CPG','CRD','CRR','CSZ','CTC','CUT','CVH','EHL','ELO','EMX','EPA','EQS','EZE','FMA','FTE','GGS','GHU','GNR','GPO','HOS','IGB','IGR','ING','IRJ','JNI','JSM','JUJ','LCM','LCP','LGS','LHS','LLS','LMD','LPG','LUQ','MCS','MDQ','MDX','MDZ','MJR','MQD','NCJ','NEC','NQN','OES','OLN','ORA','OVR','OYA','OYO','PEH','PMQ','PMY','PRA','PRQ','PSS','PUD','RAF','RCQ','RCU','RDS','REL','RES','RGA','RGL','RHD','RLO','ROS','ROY','RSA','RYO','RZA','SDE','SFN','SGV','SLA','SST','TDL','TTG','TUC','UAQ','ULA','USH','UZU','VCF','VDM','VDR','VGS','VLG','VME','VMR']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in United States."}],"ideal":"['ABE','ABI','ABQ','ABR','ABY','ACK','ACT','ACV','ACY','ADQ','AEX','AGS','AKN','ALB','ALO','ALS','ALW','AMA','ANC','APN','ART','ASE','ATL','ATW','ATY','AUS','AVL','AVP','AZA','AZO','BDL','BET','BFF','BFI','BFL','BGM','BGR','BHM','BID','BIL','BIS','BJI','BKG','BLD','BLI','BLV','BMI','BNA','BOI','BOS','BPT','BQK','BQN','BRD','BRO','BRW','BTM','BTR','BTV','BUF','BUR','BWI','BZN','CAE','CAK','CDC','CDV','CHA','CHO','CHS','CID','CIU','CKB','CLE','CLL','CLT','CMH','CMI','CMX','CNY','COD','COS','COU','CPR','CPX','CRP','CRW','CSG','CVG','CWA','DAB','DAL','DAY','DBQ','DCA','DEN','DFW','DHN','DIK','DLG','DLH','DRO','DRT','DSM','DTW','DUT','EAR','EAT','EAU','ECP','EGE','EKO','ELM','ELP','ENA','ERI','ESC','ESD','EUG','EVV','EWN','EWR','EYW','FAI','FAR','FAT','FAY','FCA','FLG','FLL','FLO','FNT','FRD','FSD','FSM','FWA','GCC','GCK','GEG','GFK','GGG','GJT','GNV','GPT','GRB','GRI','GRK','GRR','GSO','GSP','GST','GTF','GTR','GUC','GUM','HDN','HGR','HHH','HIB','HLN','HNL','HOB','HOM','HOU','HPN','HRL','HSV','HTS','HVN','HYA','HYS','IAD','IAG','IAH','IAT','ICT','IDA','ILG','ILM','IMT','IND','ISP','ITH','ITO','JAC','JAN','JAX','JFK','JLN','JMS','JNU','KLW','KOA','KTN','LAN','LAR','LAS','LAW','LAX','LBB','LBE','LBF','LCH','LCK','LEX','LFT','LGA','LGB','LIH','LIT','LNK','LNY','LRD','LSE','LWB','LWS','LYH','MAF','MBS','MCI','MCN','MCO','MDT','MDW','MEI','MEM','MFE','MFR','MGM','MHK','MHT','MIA','MKE','MKG','MKK','MLB','MLI','MLU','MOB','MOT','MQT','MRI','MRY','MSN','MSO','MSP','MSY','MTJ','MVY','MWA','MYR','NRR','OAJ','OAK','OGD','OGG','OGS','OKC','OMA','OME','ONT','ORD','ORF','ORH','OTH','OTZ','OWB','PAE','PAH','PBG','PBI','PDX','PGA','PGD','PGV','PHF','PHL','PHX','PIA','PIB','PIE','PIH','PIR','PIT','PLN','PNS','PQI','PRC','PSC','PSE','PSG','PSM','PSP','PUW','PVD','PVU','PWM','RAP','RDD','RDM','RDU','RFD','RHI','RIC','RIW','RKD','RKS','RNO','ROA','ROC','ROW','RST','RSW','SAF','SAN','SAT','SAV','SBA','SBN','SBP','SBY','SCC','SCE','SCK','SDF','SEA','SFB','SFO','SGF','SGU','SHD','SHR','SHV','SIG','SIT','SJC','SJT','SJU','SLC','SLN','SMF','SMX','SNA','SPI','SPN','SPS','SRQ','STC','STL','STS','STT','STX','SUN','SUX','SWF','SWO','SYR','TBN','TIQ','TLH','TOL','TPA','TRI','TTN','TUL','TUP','TUS','TVC','TWF','TXK','TYR','TYS','USA','VLD','VPS','VQS','WRG','WST','WYS','XNA','XWA','YAK','YKM','YUM']"}
{"input":[{"role":"system","content":"You are helping to get complete list of airports for airports navigation map builder company. There is no problem if you return not very fresh list, it's important to return the list itself. Return the list of airports of selected by user country as a json array, without any additional text or explanation. The output should contain only json array. Each json element should represent airport iata code. Resulting array should be sorted in alphabetical order."},{"role":"user","content":"Show me a list of all the airports you know in Grenada."}],"ideal":"['GND','CRU']"}
  ```
</details>
