### PR TITLE
Eval: 100 samples for Count how many numbers are greater than X

### DIFF
--- a/evals/registry/data/count_numbers_greater_than_x/samples.jsonl
+++ b/evals/registry/data/count_numbers_greater_than_x/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d10fa7e11006711c18fdcd60808b19fd715e45e77ad8f9319e2d4eea7a1b604a
+size 26194

--- a/evals/registry/evals/count-numbers-greater-than-x.yaml
+++ b/evals/registry/evals/count-numbers-greater-than-x.yaml
@@ -1,0 +1,8 @@
+count-numbers-greater-than-x:
+  id: count-numbers-greater-than-x.v0
+  description: How many times does a number appear that is greater than X? Respond with your answer only.
+  metrics: [accuracy]
+count-numbers-greater-than-x.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: count_numbers_greater_than_x/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
count-numbers-greater-than-x

### Eval description
"How many times does a number appear that is greater than X? Respond with your answer only." Testing a models ability to select based on a condition and count based on selection; a mix of logic/reasoning and counting.

### What makes this a useful eval?
This eval chains two different difficult tasks for LLMs: logic and counting

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

Mixing logic and counting is very important for LLMs accross many tasks (e.g. data analysis, doing SQL like operations, etc.)


## Eval structure 🏗️

Your eval should
- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [X] I have filled out all required fields in the evals PR form
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input": [{"role": "system", "content": "How many times does a number appear that is greater than 2? Respond with your answer only, no words."}, {"role": "user", "content": "2, -1, 5, 5, 3, 2, 1, 3, 3, 3, 4, 3, 4, -1, -1, 1, 0, 4, -2, 0, -2, -1, 3, 4, 1, 0, 3, -1, -2, 5, 2, 4, 2, 4"}], "ideal": "16"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than 3? Respond with your answer only, no words."}, {"role": "user", "content": "-1, -2, 2, 1, -2, 0, 1, 0, 2, -2, 2, 1, -1, 0, 1, -2, 1, -1, -1, 1, 0, 0, 2, 2, 0, 1, 3, -1, -1, 2, 3, -2, 2, 1, 2, -1"}], "ideal": "0"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than -1? Respond with your answer only, no words."}, {"role": "user", "content": "0, -1, 0, 0, 1, 2, -1, -1, 2, 0, -1, 0, 2, 1, -1, 2, -1, 2, 1, 1, 0, -1, 1, 0, -1, -1, 2, 2, -1, 0, 2, 2, 0, 2, 1, 1, -1, 1, 0"}], "ideal": "28"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than -1? Respond with your answer only, no words."}, {"role": "user", "content": "-1, 0, 1, 1, 0, 1, -1, 1, 1, -2, -1, 0, 0, 0, -1, 0, 1, 0, 0, -1, 0, 0, -1, 1, -1, 0, -1, 1"}], "ideal": "19"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than 5? Respond with your answer only, no words."}, {"role": "user", "content": "0, 3, 0, 5, 3, 0, 2, 0, 2, 2, 5, 3"}], "ideal": "0"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than 4? Respond with your answer only, no words."}, {"role": "user", "content": "1, -1, 0, 1, 0, -3, 2, -1, -2, -1, 2, -1, -1, -1, -2, 0, 1, 4, 3, 3, 3, 0, -2, 2, 0, 3, -2, -1"}], "ideal": "0"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than 2? Respond with your answer only, no words."}, {"role": "user", "content": "0, 3, 2, 2, 2, 3, 2, 3, 0, -1, 0, 3, 2, 3, -1, -2, 3, 1, 0, 0, 2, -2, -1, 3, -2, 0, 3, 0, 3, 0, 3, -2, 1, 1, 3, -1, 3, 0, 0"}], "ideal": "12"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than -2? Respond with your answer only, no words."}, {"role": "user", "content": "0, 0, 0, 1, 0, 0, 0, 1, -3, -2, 1, -2, 1, -3, -2, 0, -1, 0, -1, 1, -3, -1, -1, 0, 1, -1, 1, -3, -2, -2, -1, 1, 1, -2, -2"}], "ideal": "24"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than 0? Respond with your answer only, no words."}, {"role": "user", "content": "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0"}], "ideal": "0"}
{"input": [{"role": "system", "content": "How many times does a number appear that is greater than -2? Respond with your answer only, no words."}, {"role": "user", "content": "0, -2, 1, 2, 2, -1, 4, -1, -2, -2, 4, -2"}], "ideal": "8"}
  ```
</details>
