### PR TITLE
[evals] Bidirectional conversion ISO 8601 <-> Chinese lunar calendar

### DIFF
--- a/evals/registry/data/lunar_calendar/iso_to_lunar_calendar.jsonl
+++ b/evals/registry/data/lunar_calendar/iso_to_lunar_calendar.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e1faca57aa6dcb01fcac7c057378e09c5c86e76eed1abc1c2d79d200b7f4fb4
+size 13200

--- a/evals/registry/data/lunar_calendar/lunar_calendar_to_iso.jsonl
+++ b/evals/registry/data/lunar_calendar/lunar_calendar_to_iso.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2521c05b6729466a4ff847ebe4ae0ebd3869ef66637fdab04707f7cf466ead73
+size 9990

--- a/evals/registry/evals/lunar-calendar.yaml
+++ b/evals/registry/evals/lunar-calendar.yaml
@@ -1,0 +1,23 @@
+iso-to-lunar-calendar:
+  id: iso-to-lunar-calendar.dev.v0
+  description: |-
+    Test the model's ability to convert dates from ISO 8601 format into the Chinese lunar calendar.
+
+    All dates are in the future as of 2023-05-04.
+  metrics: [accuracy]
+iso-to-lunar-calendar.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: lunar_calendar/iso_to_lunar_calendar.jsonl
+
+lunar-calendar-to-iso:
+  id: lunar-calendar-to-iso.dev.v0
+  description: |-
+    Test the model's ability to convert dates from the Chinese lunar calendar into ISO 8601 format, with a target Gregorian-calendar year given as a hint (the lunar calendar operates on a 60-year cycle, so this eliminates any ambiguity).
+
+    All dates are in the future as of 2023-05-04.
+  metrics: [accuracy]
+lunar-calendar-to-iso.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: lunar_calendar/lunar_calendar_to_iso.jsonl


### PR DESCRIPTION
<details>
<summary>Boilerplate</summary>

# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**
</details>


## Eval details 📑
### Eval name

Lunar Calendar

### Eval description

* Test the model's ability to convert dates from ISO 8601 format into the Chinese lunar calendar.
* Test the model's ability to convert dates from the Chinese lunar calendar into ISO 8601 format, with a target Gregorian-calendar year given as a hint (the lunar calendar operates on a 60-year cycle, so this eliminates any ambiguity).

All dates are in the future as of 2023-05-04.

### What makes this a useful eval?

The lunar calendar is still widely used for certain purposes in the Chinese-speaking world and beyond, for cases such as celebrating birthdays and calculating where traditional holidays fall. As a result, lunar-calendar dates often occur in natural-language Chinese text with subject matter from relevant domains.

GPT3.5 performs extremely poorly at date conversions of this type, especially ones that lie outside the temporal range of its training data:
* `iso-to-lunar-calendar` gives an accuracy of 0.0 with `gpt-3.5-turbo`
* `lunar-calendar-to-iso` gives an accuracy of 0.03... with `gpt-3.5-turbo`

My suspicion is that GPT4 won't perform significantly better, though I don't have access to test right now.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

Evaluates ability to perform complex reasoning that can be algorithmically expressed about semi-structured data that is likely to occur in natural-language text.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields in the evals PR form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
<summary>View evals in JSON</summary>

### `lunar_calendar_to_iso.jsonl`

