### PR TITLE
Test GPT's ability to sort a list of names by last name

### DIFF
--- a/evals/registry/data/sort_last_name/sort_last_name.jsonl
+++ b/evals/registry/data/sort_last_name/sort_last_name.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:507eae9ed022e9b34eac63723066a8e3350f1b05e21062396d8d303a56065ac2
+size 18525

--- a/evals/registry/evals/sort_last_name.yaml
+++ b/evals/registry/evals/sort_last_name.yaml
@@ -1,0 +1,8 @@
+sort_last_name:
+  id: sort_last_name.s1.simple-v0
+  description: Test the model's ability to sort a list of full names by last name.
+  metrics: [accuracy]
+sort_last_name.s1.simple-v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: sort_last_name/sort_last_name.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
sort_last_name

### Eval description

This eval tests GPT's ability to sort a list of names by last name. This fails quite often on GPT-4 (tested on ChatGPT) and fails more frequently when the list of names is longer. Names were created using a name generator and the lists vary in length from 15 to 45 names.

### What makes this a useful eval?

Sorting a list of names is easily performed by people. This is useful for people who need to sort a list of names alphabetically and want to use GPT for that purpose (teachers, etc).

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

jerrytdang@gmail.com

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [X] I have filled out all required fields in the evals PR form
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Can you sort this list by last name and output in the same format? Only state the names and include no other text."}, {"role": "user", "content": "Nelson Jacobson, Fern Kim, Matthew Howard, Muhammed Hicks, Keith Mcmahon, Cole Mcgrath, Jemma Mueller, Beth Peterson, Zoya Pope, Elinor Sherman"}], "ideal": "Muhammed Hicks, Matthew Howard, Nelson Jacobson, Fern Kim, Cole Mcgrath, Keith Mcmahon, Jemma Mueller, Beth Peterson, Zoya Pope, Elinor Sherman"}
{"input": [{"role": "system", "content": "Can you sort this list by last name and output in the same format? Only state the names and include no other text."}, {"role": "user", "content": "Anas Woodward, Kain Frazier, Caspar Camacho, Lillie Nelson, Jada Hale, Lara Adkins, Agnes Pollard, Esme Rowland, Poppie Hilton, Kristian Smith, Imran Bush, Anais Skinner, Nadia Bates"}], "ideal": "Lara Adkins, Nadia Bates, Imran Bush, Caspar Camacho, Kain Frazier, Jada Hale, Poppie Hilton, Lillie Nelson, Agnes Pollard, Esme Rowland, Anais Skinner, Kristian Smith, Anas Woodward"}
{"input": [{"role": "system", "content": "Can you sort this list by last name and output in the same format? Only state the names and include no other text."}, {"role": "user", "content": "Montgomery Mccarty, Matthew Gross, Lucinda Bird, Muhammad Cordova, Zak Sawyer, Zohaib Sheppard, Anoushka Knox, Alissa Nguyen, Billie Wade, Jakob Joyce, Kenneth Russell, Rhea Ramsey, Robbie Benton, Miah Horn, Georgie Noble, Jason Foster, Dillon Deleon, Anne O'Ryan, Lyla Lozano, Kiran Pratt"}], "ideal": "Robbie Benton, Lucinda Bird, Muhammad Cordova, Dillon Deleon, Jason Foster, Matthew Gross, Miah Horn, Jakob Joyce, Anoushka Knox, Lyla Lozano,Montgomery Mccarty, Alissa Nguyen, Georgie Noble, Anne O'Ryan, Kiran Pratt, Rhea Ramsey, Kenneth Russell, Zak Sawyer, Zohaib Sheppard, Billie Wade"}
{"input": [{"role": "system", "content": "Can you sort this list by last name and output in the same format? Only state the names and include no other text."}, {"role": "user", "content": "Keyaan Lester, Dillon Harrell, Orlando Mcgrath, Sofia Prince, Jennifer Yates, Angel Townsend, Ibraheem Briggs, Kara Gregory, Sachin Ayala, Steffan Delacruz, Steven Hebert, Felix Stark, Riya Everett, Fern Howell, Bartosz Mendoza, Jaime Jimenez, Sylvia Foley, Isra Khan, Magnus Jacobs, Lilly-Rose Brennan, Tori Hahn, Caiden John, Brett Sosa, Alfie Bond, Rocco Flores"}], "ideal": "Sachin Ayala, Alfie Bond, Lilly-Rose Brennan, Ibraheem Briggs, Steffan Delacruz, Riya Everett, Rocco Flores, Sylvia Foley, Kara Gregory, Tori Hahn, Dillon Harrell, Steven Hebert, Fern Howell, Magnus Jacobs, Jaime Jimenez, Caiden John, Isra Khan, Keyaan Lester, Orlando Mcgrath, Bartosz Mendoza, Sofia Prince, Brett Sosa, Felix Stark, Angel Townsend, Jennifer Yates"}
{"input": [{"role": "system", "content": "Can you sort this list by last name and output in the same format? Only state the names and include no other text."}, {"role": "user", "content": "Valerie Avila, Joanna O'Brien, Alan Hanna, Fraser Hunter, Mariam Leach, Anoushka Rosario, Bethany Walsh, Harry Bray, Sulayman Butler, Damien Osborn, Brodie Green, Sonia Poole, Constance Downs, Cheryl Barker, Pablo Welsh, Keane Harrington, Sadia Hartman, Safaa Ramos, Jesse Jenkins, Fintan Frazier, Oisin Floyd, Yusra Fowler, Harvey Stanley, Billy Hogan, Milo Jennings, Denise White, Kyran Graham, Tamsin Stanton, Rishi Singleton, Arnold Jacobs"}], "ideal": "Valerie Avila, Cheryl Barker, Harry Bray, Sulayman Butler, Constance Downs, Oisin Floyd, Yusra Fowler, Fintan Frazier, Kyran Graham, Brodie Green, Alan Hanna, Keane Harrington, Sadia Hartman, Billy Hogan, Fraser Hunter, Arnold Jacobs, Jesse Jenkins, Milo Jennings, Mariam Leach, Joanna O'Brien, Damien Osborn, Sonia Poole, Safaa Ramos, Anoushka Rosario, Rishi Singleton, Harvey Stanley, Tamsin Stanton, Bethany Walsh, Pablo Welsh, Denise White"}
  ```
</details>
