### PR TITLE
Add missing dependency LangChain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "sacrebleu",
     "matplotlib",
     "setuptools_scm",
+    "langchain"
 ]
 
 [project.scripts]


### PR DESCRIPTION
It is being used in `evals/completion_fns/langchain_llm.py`;
however, `langchain` was not declared in the dependencies list.

This PR fixed it.