```jsonl
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2026. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "丙午年 正月 十一" }], "ideal": "2026-02-27"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2028. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "戊申年 六月 初九" }], "ideal": "2028-07-30"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2030. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "庚戌年 正月 十七" }], "ideal": "2030-02-19"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2031. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "辛亥年 三月 初七" }], "ideal": "2031-03-29"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2034. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "甲寅年 二月 初十" }], "ideal": "2034-03-29"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2035. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "乙卯年 七月 廿八" }], "ideal": "2035-08-31"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2036. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "丙辰年 四月 初一" }], "ideal": "2036-04-26"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2037. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "丁巳年 八月 初九" }], "ideal": "2037-09-18"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2039. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "己未年 七月 廿一" }], "ideal": "2039-09-09"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2041. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "辛酉年 七月 廿三" }], "ideal": "2041-08-19"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2043. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "癸亥年 六月 初九" }], "ideal": "2043-07-15"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2046. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "丙寅年 三月 廿五" }], "ideal": "2046-04-30"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2047. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "丙寅年 正月 初六" }], "ideal": "2047-01-31"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2049. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "己巳年 五月 十七" }], "ideal": "2049-06-16"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2052. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "辛未年 腊月 十七" }], "ideal": "2052-01-18"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2053. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "癸酉年 五月 初八" }], "ideal": "2053-06-23"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2053. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "癸酉年 八月 初三" }], "ideal": "2053-09-14"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2053. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "癸酉年 九月 十三" }], "ideal": "2053-10-24"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2054. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "甲戌年 腊月 廿八" }], "ideal": "2054-02-05"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2055. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "乙亥年 十月 廿三" }], "ideal": "2055-12-11"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2057. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "丁丑年 七月 廿八" }], "ideal": "2057-08-27"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2058. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "戊寅年 八月 初三" }], "ideal": "2058-09-20"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2059. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "己卯年 冬月 廿五" }], "ideal": "2059-12-29"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2062. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "壬午年 九月 初五" }], "ideal": "2062-10-07"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2065. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "乙酉年 二月 廿一" }], "ideal": "2065-03-27"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2068. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "戊子年 二月 廿七" }], "ideal": "2068-03-30"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2070. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "庚寅年 六月 十二" }], "ideal": "2070-07-19"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2072. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "壬辰年 三月 初六" }], "ideal": "2072-04-23"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2073. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "癸巳年 五月 初八" }], "ideal": "2073-06-13"}
{"input": [{"role": "system", "content": "Convert the following dates from the Chinese lunar calendar into ISO 8601 format. The answer falls within the Gregorian calendar year 2074. Include only the ISO date in your answer, without any explanation."}, {"role": "user", "content": "甲午年 九月 十七" }], "ideal": "2074-11-05"}
```

### `iso_to_lunar_calendar.jsonl`

```jsonl
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2026-02-27"}], "ideal": "丙午年 正月 十一"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2028-07-30"}], "ideal": "戊申年 六月 初九"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2030-02-19"}], "ideal": "庚戌年 正月 十七"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2031-03-29"}], "ideal": "辛亥年 三月 初七"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2034-03-29"}], "ideal": "甲寅年 二月 初十"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2035-08-31"}], "ideal": "乙卯年 七月 廿八"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2036-04-26"}], "ideal": "丙辰年 四月 初一"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2037-09-18"}], "ideal": "丁巳年 八月 初九"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2039-09-09"}], "ideal": "己未年 七月 廿一"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2041-08-19"}], "ideal": "辛酉年 七月 廿三"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2043-07-15"}], "ideal": "癸亥年 六月 初九"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2046-04-30"}], "ideal": "丙寅年 三月 廿五"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2047-01-31"}], "ideal": "丙寅年 正月 初六"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2049-06-16"}], "ideal": "己巳年 五月 十七"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2052-01-18"}], "ideal": "辛未年 腊月 十七"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2053-06-23"}], "ideal": "癸酉年 五月 初八"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2053-09-14"}], "ideal": "癸酉年 八月 初三"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2053-10-24"}], "ideal": "癸酉年 九月 十三"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2054-02-05"}], "ideal": "甲戌年 腊月 廿八"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2055-12-11"}], "ideal": "乙亥年 十月 廿三"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2057-08-27"}], "ideal": "丁丑年 七月 廿八"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2058-09-20"}], "ideal": "戊寅年 八月 初三"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2059-12-29"}], "ideal": "己卯年 冬月 廿五"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2062-10-07"}], "ideal": "壬午年 九月 初五"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2065-03-27"}], "ideal": "乙酉年 二月 廿一"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2068-03-30"}], "ideal": "戊子年 二月 廿七"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2070-07-19"}], "ideal": "庚寅年 六月 十二"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2072-04-23"}], "ideal": "壬辰年 三月 初六"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2073-06-13"}], "ideal": "癸巳年 五月 初八"}
{"input": [{"role": "system", "content": "Convert the following dates from ISO 8601 into the Chinese lunar calendar. The answer should consist of the lunar-calendar year, the lunar-calendar month, and the lunar-calendar day, all in Chinese, and each separated by a single space. Include only the lunar-calendar date in your answer, without any explanation."}, {"role": "user", "content": "2074-11-05"}], "ideal": "甲午年 九月 十七"}
```
</details>
