### PR TITLE
[Eval] resolving ambiguous sentences

### DIFF
--- a/evals/registry/data/ambiguous-sentences/samples.jsonl
+++ b/evals/registry/data/ambiguous-sentences/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73b415da88ac7043f6a9fc1373d0bcf7171344bb79888903f8abe41b32635bc5
+size 14981

--- a/evals/registry/evals/ambiguous-sentences.yaml
+++ b/evals/registry/evals/ambiguous-sentences.yaml
@@ -1,0 +1,8 @@
+ambiguous-sentences:
+  id: ambiguous-sentences.dev.v0
+  description: test pair of sentences that differ in only one or two words and that contain an ambiguity that is resolved in opposite ways in the two sentences and requires the use of world knowledge and reasoning for its resolution.
+  metrics: [accuracy]
+ambiguous-sentences.dev.v0:
+  class: evals.elsuite.basic.fuzzy_match:FuzzyMatch
+  args:
+    samples_jsonl: ambiguous-sentences/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name
ambiguous sentences (`ambiguous-sentences`)

### Eval description
Resolves ambiguous questions of sentence pairs. Examples are taken from the Winograd Schema Challenge. The challenge involves a pair of sentences that differ in only one or two words, and the machine is required to determine the correct meaning of a pronoun in the sentence.

### What makes this a useful eval?
It is pointed out that GPT is still often thrown off by these types of questions, providing one answer upon the first request, and it often changes if the request is regenerated with a different result (0.7666666666666667).

I think it is worth including as an example to others viewing the repository who are trying to understand what kind of logic GPT tends to fail with, even if some of this data has already been trained on.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)
- Handpicked specific prompts from the challenge that I have noticed have mixed results consistently.
- Ensure that matching prompts are next to each other for easy comparison for humans in the .jsonl file.

## Eval structure 🏗️

Your eval should
- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [X] I have filled out all required fields in the evals PR form
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"The city councilmen refused the demonstrators a permit because they feared violence.. Who feared violence?"}],"ideal":"city councilmen"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"The city councilmen refused the demonstrators a permit because they advocated violence.. Who advocated violence?"}],"ideal":"demonstrators"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"The lawyer asked the witness a question, but he was reluctant to answer it.. Who was reluctant to answer the question?"}],"ideal":"witness"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"The lawyer asked the witness a question, but he was reluctant to repeat it.. Who was reluctant to repeat the question?"}],"ideal":"lawyer"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Tom threw his schoolbag down to Ray after he reached the top of the stairs.. Who reached the top of the stairs?"}],"ideal":"Tom"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Tom threw his schoolbag down to Ray after he reached the bottom of the stairs.. Who reached the bottom of the stairs?"}],"ideal":"Ray"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Although they ran at about the same speed, Sue beat Sally because she had such a good start. Who had a good start?"}],"ideal":"Sue"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Although they ran at about the same speed, Sue beat Sally because she had such a bad start. Who had a bad start?"}],"ideal":"Sally"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Frank was upset with Tom because the toaster he had bought from him didn't work.. Who had bought from the toaster?"}],"ideal":"Frank"}
{"input":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Frank was upset with Tom because the toaster he had sold to him didn't work.. Who had sold to the toaster?"}],"ideal":"Tom"}
  ```
</details>
