### PR TITLE
Eval to Assess GPT's Ability to Precisely Compose Conclusion Sections of Scientific Abstracts

### DIFF
--- a/evals/registry/data/abstract_conclusion/abstract_conclusion.jsonl
+++ b/evals/registry/data/abstract_conclusion/abstract_conclusion.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f2b5a0581d4a4cba7760783ccac665642b95cc99d5402d45ae6514c56f46c0
+size 46077

--- a/evals/registry/evals/abstract_conclusion.yaml
+++ b/evals/registry/evals/abstract_conclusion.yaml
@@ -1,0 +1,9 @@
+abstract_conclusion:
+  id: abstract_conclusion.test.v1
+  description: Test the model's ability to create the conclusion of an abstract based on the title, background, methods, and results of an abstract.
+  metrics:
+  - accuracy
+abstract_conclusion.test.v1:
+  args:
+    samples_jsonl: abstract_conclusion\abstract_conclusion.jsonl
+  class: evals.elsuite.translate:Translate


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
abstract_conclusion

### Eval description

Utilize the title, background, methods, and results derived from the abstract of scientific literature to generate a conclusion, and apply the Bleu score to assess the quality of the generated conclusion.

### What makes this a useful eval?

This assessment is advantageous in promoting the precise completion of conclusion segments in abstracts by GPT, leading to considerable time and effort savings for scientific authors. The data are sourced from recent high-impact publications in the New England Journal of Medicine. GPT-3.5 demonstrates suboptimal performance in this regard, with an accuracy of 0.105 and a SacreBLEU score of 20.2.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

