### PR TITLE
docs: Clarify that custom code evals are not accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To get set up with evals, follow the [setup instructions below](README.md#Setup)
 
 #### Writing evals
 
-**Important: Please note that we are currenlty not accepting Evals with custom code, with the exception of modelgraded evals with custom code.**
+**Important: Please note that we are currently not accepting Evals with custom code!** While we ask you to not submit such evals at the moment, you can still submit modelgraded evals with custom modelgraded YAML files.
 
 - Walk through the process for building an eval: [build-eval.md](docs/build-eval.md)
 - See an example of implementing custom eval logic: [custom-eval.md](docs/custom-eval.md).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ To get set up with evals, follow the [setup instructions below](README.md#Setup)
 - Familiarize yourself with the existing eval templates: [eval-templates.md](docs/eval-templates.md).
 
 #### Writing evals
+
+**Important: Please note that we are currenlty not accepting Evals with custom code, with the exception of modelgraded evals with custom code.**
+
 - Walk through the process for building an eval: [build-eval.md](docs/build-eval.md)
 - See an example of implementing custom eval logic: [custom-eval.md](docs/custom-eval.md).
 

--- a/docs/build-eval.md
+++ b/docs/build-eval.md
@@ -1,6 +1,6 @@
 # Building an eval
 
-**Important: Please note that we are currenlty not accepting Evals with custom code, with the exception of modelgraded evals with custom code.**
+**Important: Please note that we are currently not accepting Evals with custom code!** While we ask you to not submit such evals at the moment, you can still submit modelgraded evals with custom modelgraded YAML files.
 
 This document walks through the end-to-end process for building an eval, which is a dataset and a choice of eval class. The `examples` folder contains Jupyter notebooks that follow the steps below to build several academic evals, thus helping to illustrate the overall process.
 

--- a/docs/build-eval.md
+++ b/docs/build-eval.md
@@ -1,5 +1,7 @@
 # Building an eval
 
+**Important: Please note that we are currenlty not accepting Evals with custom code, with the exception of modelgraded evals with custom code.**
+
 This document walks through the end-to-end process for building an eval, which is a dataset and a choice of eval class. The `examples` folder contains Jupyter notebooks that follow the steps below to build several academic evals, thus helping to illustrate the overall process.
 
 The steps in this process are building your dataset, registering a new eval with your dataset, and running your eval. Crucially, we assume that you are using an [existing eval template](eval-templates.md) out of the box (if that's not the case, see [this example of building a custom eval](custom-eval.md)). If you are interested in contributing your eval publicly, we also include some criteria at the bottom for what we think makes an interesting eval.

--- a/docs/custom-eval.md
+++ b/docs/custom-eval.md
@@ -1,5 +1,7 @@
 # How to add a custom eval
 
+**Important: Please note that we are currenlty not accepting Evals with custom code, with the exception of modelgraded evals with custom code.**
+
 This tutorial will walk you through a simple example of writing and adding a custom eval. The example eval will test the model's ability to do basic arithmetic. We will assume that you have followed the setup instructions in the [README](../README.md) and gone through the other docs for how to run and build evals.
 
 When writing your own evals, the primary files of interest are:

--- a/docs/custom-eval.md
+++ b/docs/custom-eval.md
@@ -1,6 +1,6 @@
 # How to add a custom eval
 
-**Important: Please note that we are currenlty not accepting Evals with custom code, with the exception of modelgraded evals with custom code.**
+**Important: Please note that we are currently not accepting Evals with custom code!** While we ask you to not submit such evals at the moment, you can still submit modelgraded evals with custom modelgraded YAML files.
 
 This tutorial will walk you through a simple example of writing and adding a custom eval. The example eval will test the model's ability to do basic arithmetic. We will assume that you have followed the setup instructions in the [README](../README.md) and gone through the other docs for how to run and build evals.
 


### PR DESCRIPTION
## Description

This PR provides a clear info statement, reg. the fact that custom code evals are currently not accepted. 