### PR TITLE
[evals] simplify and extend modelgraded evals

### DIFF
--- a/evals/elsuite/modelgraded/classify.py
+++ b/evals/elsuite/modelgraded/classify.py
@@ -60,14 +60,10 @@ class ModelBasedClassify(evals.Eval):
                 multicomp_n, int
             ), f"multicomp_n={multicomp_n} must be an int or 'from_models'."
             self.multicomp_n = multicomp_n
+        if len(self.completion_fns) > 1:
+            assert self.multicomp_n == n_models
         self.multicomp_temperature = multicomp_temperature
         self.samples_renamings = samples_renamings or {}
-
-        # check if multiple models are specified
-        if len(self.completion_fns) > 1:
-            assert (
-                self.multicomp_n == n_models
-            ), f"multicomp_n={self.multicomp_n} must be equal to the number of models={len(self.completion_fns)} if multiple models are specified."
 
         if isinstance(self.completion_fn, DummyCompletionFn):
             self.eval_completion_fn = self.completion_fn
@@ -77,13 +73,13 @@ class ModelBasedClassify(evals.Eval):
             self.eval_completion_fn = OpenAIChatCompletionFn(model="gpt-3.5-turbo")
 
         spec_kwargs = {"multicomp_n": self.multicomp_n}
-        if modelgraded_spec_args:
-            spec_kwargs["args"] = modelgraded_spec_args
         self.mg: ModelGradedSpec = self.registry.get_modelgraded_spec(
             modelgraded_spec, **spec_kwargs
         )
         if eval_type:
             self.mg.append_answer_prompt(eval_type)
