### PR TITLE
Types: Enable type check in `scripts`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -29,4 +29,8 @@ disallow_untyped_defs=True
 ignore_errors=False
 disallow_untyped_defs=True
 
+[mypy-scripts.*]
+ignore_errors=False
+disallow_untyped_defs=True
+
 ; TODO: Add the other modules here

--- a/scripts/battle_generator.py
+++ b/scripts/battle_generator.py
@@ -7,7 +7,7 @@ import string
 REGISTRY_PATH = os.path.join(os.path.dirname(__file__), "../evals/registry")
 
 
-def format(template: str, **kwargs: dict[str, str]) -> str:
+def format(template: str, **kwargs: str) -> str:
     """Format a template string with kwargs."""
     keys = [k[1] for k in string.Formatter().parse(template) if k[1]]
     assert all(k in kwargs for k in keys), f"Required: {keys}, got: {sorted(kwargs)}"

--- a/scripts/modelgraded_generator.py
+++ b/scripts/modelgraded_generator.py
@@ -7,7 +7,7 @@ import string
 REGISTRY_PATH = os.path.join(os.path.dirname(__file__), "../evals/registry")
 
 
-def format(template: str, **kwargs: dict[str, str]) -> str:
+def format(template: str, **kwargs: str) -> str:
     """Format a template string with kwargs."""
     keys = [k[1] for k in string.Formatter().parse(template) if k[1]]
     assert all(k in kwargs for k in keys), f"Required: {keys}, got: {sorted(kwargs)}"
@@ -206,8 +206,8 @@ for prompt_name, subject in unlabeled_target_sets:
 
 
 yaml_file = f"{REGISTRY_PATH}/evals/test-modelgraded-generated.yaml"
-with open(yaml_file, "w") as f:
-    f.write(yaml_str)
+with open(yaml_file, "w") as yf:
+    yf.write(yaml_str)
 print(f"wrote {yaml_file}")
 for e in evals:
     print(e)

--- a/scripts/pattern_identification_generator.py
+++ b/scripts/pattern_identification_generator.py
@@ -4,32 +4,44 @@
 
 import json
 import random
+from typing import Literal
+
 random.seed(42)
 
 SYMBOLS = list("abcdefghijklmnopqrstuvwxyz")
 DELIMETER = "->"
-INSTRUCTION = "Figure out the pattern in the below examples, and then answer with just \"foo\" or \"bar\"."
+INSTRUCTION = (
+    'Figure out the pattern in the below examples, and then answer with just "foo" or "bar".'
+)
 TASK_NAME = "pattern_identification"
 
 
-def generate_example():
+def generate_example() -> tuple[str, list[str], Literal["foo", "bar"]]:
     num_symbols = int(len(SYMBOLS) / 2)
     target_symbol = random.choice(SYMBOLS)
     symbol_list = random.sample(SYMBOLS, num_symbols)
-    target = "foo" if target_symbol in symbol_list else "bar"
+    target: Literal["foo", "bar"] = "foo" if target_symbol in symbol_list else "bar"
     return (target_symbol, symbol_list, target)
 
 
-def generate_exemplars_str(num_exemplars: int = 8):
+def generate_exemplars_str(num_exemplars: int = 8) -> str:
     exemplars = [generate_example() for _ in range(num_exemplars)]
-    exemplars_str = [f"({exemplar[0]}, {exemplar[1]}) {DELIMETER} {exemplar[2]}".replace("'", "") for exemplar in exemplars]
+    exemplars_str = [
+        f"({exemplar[0]}, {exemplar[1]}) {DELIMETER} {exemplar[2]}".replace("'", "")
+        for exemplar in exemplars
+    ]
     return "\n".join([INSTRUCTION] + exemplars_str)
 
 
-def generate_eval_examples(num_eval_examples: int = 250):
+def generate_eval_examples(
+    num_eval_examples: int = 250,
+) -> tuple[list[str], list[Literal["foo", "bar"]]]:
     eval_examples = [generate_example() for _ in range(num_eval_examples)]
-    eval_examples_str = [f"{generate_exemplars_str()}\n({example[0]}, {example[1]}) {DELIMETER}".replace("'", "") for example in eval_examples]
-    targets = [example[2] for example in eval_examples]
+    eval_examples_str = [
+        f"{generate_exemplars_str()}\n({example[0]}, {example[1]}) {DELIMETER}".replace("'", "")
+        for example in eval_examples
+    ]
+    targets: list[Literal["foo", "bar"]] = [example[2] for example in eval_examples]
     return eval_examples_str, targets
 
 
@@ -42,7 +54,7 @@ if __name__ == "__main__":
                 "input": [
                     {"role": "system", "content": "You are a helpful assistant."},
                     {"role": "user", "content": eval_example_str},
-                    ],
+                ],
                 "ideal": target,
             }
             writer.write(json.dumps(d) + "\n")


### PR DESCRIPTION
## Eval details 📑

Note that it is not a eval.

This PR completes the types in the files under `scripts`. Also, it enables the type check of the directory `scripts`.

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

