### PR TITLE
[Evals] Japanese city name pronunciation

### DIFF
--- a/evals/registry/data/japanese_city_name_pronunciation/samples.jsonl
+++ b/evals/registry/data/japanese_city_name_pronunciation/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f13ad961153165fc4dab52594d2ae386366fb6e43daccf3488f06d38fafb1ece
+size 580373

--- a/evals/registry/data/japanese_city_name_pronunciation/samples.jsonl
+++ b/evals/registry/data/japanese_city_name_pronunciation/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f13ad961153165fc4dab52594d2ae386366fb6e43daccf3488f06d38fafb1ece
-size 580373
+oid sha256:c05ed7e4e2c5ca1781eb370dd5180c7deef483d609661cd1b30af9158062494b
+size 580035

--- a/evals/registry/evals/japanese_city_name_pronuciation.yaml
+++ b/evals/registry/evals/japanese_city_name_pronuciation.yaml
@@ -1,0 +1,9 @@
+japanese_city_name_pronunciation:
+  id: japanese_city_name_pronunciation.dev.v0
+  description: Test the model's ability to answer the correct pronunciation of Japanese cities in hiragana(phonetic characters of Japanese).
+  metrics: [accuracy]
+
+japanese_city_name_pronunciation.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: japanese_city_name_pronunciation/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
japanese_city_name_pronunciation

### Eval description

This eval tests the ability of the model to answer the pronunciation (hiragana) of Japanese city names.
* A list of Japanese city names can be found at https://www.e-stat.go.jp/municipalities/cities/areacode.
* In this eval, I call '市町村'( japanese administrative units) to  'city'.

Japanese has several sets of characters, including kanji, hiragana, and katakana. Kanji is ideograms, hiragana and katakana are phonograms.

Japanese documents generaly mix kanji, hiragana, and katakana. All words that use kanji can be rendered in hiragana, but this conversion is quite complex because there are many rules and exceptions. In particular, there are many exceptions for geographical names and family names.
This eval tests city names because they are commonly used geographical names. Furthermore, since they are administrative units, having each just a single corresponding hiragana expression is suitable for evaluation.

### What makes this a useful eval?

Improving the accuracy of kanji and hiragana conversion is important for several types of applications. For instance, city names are used to name various things, so conversion between kanji and hiragana (phonetic characters) is often required to understand the context. Therefore, improving the accuracy of recognition of city names in both kanji and hiragana can improve the accuracy of understanding context.

For example, improving geography-related applications such as car navigation is one such use case. The input is often done by voice, and if the model correctly recognizes the correspondence between kanji and hiragana (pronunciation), the input can be improved.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Answer the pronunciation of a Japanese city in hiragana. Answer just a word containing only hiragana that indicates the city's pronunciation. Do not output any other output at all. The city is located in '北海道'"}, {"role": "user", "content": "札幌市"}], "ideal": "さっぽろし"}
{"input": [{"role": "system", "content": "Answer the pronunciation of a Japanese city in hiragana. Answer just a word containing only hiragana that indicates the city's pronunciation. Do not output any other output at all. The city is located in '北海道'"}, {"role": "user", "content": "函館市"}], "ideal": "はこだてし"}
{"input": [{"role": "system", "content": "Answer the pronunciation of a Japanese city in hiragana. Answer just a word containing only hiragana that indicates the city's pronunciation. Do not output any other output at all. The city is located in '東京都'"}, {"role": "user", "content": "八王子市"}], "ideal": "はちおうじし"}
{"input": [{"role": "system", "content": "Answer the pronunciation of a Japanese city in hiragana. Answer just a word containing only hiragana that indicates the city's pronunciation. Do not output any other output at all. The city is located in '東京都'"}, {"role": "user", "content": "立川市"}], "ideal": "たちかわし"}
{"input": [{"role": "system", "content": "Answer the pronunciation of a Japanese city in hiragana. Answer just a word containing only hiragana that indicates the city's pronunciation. Do not output any other output at all. The city is located in '東京都'"}, {"role": "user", "content": "武蔵野市"}], "ideal": "むさしのし"}

  ```
</details>
