### PR TITLE
Add pre-commit config for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.3.0'
+    hooks:
+      - id: mypy
+        args: ["--config-file=mypy.ini", "--no-site-packages", "."]
+
   - repo: https://github.com/psf/black
     rev: 22.8.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 'v1.3.0'
     hooks:
       - id: mypy
-        args: ["--config-file=mypy.ini", "--no-site-packages", "."]
+        args: ["--config-file=mypy.ini", "--no-site-packages"]
 
   - repo: https://github.com/psf/black
     rev: 22.8.0


### PR DESCRIPTION
## Eval details 📑

Not an eval.

This PR adds `mypy` in the `pre-commit` checklist to ensure that the types in this codebase are correct.

```plain
$ cat mypy.ini
[mypy]

; Not all dependencies have type annotations; ignore this.
ignore_missing_imports=True
namespace_packages=True
explicit_package_bases = True

; Be strict about certain rules.
strict_equality=True
warn_unused_configs=True
no_implicit_optional=True
strict_optional=True
warn_redundant_casts=True
warn_unused_ignores=True
check_untyped_defs=True

; By default, code is not checked for type errors.
; ignore_errors=True  <-- note that I have commented out this line
disallow_untyped_defs=False

; However, some directories that are fully type-annotated and don't have type errors have opted in
; to type checking.

[mypy-registry.*]
ignore_errors=False
disallow_untyped_defs=True

[mypy-oaievalset.*]
ignore_errors=False
disallow_untyped_defs=True

; TODO: Add the other modules here


$ pre-commit
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

evals/utils/misc.py:26: error: Argument 1 to "partial" has incompatible type Module; expected "Callable[..., Any]"  [arg-type]
[omitted]
Found 55 errors in 11 files (checked 1 source file)

black....................................................................Passed
isort....................................................................Passed
autoflake................................................................Passed
```

(it should be always passed before #1027 or #1018 got merged)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push
