### PR TITLE
Add convexhull test eval

### DIFF
--- a/evals/registry/data/convexhull-tests/samples.jsonl
+++ b/evals/registry/data/convexhull-tests/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d854a5e569a995a08c07c96fdb04b7db534f79a922aa2c72a6e5a9c552f77cc
+size 89078

--- a/evals/registry/evals/convexhull-tests.yaml
+++ b/evals/registry/evals/convexhull-tests.yaml
@@ -1,0 +1,7 @@
+convexhull-tests:
+  id: convexhull-tests.dev.v0
+  metrics: [accuracy]
+convexhull-tests.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: convexhull-tests/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
Finding convexhull

### Eval description

Find the convex hull by passing five 2D points as input.

### What makes this a useful eval?

I created this evaluation to assess the model's spatial understanding.
Through this evaluation, I expect the model to demonstrate its geometric understanding and use it to solve other problems.

GPT-3.5 is successful at solving the given examples about 10%, with 25 successful attempts out of 256 samples.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

To generate code for testing, I have written the following code using the scipy package:

```python
def make_data():
  from scipy.spatial import ConvexHull, convex_hull_plot_2d
  import numpy as np
  points = np.random.randint(0, 100, (5, 2))
  hull = ConvexHull(points)

  hullpoints = points[hull.vertices]
  hullpoints = hullpoints.tolist()
  hullpoints.sort()
  points = points.tolist()
  return str(points), str(hullpoints)
```

Additionally, in each test, I sampled 5 points and inserted the result of finding the convex hull from these points into the 'ideal' dataset.
Using the aforementioned code, I generated 256 sample data points.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{
    "input": [{
        "role": "system",
        "content": "You are a helpful calculator find convex hull in these points. Don't print out explanitions. Just print out sorted result. Sort the x-axis in ascending order, then the y-axis."
    }, {
        "role": "user",
        "content": "[[62, 50], [54, 48], [36, 22], [91, 78], [79, 3]]"
    }],
    "ideal": "[[36, 22], [54, 48], [79, 3], [91, 78]]"
} {
    "input": [{
        "role": "system",
        "content": "You are a helpful calculator find convex hull in these points. Don't print out explanitions. Just print out sorted result. Sort the x-axis in ascending order, then the y-axis."
    }, {
        "role": "user",
        "content": "[[80, 42], [58, 76], [16, 11], [25, 73], [59, 10]]"
    }],
    "ideal": "[[16, 11], [25, 73], [58, 76], [59, 10], [80, 42]]"
} {
    "input": [{
        "role": "system",
        "content": "You are a helpful calculator find convex hull in these points. Don't print out explanitions. Just print out sorted result. Sort the x-axis in ascending order, then the y-axis."
    }, {
        "role": "user",
        "content": "[[20, 35], [17, 20], [22, 84], [63, 9], [48, 15]]"
    }],
    "ideal": "[[17, 20], [22, 84], [63, 9]]"
} {
    "input": [{
        "role": "system",
        "content": "You are a helpful calculator find convex hull in these points. Don't print out explanitions. Just print out sorted result. Sort the x-axis in ascending order, then the y-axis."
    }, {
        "role": "user",
        "content": "[[31, 73], [58, 98], [20, 48], [53, 35], [99, 6]]"
    }],
    "ideal": "[[20, 48], [31, 73], [58, 98], [99, 6]]"
} {
    "input": [{
        "role": "system",
        "content": "You are a helpful calculator find convex hull in these points. Don't print out explanitions. Just print out sorted result. Sort the x-axis in ascending order, then the y-axis."
    }, {
        "role": "user",
        "content": "[[18, 61], [16, 35], [48, 4], [55, 32], [48, 9]]"
    }],
    "ideal": "[[16, 35], [18, 61], [48, 4], [55, 32]]"
} {
    "input": [{
        "role": "system",
        "content": "You are a helpful calculator find convex hull in these points. Don't print out explanitions. Just print out sorted result. Sort the x-axis in ascending order, then the y-axis."
    }, {
        "role": "user",
        "content": "[[1, 5], [26, 39], [45, 1], [4, 59], [37, 37]]"
    }],
    "ideal": "[[1, 5], [4, 59], [37, 37], [45, 1]]"
}
  ```
</details>
