### PR TITLE
Add logic_bat_ball_problem

### DIFF
--- a/evals/registry/data/logic_bat_ball_problem/problem_generator.py
+++ b/evals/registry/data/logic_bat_ball_problem/problem_generator.py
@@ -1,0 +1,48 @@
+# generate a jsonl where each line is a sample combination of a battle between two subjects
+
+import json
+import os
+import string
+
+DATA_PATH = os.path.dirname(__file__)
+
+file_name = f"{DATA_PATH}/samples.jsonl"
+
+def format_conversational_money(val):
+    if val == int(val):
+        return str(val)
+
+    return '{:.2f}'.format(val)
+
+
+samples = []
+
+starting_total = 1.1
+total_increment = 0.1
+ball_bat_diffs = [0.5, 1, 1.5, 2]
+
+for ball_bat_diff in ball_bat_diffs:
+    for i in range(100):
+        total = starting_total + (i * total_increment)
+        ball_cost = (total - ball_bat_diff) / 2
+
+        total_formatted = format_conversational_money(total)
+        ball_more_than_bat_formatted = format_conversational_money(ball_bat_diff)
+        answer = '{:.2f}'.format(ball_cost)
+
+        if float(answer) <= 0:
+            continue
+
+        prompt = f'A bat and a ball cost ${total_formatted} in total. The bat costs ${ball_more_than_bat_formatted} more than the ball. How much does the ball cost? Answer in number only, with no explanation, and with no formatting or dollar signs.'
+
+        samples.append({
+            'input': [
+                {'role': 'system', 'content': prompt}
+            ],
+            'ideal': str(answer),
+        })
+        
+        # save samples jsonl
+        with open(file_name, "w") as f:
+            for sample in samples:
+              f.write(json.dumps(sample) + "\n")

--- a/evals/registry/data/logic_bat_ball_problem/samples.jsonl
+++ b/evals/registry/data/logic_bat_ball_problem/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7a6cb04dd1ba44ef6e97450d67d618a70533c416d565d2c74c665c84f9243a8
+size 988451

--- a/evals/registry/data/logic_bat_ball_problem/samples.jsonl
+++ b/evals/registry/data/logic_bat_ball_problem/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e7a6cb04dd1ba44ef6e97450d67d618a70533c416d565d2c74c665c84f9243a8
-size 988451
+oid sha256:cacaa975e505fff09a86da43d099beb04a50be3cddf6270c36a5ae2d458b34b3
+size 97610

--- a/evals/registry/evals/logic_bat_ball_problem.yaml
+++ b/evals/registry/evals/logic_bat_ball_problem.yaml
@@ -1,0 +1,8 @@
+logic_bat_ball_problem:
+  id: logic_bat_ball_problem.dev.v0
+  metrics: [accuracy]
+
+logic_bat_ball_problem.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: logic_bat_ball_problem/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, pelase note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑
### Eval name
Logic bat ball problem

### Eval description

The bat/ball problem is a classic math puzzle, usually expressed as:
A bat and a ball cost $1.10 in total. The bat costs $1 more than the ball. How much does the ball cost?
I found that GPT-3.5 and GPT-4 gave incorrect answers as the problem varied.

### What makes this a useful eval?

Logical reasoning is important, and the model is generally inaccurate with this dataset.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

3.5 failed almost all the time (0.0038 accuracy)
GPT-4 failed in my spot checks also

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input":[{"role":"system","content":"A bat and a ball cost $1.10 in total. The bat costs $1 more than the ball. How much does the ball cost? Answer in number only, with no explanation, and with no formatting or dollar signs."}],"ideal":"0.05"}
{"input":[{"role":"system","content":"A bat and a ball cost $1.20 in total. The bat costs $1 more than the ball. How much does the ball cost? Answer in number only, with no explanation, and with no formatting or dollar signs."}],"ideal":"0.10"}
{"input":[{"role":"system","content":"A bat and a ball cost $1.30 in total. The bat costs $1 more than the ball. How much does the ball cost? Answer in number only, with no explanation, and with no formatting or dollar signs."}],"ideal":"0.15"}
{"input":[{"role":"system","content":"A bat and a ball cost $1.40 in total. The bat costs $1 more than the ball. How much does the ball cost? Answer in number only, with no explanation, and with no formatting or dollar signs."}],"ideal":"0.20"}
{"input":[{"role":"system","content":"A bat and a ball cost $1.50 in total. The bat costs $1 more than the ball. How much does the ball cost? Answer in number only, with no explanation, and with no formatting or dollar signs."}],"ideal":"0.25"}
{"input":[{"role":"system","content":"A bat and a ball cost $1.60 in total. The bat costs $1 more than the ball. How much does the ball cost? Answer in number only, with no explanation, and with no formatting or dollar signs."}],"ideal":"0.30"}
{"input":[{"role":"system","content":"A bat and a ball cost $1.70 in total. The bat costs $1 more than the ball. How much does the ball cost? Answer in number only, with no explanation, and with no formatting or dollar signs."}],"ideal":"0.35"}
  ```
</details>