+        if modelgraded_spec_args:
+            self.mg.fill_args(**modelgraded_spec_args)
 
     def eval_sample(self, test_sample: dict, rng: Random) -> None:
         """Evaluate a single sample.

--- a/evals/elsuite/modelgraded/classify_utils.py
+++ b/evals/elsuite/modelgraded/classify_utils.py
@@ -1,7 +1,9 @@
+import logging
 import string
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Optional, Union
 
-from evals.elsuite.utils import format_necessary
+from evals.elsuite.utils import format_necessary, format_prompt
+from evals.prompt.base import OpenAICreateChatPrompt, is_chat_prompt
 
 INVALID_STR = "__invalid__"
 CHOICE_KEY = "choice"
@@ -36,8 +38,12 @@ def choice_to_str(choice_strings: Iterable[str]) -> str:
     return " or ".join(f'"{choice}"' for choice in choice_strings)
 
 
-def get_choice(text: str, eval_type: str, match_fn: Callable, choice_strings: Iterable[str]) -> str:
+def get_choice(
+    text: str, eval_type: str, match_fn: Union[str, Callable], choice_strings: Iterable[str]
+) -> str:
     """Clean the answer string to a choice string to one of choice_strings. Return '__invalid__.' if no match."""
+    if isinstance(match_fn, str):
+        match_fn = MATCH_FNS[match_fn]
     lines = text.strip().split("\n")
     if eval_type.startswith("cot_classify"):
         lines = lines[::-1]  # reverse lines
@@ -49,6 +55,7 @@ def get_choice(text: str, eval_type: str, match_fn: Callable, choice_strings: It
         for choice in choice_strings:
             if match_fn(line, choice):
                 return choice
+    logging.warn(f"Choices {choice_strings} not parsable for {eval_type}: {text}")
     return INVALID_STR
 
 
@@ -65,3 +72,57 @@ def concat_n_completions(completions: Iterable[str], template_i: str) -> str:
             n=len(completions),
         )
     return completion.strip()
+
+
+def format_classify(
+    prompt: OpenAICreateChatPrompt,
+    format_type: str = "in_message",
+    input_outputs: Optional[dict[str, str]] = None,
+    **format_kwargs: dict[str, OpenAICreateChatPrompt],
+) -> OpenAICreateChatPrompt:
+    """Return an OpenAICreateChatPrompt that can be passed PromptFn for modelgraded eval.
+
+    'in_message' returns: [
+        {
+            "role": "user",
+            "content": \"""
+                User: {input}
+                Assistant: {completion}
+
+                Was the assistant response helpful?
+                \""".strip(),
+        }
+    ]
+
+    'out_message' returns: [
+        {"role": "user", "content": "{input}"},
+        {"role": "assistant", "content": "{completion}"},
+        {"role": "user", "content": "Was the last assistant response helpful?"},
+    ]
+    """
+    input_outputs = input_outputs or {}
+    if format_type == "in_message":
+        return format_prompt(prompt, **format_kwargs)
+    elif format_type == "out_message":
+        assert len(input_outputs) == 1, "out_message only supports one input/output pair"
+        # extra input-output data, as it is treated specially
+        input_completions = {
+            k: (k, format_kwargs[k], v, format_kwargs[v]) for k, v in input_outputs.items()
+        }
+        format_kwargs = {
+            k: v
+            for k, v in format_kwargs.items()
+            if k not in input_outputs.values() and k not in input_outputs
+        }
+        convo = []
+        for input_key, input, completion_key, completion in input_completions.values():
+            del input_key, completion_key
+            assert isinstance(completion, str), f"completion must be str, not {type(completion)}"
+            if is_chat_prompt(input):
+                convo += input
+            else:
+                convo.append({"role": "user", "content": input})
+            convo.append({"role": "assistant", "content": completion})
+        return convo + format_prompt(prompt, **format_kwargs)
+    else:
+        raise ValueError(f"format_type must be 'in_message' or 'out_message', not {format_type}")

--- a/evals/elsuite/modelgraded/classify_utils.py
+++ b/evals/elsuite/modelgraded/classify_utils.py
@@ -1,4 +1,3 @@
-import itertools
 import string
 from typing import Callable, Iterable
 
@@ -66,25 +65,3 @@ def concat_n_completions(completions: Iterable[str], template_i: str) -> str:
             n=len(completions),
         )
     return completion.strip()
-
-
-def expand_args_dict(args_dict):
-    """Expand a dict of dicts, with namings.
-
-    args_dict = {
-        "a": {"a1": 1, "a2": 2},
-        "b": {"b1": 3, "b2": 4},
-    }
-    expand_args_dict(args_dict) = {
-        "a=a1:b=b1": {"a": ("a1", 1), "b": ("b1", 3)},
-        "a=a1:b=b2": {"a": ("a1", 1), "b": ("b2", 4)},
-    ...}
-    """
-    if not args_dict:
-        return {}
-    args_dict = {k: list(v.items()) for k, v in args_dict.items()}
-    keys = list(args_dict.keys())
-    values = list(args_dict.values())
-    new_values = [dict(zip(keys, v)) for v in itertools.product(*values)]
-    new_names = [":".join([f"{k}={v[0]}" for k, v in sorted(d.items())]) for d in new_values]
-    return dict(zip(new_names, new_values))

--- a/evals/registry/eval_sets/coqa-ex.yaml
+++ b/evals/registry/eval_sets/coqa-ex.yaml
@@ -2,5 +2,6 @@ coqa-ex:
   evals:
     - coqa-match
     - coqa-fact
-    - coqa-closedqa
     - coqa-closedqa-correct
+    - coqa-closedqa-relevance
+    - coqa-closedqa-conciseness

--- a/evals/registry/eval_sets/test-all.yaml
+++ b/evals/registry/eval_sets/test-all.yaml
@@ -7,8 +7,9 @@ test:
     - coqa-match
     - coqa-fact
     - coqa-fact-expl
-    - coqa-closedqa
     - coqa-closedqa-correct
+    - coqa-closedqa-relevance
+    - coqa-closedqa-conciseness
     - logic-fact
     - joke-fruits
     - joke-fruits-v2

--- a/evals/registry/evals/coqa-ex.yaml
+++ b/evals/registry/evals/coqa-ex.yaml
@@ -46,7 +46,7 @@ coqa-closedqa-relevance.dev.v0:
     samples_jsonl: coqa/samples.jsonl
     modelgraded_spec: closedqa
     modelgraded_spec_args:
-      crtieria: "relevance: Is the submission referring to a real quote from the text?"
+      criteria: "relevance: Is the submission referring to a real quote from the text?"
 
 coqa-closedqa-conciseness:
   id: coqa-closedqa-conciseness.dev.v0
@@ -57,4 +57,4 @@ coqa-closedqa-conciseness.dev.v0:
     samples_jsonl: coqa/samples.jsonl
     modelgraded_spec: closedqa
     modelgraded_spec_args:
-      crtieria: "conciseness: Is the answer concise and to the point?"
+      criteria: "conciseness: Is the answer concise and to the point?"

--- a/evals/registry/evals/coqa-ex.yaml
+++ b/evals/registry/evals/coqa-ex.yaml
@@ -26,16 +26,6 @@ coqa-fact-expl.dev.v0:
     eval_type: classify_cot
     modelgraded_spec: fact
 
-coqa-closedqa:
-  id: coqa-closedqa.dev.v0
-  metrics: [accuracy]
-coqa-closedqa.dev.v0:
-  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
-  args:
-    samples_jsonl: coqa/samples.jsonl
-    modelgraded_spec: closedqa
-
-# (same as above, but only evaluate criteria=correct)
 coqa-closedqa-correct:
   id: coqa-closedqa-correct.dev.v0
   metrics: [accuracy]
@@ -45,7 +35,26 @@ coqa-closedqa-correct.dev.v0:
     samples_jsonl: coqa/samples.jsonl
     modelgraded_spec: closedqa
     modelgraded_spec_args:
-      criteria:
-        correct: "correctness: Is the answer correct?"
+      criteria: "correctness: Is the answer correct?"
 
+coqa-closedqa-relevance:
+  id: coqa-closedqa-relevance.dev.v0
+  metrics: [accuracy]
+coqa-closedqa-relevance.dev.v0:
+  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
+  args:
+    samples_jsonl: coqa/samples.jsonl
+    modelgraded_spec: closedqa
+    modelgraded_spec_args:
+      crtieria: "relevance: Is the submission referring to a real quote from the text?"
 
+coqa-closedqa-conciseness:
+  id: coqa-closedqa-conciseness.dev.v0
+  metrics: [accuracy]
+coqa-closedqa-conciseness.dev.v0:
+  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
+  args:
+    samples_jsonl: coqa/samples.jsonl
+    modelgraded_spec: closedqa
+    modelgraded_spec_args:
+      crtieria: "conciseness: Is the answer concise and to the point?"

--- a/evals/registry/evals/test-modelgraded-battle.yaml
+++ b/evals/registry/evals/test-modelgraded-battle.yaml
@@ -9,7 +9,6 @@ joke-animals-vs-fruits.dev.v0:
     samples_jsonl: test_multiio/battles/joke_animals_vs_fruits.jsonl
     eval_type: cot_classify
     modelgraded_spec: battle
-    eval_completion_fn: gpt-3.5-turbo
 
 rap-people-vs-people:
   id: rap-people-vs-people.dev.v0
@@ -20,7 +19,6 @@ rap-people-vs-people.dev.v0:
     samples_jsonl: test_multiio/battles/rap_people_vs_people.jsonl
     eval_type: cot_classify
     modelgraded_spec: battle
-    eval_completion_fn: gpt-3.5-turbo
 
 rap-animals-vs-fruits:
   id: rap-animals-vs-fruits.dev.v0
@@ -31,7 +29,6 @@ rap-animals-vs-fruits.dev.v0:
     samples_jsonl: test_multiio/battles/rap_animals_vs_fruits.jsonl
     eval_type: cot_classify
     modelgraded_spec: battle
-    eval_completion_fn: gpt-3.5-turbo
 
 rap-people-vs-fruits:
   id: rap-people-vs-fruits.dev.v0
@@ -42,4 +39,3 @@ rap-people-vs-fruits.dev.v0:
     samples_jsonl: test_multiio/battles/rap_people_vs_fruits.jsonl
     eval_type: cot_classify
     modelgraded_spec: battle
-    eval_completion_fn: gpt-3.5-turbo

--- a/evals/registry/modelgraded/closedqa.yaml
+++ b/evals/registry/modelgraded/closedqa.yaml
@@ -18,10 +18,5 @@ closedqa:
     "Y": 1.0
     "N": 0.0
   choice_strings: 'YN'
-  args:
-    criteria:
-      relevance: "relevance: Is the submission referring to a real quote from the text?"
-      conciseness: "conciseness: Is the answer concise and to the point?"
-      correct: "correctness: Is the answer correct?"
   input_outputs:
     input: "completion"


### PR DESCRIPTION
- removed expand_args option in modelgraded_spec yaml, and only accept modelgraded_spec_args in eval yaml. only allow one args set per eval. This is to simplify codes and improve clarity. 
- refactored modelgraded eval codes to be more modular
- removed eval_completion_fn arg in ModelGradedClassify. make it implicit in completion_fns.