### PR TITLE
Add eval: rhetorical-devices

### DIFF
--- a/evals/registry/data/rhetorical_devices/samples.jsonl
+++ b/evals/registry/data/rhetorical_devices/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c273f828764362c037b6b9a192a7a0593bebd73ed10f601d79c8dde1a7c47e67
+size 32303

--- a/evals/registry/data/rhetorical_devices/samples.jsonl
+++ b/evals/registry/data/rhetorical_devices/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c273f828764362c037b6b9a192a7a0593bebd73ed10f601d79c8dde1a7c47e67
-size 32303
+oid sha256:a6deba82304abbb68cf70ddfa683be52e8adbbc9facf5d36fad1fb63e6c093ac
+size 33890

--- a/evals/registry/evals/rhetorical-devices.yaml
+++ b/evals/registry/evals/rhetorical-devices.yaml
@@ -3,6 +3,6 @@ rhetorical-devices:
   description: Evaluate model's understanding of rhetorical device usage in sentences
   metrics: [accuracy]
 rhetorical-devices.dev.v0:
-  class: evals.elsuite.basic.match:Match
+  class: evals.elsuite.basic.includes:Includes
   args:
     samples_jsonl: rhetorical_devices/samples.jsonl

--- a/evals/registry/evals/rhetorical-devices.yaml
+++ b/evals/registry/evals/rhetorical-devices.yaml
@@ -1,0 +1,8 @@
+rhetorical-devices:
+  id: rhetorical-devices.dev.v0
+  description: Evaluate model's understanding of rhetorical device usage in sentences
+  metrics: [accuracy]
+rhetorical-devices.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: rhetorical_devices/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, pelase note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑
### Eval name
rhetorical-devices

### Eval description

Evaluates model's ability to select the most specific rhetorical modification of a sentence from a multiple choice with a large number of nuanced rhetorical devices.

### What makes this a useful eval?

Useful for using LLMs to write novels and generate consistent/parametric authorial tone.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content":"Which of the following rhetorical devices was added to the original sentence? Choose the most specific of the following (a) Alliteration, (b) Assonance, (c) Consonance, (d) Cacophony, (e) Onomatopoeia, (f) Anadiplosis, (g) Conduplicatio, (h) Anaphora, (i) Epistrophe, (j) Symploce, (k) Epanalepsis, (l) Epizeuxis, (m) Antanaclasis, (n) Diacope, (o) Antithesis, (p) Antimetabole, (q) Chiasmus, (r) Asyndeton, (s) Polysyndeton, (t) Catacosmesis, (u) Oxymoron, (v) Zeugma"}, {"role": "user", "content": "ORIGINAL She likes to listen to the winds. MODIFIED She swoons at such sweet gales. Answer in the format (x) Rhetorical"}], "ideal": "(a) Alliteration"}
{"input": [{"role": "system", "content":"Which of the following rhetorical devices was added to the original sentence? Choose the most specific of the following (a) Alliteration, (b) Assonance, (c) Consonance, (d) Cacophony, (e) Onomatopoeia, (f) Anadiplosis, (g) Conduplicatio, (h) Anaphora, (i) Epistrophe, (j) Symploce, (k) Epanalepsis, (l) Epizeuxis, (m) Antanaclasis, (n) Diacope, (o) Antithesis, (p) Antimetabole, (q) Chiasmus, (r) Asyndeton, (s) Polysyndeton, (t) Catacosmesis, (u) Oxymoron, (v) Zeugma"}, {"role": "user", "content": "ORIGINAL The rock was very large. MODIFIED The rock was remarkably raised. Answer in the format (x) Rhetorical"}], "ideal": "(a) Alliteration"}
{"input": [{"role": "system", "content":"Which of the following rhetorical devices was added to the original sentence? Choose the most specific of the following (a) Alliteration, (b) Assonance, (c) Consonance, (d) Cacophony, (e) Onomatopoeia, (f) Anadiplosis, (g) Conduplicatio, (h) Anaphora, (i) Epistrophe, (j) Symploce, (k) Epanalepsis, (l) Epizeuxis, (m) Antanaclasis, (n) Diacope, (o) Antithesis, (p) Antimetabole, (q) Chiasmus, (r) Asyndeton, (s) Polysyndeton, (t) Catacosmesis, (u) Oxymoron, (v) Zeugma"}, {"role": "user", "content": "ORIGINAL Visionary dreams elevate me at night. MODIFIED Visionary reminitions elevate self resting in lightlessness. Answer in the format (x) Rhetorical"}], "ideal": "(b) Assonance"}
{"input": [{"role": "system", "content":"Which of the following rhetorical devices was added to the original sentence? Choose the most specific of the following (a) Alliteration, (b) Assonance, (c) Consonance, (d) Cacophony, (e) Onomatopoeia, (f) Anadiplosis, (g) Conduplicatio, (h) Anaphora, (i) Epistrophe, (j) Symploce, (k) Epanalepsis, (l) Epizeuxis, (m) Antanaclasis, (n) Diacope, (o) Antithesis, (p) Antimetabole, (q) Chiasmus, (r) Asyndeton, (s) Polysyndeton, (t) Catacosmesis, (u) Oxymoron, (v) Zeugma"}, {"role": "user", "content": "ORIGINAL Once, I thought I had lost her pet. MODIFIED Once, dunce — thought I lost Juliet's pet. Answer in the format (x) Rhetorical"}], "ideal": "(b) Assonance"}
{"input": [{"role": "system", "content":"Which of the following rhetorical devices was added to the original sentence? Choose the most specific of the following (a) Alliteration, (b) Assonance, (c) Consonance, (d) Cacophony, (e) Onomatopoeia, (f) Anadiplosis, (g) Conduplicatio, (h) Anaphora, (i) Epistrophe, (j) Symploce, (k) Epanalepsis, (l) Epizeuxis, (m) Antanaclasis, (n) Diacope, (o) Antithesis, (p) Antimetabole, (q) Chiasmus, (r) Asyndeton, (s) Polysyndeton, (t) Catacosmesis, (u) Oxymoron, (v) Zeugma"}, {"role": "user", "content": "ORIGINAL Do you want to understand research on artificial general intelligence? MODIFIED Don't you want to investigate artifacts of artificial general intelligence? Answer in the format (x) Rhetorical"}], "ideal": "(c) Consonance"}
  ```
</details>
