### PR TITLE
Use the redundant form of the import in __init__

### DIFF
--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,8 +1,14 @@
-from .api import CompletionFn, CompletionResult, DummyCompletionFn, record_and_check_match
-from .completion_fns.openai import (
-    OpenAIChatCompletionFn,
-    OpenAICompletionFn,
-    OpenAICompletionResult,
-)
-from .data import get_csv, get_json, get_jsonl, get_jsonls, get_lines, iter_jsonls
-from .eval import Eval
+from .api import CompletionFn as CompletionFn
+from .api import CompletionResult as CompletionResult
+from .api import DummyCompletionFn as DummyCompletionFn
+from .api import record_and_check_match as record_and_check_match
+from .completion_fns.openai import OpenAIChatCompletionFn as OpenAIChatCompletionFn
+from .completion_fns.openai import OpenAICompletionFn as OpenAICompletionFn
+from .completion_fns.openai import OpenAICompletionResult as OpenAICompletionResult
+from .data import get_csv as get_csv
+from .data import get_json as get_json
+from .data import get_jsonl as get_jsonl
+from .data import get_jsonls as get_jsonls
+from .data import get_lines as get_lines
+from .data import iter_jsonls as iter_jsonls
+from .eval import Eval as Eval


### PR DESCRIPTION
## Details 📑

It prevents Pylance to report '"X" is not accessed'.

https://github.com/microsoft/pylance-release/issues/856#issuecomment-763793949

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

