### PR TITLE
Invert permutations of symmetric groups S3, S4, S5

### DIFF
--- a/evals/registry/data/symmetric_group_inversion/samples.jsonl
+++ b/evals/registry/data/symmetric_group_inversion/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1813fad2efdd2c70f18f0bf201b904a8348ed5c7aa8e6d7c2c42890aabc6ffb2
+size 79968

--- a/evals/registry/evals/symmetric_group_inversion.yaml
+++ b/evals/registry/evals/symmetric_group_inversion.yaml
@@ -1,0 +1,9 @@
+symmetric_group_inversion:
+  id: symmetric_group_inversion.dev.v0
+  description: Test the model's ability to invert permutations of size 4 and 5
+  metrics: [accuracy]
+symmetric_group_inversion.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: symmetric_group_inversion/samples.jsonl
+


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
Invert permutations of symmetric groups S3, S4, S5

### Eval description

All the 6, 24 and 120 permutations are tested.
Each permutation is represented in a 2-line (non-cyclic) format to avoid any ambiguities and simplify checking. 
Example input:
1 2 3
2 3 1
Example output: 
1 2 3
3 1 2

### What makes this a useful eval?

Symmetric groups are rather simple and well-known algebraic objects. Reverting a permutation of size 3 in this format is easier than adding 2-digit numbers, say. Still gpt-3.5 gives an accuracy of 0.66 , even though it can actually correctly list all the 6 permutations with their inverses. gpt-4 seems to fail for some permutations of size 4 at least.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "\nYou will be given permutations from symmetric group S3. One permutation per input, two lines per input. \nReply ONLY with inverse permutations in the same format.\n\nExample input:\n1 2 3\n2 3 1\nExample output: \n1 2 3\n3 1 2\n\nExample input:\n1 2 3\n1 3 2\nExample output: \n1 2 3\n1 3 2\n\nExample input:\n1 2 3\n2 3 1\nExample output:\n1 2 3\n3 1 2\n"}, {"role": "user", "content": "1 2 3 \n2 1 3 "}], "ideal": "1 2 3\n2 1 3"}
{"input": [{"role": "system", "content": "\nYou will be given permutations from symmetric group S4. One permutation per input, two lines per input. \nReply ONLY with inverse permutations in the same format.\n\nExample input:\n1 2 3 4\n2 3 1 4\nExample output: \n1 2 3 4\n3 1 2 4\n\nExample input:\n1 2 3 4\n1 3 2 4\nExample output: \n1 2 3 4\n1 3 2 4\n\nExample input:\n1 2 3 4\n2 4 3 1\nExample output:\n1 2 3 4\n4 1 3 2\n"}, {"role": "user", "content": "1 2 3 4 \n4 1 3 2 "}], "ideal": "1 2 3 4\n2 4 3 1"}
{"input": [{"role": "system", "content": "\nYou will be given permutations from symmetric group S5. One permutation per input, two lines per input. \nReply ONLY with inverse permutations in the same format.\n\nExample input:\n1 2 3 4 5 \n2 3 1 4 5\nExample output: \n1 2 3 4 5\n3 1 2 4 5\n\nExample input:\n1 2 3 4 5\n1 3 2 4 5\nExample output: \n1 2 3 4 5\n1 3 2 4 5\n\nExample input:\n1 2 3 4 5\n2 4 3 5 1\nExample output:\n1 2 3 4 5\n5 1 3 2 4\n"}, {"role": "user", "content": "1 2 3 4 5 \n1 5 2 3 4 "}], "ideal": "1 2 3 4 5\n1 3 4 5 2"}
{"input": [{"role": "system", "content": "\nYou will be given permutations from symmetric group S5. One permutation per input, two lines per input. \nReply ONLY with inverse permutations in the same format.\n\nExample input:\n1 2 3 4 5 \n2 3 1 4 5\nExample output: \n1 2 3 4 5\n3 1 2 4 5\n\nExample input:\n1 2 3 4 5\n1 3 2 4 5\nExample output: \n1 2 3 4 5\n1 3 2 4 5\n\nExample input:\n1 2 3 4 5\n2 4 3 5 1\nExample output:\n1 2 3 4 5\n5 1 3 2 4\n"}, {"role": "user", "content": "1 2 3 4 5 \n1 5 2 4 3 "}], "ideal": "1 2 3 4 5\n1 3 5 4 2"}
{"input": [{"role": "system", "content": "\nYou will be given permutations from symmetric group S5. One permutation per input, two lines per input. \nReply ONLY with inverse permutations in the same format.\n\nExample input:\n1 2 3 4 5 \n2 3 1 4 5\nExample output: \n1 2 3 4 5\n3 1 2 4 5\n\nExample input:\n1 2 3 4 5\n1 3 2 4 5\nExample output: \n1 2 3 4 5\n1 3 2 4 5\n\nExample input:\n1 2 3 4 5\n2 4 3 5 1\nExample output:\n1 2 3 4 5\n5 1 3 2 4\n"}, {"role": "user", "content": "1 2 3 4 5 \n1 5 3 2 4 "}], "ideal": "1 2 3 4 5\n1 4 3 5 2"}

  ```
</details>