jerrytdang@gmail.com

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [X] I have filled out all required fields in the evals PR form
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Can you complete this scientific abstract by writing a short 1-2 sentence conclusion?"}, {"role": "user", "content": "TITLE Genomic Diagnosis of Rare Pediatric Disease in the United Kingdom and Ireland. BACKGROUND Pediatric disorders include a range of highly penetrant, genetically heterogeneous conditions amenable to genomewide diagnostic approaches. Finding a molecular diagnosis is challenging but can have profound lifelong benefits. METHODS We conducted a large-scale sequencing study involving more than 13,500 families with probands with severe, probably monogenic, difficult-to-diagnose developmental disorders from 24 regional genetics services in the United Kingdom and Ireland. Standardized phenotypic data were collected, and exome sequencing and microarray analyses were performed to investigate novel genetic causes. We developed an iterative variant analysis pipeline and reported candidate variants to clinical teams for validation and diagnostic interpretation to inform communication with families. Multiple regression analyses were performed to evaluate factors affecting the probability of diagnosis. RESULTS A total of 13,449 probands were included in the analyses. On average, we reported 1.0 candidate variant per parent–offspring trio and 2.5 variants per singleton proband. With the use of clinical and computational approaches to variant classification, a diagnosis was made in approximately 41% of probands (5502 of 13,449), of whom 76% had a pathogenic de novo variant. Another 22% of probands (2997 of 13,449) had variants of uncertain significance in genes that were strongly linked to monogenic developmental disorders. Recruitment in a parent–offspring trio had the largest effect on the probability of diagnosis (odds ratio, 4.70; 95% confidence interval [CI], 4.16 to 5.31). Probands were less likely to receive a diagnosis if they were born extremely prematurely (i.e., 22 to 27 weeks’ gestation; odds ratio, 0.39; 95% CI, 0.22 to 0.68), had in utero exposure to antiepileptic medications (odds ratio, 0.44; 95% CI, 0.29 to 0.67), had mothers with diabetes (odds ratio, 0.52; 95% CI, 0.41 to 0.67), or were of African ancestry (odds ratio, 0.51; 95% CI, 0.31 to 0.78)."}], "ideal": "CONCLUSION Among probands with severe, probably monogenic, difficult-to-diagnose developmental disorders, multimodal analysis of genomewide data had good diagnostic power, even after previous attempts at diagnosis."}
{"input": [{"role": "system", "content": "Can you complete this scientific abstract by writing a short 1-2 sentence conclusion?"}, {"role": "user", "content": "TITLE Decompressive Craniectomy versus Craniotomy for Acute Subdural Hematoma. BACKGROUND Traumatic acute subdural hematomas frequently warrant surgical evacuation by means of a craniotomy (bone flap replaced) or decompressive craniectomy (bone flap not replaced). Craniectomy may prevent intracranial hypertension, but whether it is associated with better outcomes is unclear. METHODS We conducted a trial in which patients undergoing surgery for traumatic acute subdural hematoma were randomly assigned to undergo craniotomy or decompressive craniectomy. An inclusion criterion was a bone flap with an anteroposterior diameter of 11 cm or more. The primary outcome was the rating on the Extended Glasgow Outcome Scale (GOSE) (an 8-point scale, ranging from death to “upper good recovery” [no injury-related problems]) at 12 months. Secondary outcomes included the GOSE rating at 6 months and quality of life as assessed by the EuroQol Group 5-Dimension 5-Level questionnaire (EQ-5D-5L). RESULTS A total of 228 patients were assigned to the craniotomy group and 222 to the decompressive craniectomy group. The median diameter of the bone flap was 13 cm (interquartile range, 12 to 14) in both groups. The common odds ratio for the differences across GOSE ratings at 12 months was 0.85 (95% confidence interval, 0.60 to 1.18; P=0.32). Results were similar at 6 months. At 12 months, death had occurred in 30.2% of the patients in the craniotomy group and in 32.2% of those in the craniectomy group; a vegetative state occurred in 2.3% and 2.8%, respectively, and a lower or upper good recovery occurred in 25.6% and 19.9%. EQ-5D-5L scores were similar in the two groups at 12 months. Additional cranial surgery within 2 weeks after randomization was performed in 14.6% of the craniotomy group and in 6.9% of the craniectomy group. Wound complications occurred in 3.9% of the craniotomy group and in 12.2% of the craniectomy group."}], "ideal": "CONCLUSION Among patients with traumatic acute subdural hematoma who underwent craniotomy or decompressive craniectomy, disability and quality-of-life outcomes were similar with the two approaches. Additional surgery was performed in a higher proportion of the craniotomy group, but more wound complications occurred in the craniectomy group."}
{"input": [{"role": "system", "content": "Can you complete this scientific abstract by writing a short 1-2 sentence conclusion?"}, {"role": "user", "content": "TITLE Dostarlimab for Primary Advanced or Recurrent Endometrial Cancer. BACKGROUND Dostarlimab is an immune-checkpoint inhibitor that targets the programmed cell death 1 receptor. The combination of chemotherapy and immunotherapy may have synergistic effects in the treatment of endometrial cancer. METHODS We conducted a phase 3, global, double-blind, randomized, placebo-controlled trial. Eligible patients with primary advanced stage III or IV or first recurrent endometrial cancer were randomly assigned in a 1:1 ratio to receive either dostarlimab (500 mg) or placebo, plus carboplatin (area under the concentration–time curve, 5 mg per milliliter per minute) and paclitaxel (175 mg per square meter of body-surface area), every 3 weeks (six cycles), followed by dostarlimab (1000 mg) or placebo every 6 weeks for up to 3 years. The primary end points were progression-free survival as assessed by the investigator according to Response Evaluation Criteria in Solid Tumors (RECIST), version 1.1, and overall survival. Safety was also assessed. RESULTS Of the 494 patients who underwent randomization, 118 (23.9%) had mismatch repair–deficient (dMMR), microsatellite instability–high (MSI-H) tumors. In the dMMR–MSI-H population, estimated progression-free survival at 24 months was 61.4% (95% confidence interval [CI], 46.3 to 73.4) in the dostarlimab group and 15.7% (95% CI, 7.2 to 27.0) in the placebo group (hazard ratio for progression or death, 0.28; 95% CI, 0.16 to 0.50; P<0.001). In the overall population, progression-free survival at 24 months was 36.1% (95% CI, 29.3 to 42.9) in the dostarlimab group and 18.1% (95% CI, 13.0 to 23.9) in the placebo group (hazard ratio, 0.64; 95% CI, 0.51 to 0.80; P<0.001). Overall survival at 24 months was 71.3% (95% CI, 64.5 to 77.1) with dostarlimab and 56.0% (95% CI, 48.9 to 62.5) with placebo (hazard ratio for death, 0.64; 95% CI, 0.46 to 0.87). The most common adverse events that occurred or worsened during treatment were nausea (53.9% of the patients in the dostarlimab group and 45.9% of those in the placebo group), alopecia (53.5% and 50.0%), and fatigue (51.9% and 54.5%). Severe and serious adverse events were more frequent in the dostarlimab group than in the placebo group."}], "ideal": "CONCLUSION Dostarlimab plus carboplatin–paclitaxel significantly increased progression-free survival among patients with primary advanced or recurrent endometrial cancer, with a substantial benefit in the dMMR–MSI-H population."}
{"input": [{"role": "system", "content": "Can you complete this scientific abstract by writing a short 1-2 sentence conclusion?"}, {"role": "user", "content": "TITLE Pembrolizumab plus Chemotherapy in Advanced Endometrial Cancer. BACKGROUND Standard first-line chemotherapy for endometrial cancer is paclitaxel plus carboplatin. The benefit of adding pembrolizumab to chemotherapy remains unclear. METHODS In this double-blind, placebo-controlled, randomized, phase 3 trial, we assigned 816 patients with measurable disease (stage III or IVA) or stage IVB or recurrent endometrial cancer in a 1:1 ratio to receive pembrolizumab or placebo along with combination therapy with paclitaxel plus carboplatin. The administration of pembrolizumab or placebo was planned in 6 cycles every 3 weeks, followed by up to 14 maintenance cycles every 6 weeks. The patients were stratified into two cohorts according to whether they had mismatch repair–deficient (dMMR) or mismatch repair–proficient (pMMR) disease. Previous adjuvant chemotherapy was permitted if the treatment-free interval was at least 12 months. The primary outcome was progression-free survival in the two cohorts. Interim analyses were scheduled to be triggered after the occurrence of at least 84 events of death or progression in the dMMR cohort and at least 196 events in the pMMR cohort. RESULTS In the 12-month analysis, Kaplan–Meier estimates of progression-free survival in the dMMR cohort were 74% in the pembrolizumab group and 38% in the placebo group (hazard ratio for progression or death, 0.30; 95% confidence interval [CI], 0.19 to 0.48; P<0.001), a 70% difference in relative risk. In the pMMR cohort, median progression-free survival was 13.1 months with pembrolizumab and 8.7 months with placebo (hazard ratio, 0.54; 95% CI, 0.41 to 0.71; P<0.001). Adverse events were as expected for pembrolizumab and combination chemotherapy."}], "ideal": "CONCLUSION In patients with advanced or recurrent endometrial cancer, the addition of pembrolizumab to standard chemotherapy resulted in significantly longer progression-free survival than with chemotherapy alone."}
{"input": [{"role": "system", "content": "Can you complete this scientific abstract by writing a short 1-2 sentence conclusion?"}, {"role": "user", "content": "TITLE Hydrocortisone in Severe Community-Acquired Pneumonia. BACKGROUND Whether the antiinflammatory and immunomodulatory effects of glucocorticoids may decrease mortality among patients with severe community-acquired pneumonia is unclear. METHODS In this phase 3, multicenter, double-blind, randomized, controlled trial, we assigned adults who had been admitted to the intensive care unit (ICU) for severe community-acquired pneumonia to receive intravenous hydrocortisone (200 mg daily for either 4 or 8 days as determined by clinical improvement, followed by tapering for a total of 8 or 14 days) or to receive placebo. All the patients received standard therapy, including antibiotics and supportive care. The primary outcome was death at 28 days. RESULTS A total of 800 patients had undergone randomization when the trial was stopped after the second planned interim analysis. Data from 795 patients were analyzed. By day 28, death had occurred in 25 of 400 patients (6.2%; 95% confidence interval [CI], 3.9 to 8.6) in the hydrocortisone group and in 47 of 395 patients (11.9%; 95% CI, 8.7 to 15.1) in the placebo group (absolute difference, −5.6 percentage points; 95% CI, −9.6 to −1.7; P=0.006). Among the patients who were not undergoing mechanical ventilation at baseline, endotracheal intubation was performed in 40 of 222 (18.0%) in the hydrocortisone group and in 65 of 220 (29.5%) in the placebo group (hazard ratio, 0.59; 95% CI, 0.40 to 0.86). Among the patients who were not receiving vasopressors at baseline, such therapy was initiated by day 28 in 55 of 359 (15.3%) of the hydrocortisone group and in 86 of 344 (25.0%) in the placebo group (hazard ratio, 0.59; 95% CI, 0.43 to 0.82). The frequencies of hospital-acquired infections and gastrointestinal bleeding were similar in the two groups; patients in the hydrocortisone group received higher daily doses of insulin during the first week of treatment."}], "ideal": "CONCLUSION Among patients with severe community-acquired pneumonia being treated in the ICU, those who received hydrocortisone had a lower risk of death by day 28 than those who received placebo."}
  ```
</details>
