### PR TITLE
add eval of japanese_populer_video_game_title_and_the_publisher

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.8.0
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
     hooks:
-      - id: black
-        args: [--line-length=100, --exclude=""]
-
-  # this is not technically always safe but usually is
-  # use comments `# isort: off` and `# isort: on` to disable/re-enable isort
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: [--line-length=100, --profile=black]
-
-  # this is slightly dangerous because python imports have side effects
-  # and this tool removes unused imports, which may be providing
-  # necessary side effects for the code to run
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v1.6.1
-    hooks:
-      - id: autoflake
-        args:
-          - "--in-place"
-          - "--expand-star-imports"
-          - "--remove-duplicate-keys"
-          - "--remove-unused-variables"
-          - "--remove-all-unused-imports"
-        exclude: "evals/__init__.py"
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/evals/registry/data/japanese_populer_video_game_title_and_the_publisher/samples.jsonl
+++ b/evals/registry/data/japanese_populer_video_game_title_and_the_publisher/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae4b7c8c92215d101ce7cfcee5e1c6060fabf4e2074fd3b2eaf9bf0499e512a4
+size 16426

--- a/evals/registry/evals/japanese_populer_video_game_title_and_the_publisher.yaml
+++ b/evals/registry/evals/japanese_populer_video_game_title_and_the_publisher.yaml
@@ -1,0 +1,9 @@
+japanese_populer_video_game_title_and_the_publisher:
+  id: japanese_populer_video_game_title_and_the_publisher.val.v0
+  description: Test the model's ability to identify game publisher published popular japanese video games.
+  metrics: [accuracy]
+
+japanese_populer_video_game_title_and_the_publisher.val.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: japanese_populer_video_game_title_and_the_publisher/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

## Eval details 📑
### Eval name

japanese_populer_video_game_title_and_the_publisher

### Eval description

Test the model's ability to identify game publisher published popular japanese video games.

### What makes this a useful eval?

This is to correctly identify prominent Japanese video game titles and their release sources. Since it is expected that many well-known Japanese video game titles will be issued as queries to the GPT, being able to correctly answer them contributes to the reliability of the GPT.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> The top 100 titles from the "Video Game Roundup," a TV program aired in Japan in 2021, are included. For series titles, the name of the series is given. This allows GPT to increase the accuracy of its predictions of their release sources.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input": [{"role": "system", "content": "あなたは日本の著名なゲームタイトルの発売元を回答します"}, {"role": "user", "content": "スーパーマリオブラザーズ"}], "ideal": "任天堂"}
{"input": [{"role": "system", "content": "あなたは日本の著名なゲームタイトルの発売元を回答します"}, {"role": "user", "content": "ゼルダの伝説"}], "ideal": "任天堂"}
{"input": [{"role": "system", "content": "あなたは日本の著名なゲームタイトルの発売元を回答します"}, {"role": "user", "content": "星のカービィ"}], "ideal": "任天堂"}
{"input": [{"role": "system", "content": "あなたは日本の著名なゲームタイトルの発売元を回答します"}, {"role": "user", "content": "MOTHER"}], "ideal": "任天堂"}
{"input": [{"role": "system", "content": "あなたは日本の著名なゲームタイトルの発売元を回答します"}, {"role": "user", "content": "ゼノブレイド"}], "ideal": "任天堂"}
{"input": [{"role": "system", "content": "あなたは日本の著名なゲームタイトルの発売元を回答します"}, {"role": "user", "content": "ファイアーエムブレム"}], "ideal": "任天堂"}
{"input": [{"role": "system", "content": "あなたは日本の著名なゲームタイトルの発売元を回答します"}, {"role": "user", "content": "ポケットモンスター"}], "ideal": "任天堂"}
  ```
</details>
