### PR TITLE
[evals] added pause/unpause to record.py

### DIFF
--- a/evals/elsuite/modelgraded/classify.py
+++ b/evals/elsuite/modelgraded/classify.py
@@ -7,19 +7,14 @@ from typing import Any, Optional, Union
 
 import evals
 import evals.record
-from evals import CompletionFn
 from evals.elsuite.modelgraded.classify_utils import classify, sample_and_concat_n_completions
 from evals.elsuite.utils import PromptFn, scrub_formatting_from_prompt
-from evals.registry import Registry
 
 
 class ModelBasedClassify(evals.Eval):
     def __init__(
         self,
-        completion_fns: list[CompletionFn],
-        samples_jsonl: str,
         modelgraded_spec: str,
-        registry: Registry,
         *args,
         modelgraded_spec_args: Optional[dict[str, dict[str, str]]] = None,
         sample_kwargs: Optional[dict[str, Any]] = None,
@@ -29,7 +24,7 @@ class ModelBasedClassify(evals.Eval):
         metaeval: bool = False,
         **kwargs,
     ):
-        super().__init__(completion_fns, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         # treat last completion_fn as eval_completion_fn
         self.eval_completion_fn = self.completion_fns[-1]
         if len(self.completion_fns) > 1:
@@ -39,9 +34,7 @@ class ModelBasedClassify(evals.Eval):
         self.sample_kwargs.update(sample_kwargs or {})
         self.eval_kwargs = {"max_tokens": 1024}
         self.eval_kwargs.update(eval_kwargs or {})
-        self.samples_jsonl = samples_jsonl
         self.metaeval = metaeval
-        self.registry = registry
         self.modelgraded_spec_args = modelgraded_spec_args or {}
         self.eval_type = eval_type
         if multicomp_n == "from_models":

--- a/evals/record.py
+++ b/evals/record.py
@@ -100,12 +100,14 @@ class RecorderBase:
     def pause(self):
         sample_id = self.current_sample_id()
         with self._event_lock:
-            self._paused_ids.append(sample_id)
+            if sample_id not in self._paused_ids:
+                self._paused_ids.append(sample_id)
 
     def unpause(self):
         sample_id = self.current_sample_id()
         with self._event_lock:
-            self._paused_ids.remove(sample_id)
+            if sample_id in self._paused_ids:
+                self._paused_ids.remove(sample_id)
 
     def is_paused(self):
         sample_id = self.current_sample_id()

--- a/evals/record.py
+++ b/evals/record.py
@@ -109,8 +109,9 @@ class RecorderBase:
             if sample_id in self._paused_ids:
                 self._paused_ids.remove(sample_id)
 
-    def is_paused(self):
-        sample_id = self.current_sample_id()
+    def is_paused(self, sample_id: str = None):
+        if sample_id is None:
+            sample_id = self.current_sample_id()
         with self._event_lock:
             return sample_id in self._paused_ids
 
@@ -158,7 +159,7 @@ class RecorderBase:
         if sample_id is None:
             raise ValueError("No sample_id set! Either pass it in or use as_default_recorder!")
 
-        if self.is_paused():
+        if self.is_paused(sample_id):
             return
         with self._event_lock:
             event = Event(

--- a/evals/record.py
+++ b/evals/record.py
@@ -153,13 +153,13 @@ class RecorderBase:
         self._flush_events_internal(events_to_write)
 
     def record_event(self, type, data=None, sample_id=None):
-        if self.is_paused():
-            return
         if sample_id is None:
             sample_id = self.current_sample_id()
         if sample_id is None:
             raise ValueError("No sample_id set! Either pass it in or use as_default_recorder!")
 
+        if self.is_paused():
+            return
         with self._event_lock:
             event = Event(
                 run_id=self.run_spec.run_id,


### PR DESCRIPTION
- this allows more flexibly controlling when PromptFn etc records logs or not

```
with recorder.as_default_recorder():
  evals.record.pause() 
  # ... any record_event() is skipped
  evals.record.unpause()
```