### PR TITLE
[Eval] German part-of-speech

### DIFF
--- a/evals/registry/data/german-part-of-speech/buildDataDe.py
+++ b/evals/registry/data/german-part-of-speech/buildDataDe.py
@@ -1,0 +1,58 @@
+import json
+import random
+import itertools
+
+CHOOSE_WORDS = 1000
+
+with open("out/de/pos.json", "r") as f:
+    all_words = json.load(f)
+with open("promptDe.txt", "r") as f:
+    prompt = f.read()
+
+chosen_words = []
+next_categories = list(all_words.keys())
+stats = {}
+while len(chosen_words) < CHOOSE_WORDS:
+    next_category = next_categories.pop(0)
+    count = len(all_words[next_category]["words"])
+    choose = random.randint(0, count - 1)
+    word = all_words[next_category]["words"].pop(choose)
+    # Check for no example word, and no word not containing a vowel (including accents)
+    if word != "alle" and word != "künftig" and word != "Sommelier" and any([vowel in word for vowel in ["a", "e", "i", "o", "u", "à", "è", "é", "ê", "ë", "ï", "î", "ô", "ù", "û", "ü", "ÿ"]]):
+        chosen_words.append({
+            "pos": all_words[next_category]["pos"],
+            "word": word
+        })
+        stats[next_category] = stats.get(next_category, 0) + 1
+    if len(all_words[next_category]["words"]) == 0:
+        del all_words[next_category]
+    else:
+        next_categories.append(next_category)
+chosen_words.sort(key=lambda x: x["word"].lower())
+
+
+def generate_combinations(words):
+    return [", ".join(p)+"." for p in itertools.permutations(words)]
+
+
+with open("out/de/samples.jsonl", "w") as f:
+    for chosen_word in chosen_words:
+        combinations = generate_combinations(chosen_word["pos"].keys())
+        obj = {
+            "input": [
+                {
+                    "role": "system",
+                    "content": prompt
+                },
+                {
+                    "role": "user",
+                    "content": chosen_word["word"]
+                }
+            ],
+            "ideal": combinations
+        }
+        f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+with open("out/de/words.json", "w") as f:
+    json.dump(chosen_words, f, ensure_ascii=False, indent=4)
+with open("out/de/stats.json", "w") as f:
+    json.dump(stats, f, ensure_ascii=False, indent=4)

--- a/evals/registry/data/german-part-of-speech/parsePosDe.py
+++ b/evals/registry/data/german-part-of-speech/parsePosDe.py
@@ -1,0 +1,177 @@
+from tqdm import tqdm
+import json
+import re
+import mwxml
+import mwparserfromhell
+
+dump_path = "dewiktionary-20230520-pages-articles-multistream.xml"
+total_pages = 1215724  # correct value
+# total_pages = 40000  # for testing
+
+# mapping part of speech labels
+pos_mapping = {
+    'adjektiv': 'adjective',
+    'adverb': 'adverb',
+    'antwortpartikel': 'particle',
+    'artikel': 'article',
+    'dekliniertes gerundivum': 'adjective',
+    'demonstrativpronomen': 'pronoun',
+    'erweiterter infinitiv': 'verb',
+    'fokuspartikel': 'particle',
+    'gradpartikel': 'particle',
+    'hilfsverb': 'verb',
+    'indefinitpronomen': 'pronoun',
+    'interjektion': 'interjection',
+    'interrogativadverb': 'adverb',
+    'interrogativpronomen': 'pronoun',
+    'komparativ': 'adjective',
+    'konjugierte form': 'verb',
+    'konjunktion': 'conjunction',
+    'konjunktionaladverb': 'adverb',
+    'lokaladverb': 'adverb',
+    'modaladverb': 'adverb',
+    'modalpartikel': 'particle',
+    'negationspartikel': 'particle',
+    'partikel': 'particle',
+    'partizip i': 'adjective',
+    'partizip ii': 'adjective',
+    'personalpronomen': 'pronoun',
+    'possessivpronomen': 'pronoun',
+    'postposition': 'preposition',
+    'präposition': 'preposition',
+    'pronomen': 'pronoun',
+    'pronominaladverb': 'adverb',
+    'reflexivpronomen': 'pronoun',
+    'relativpronomen': 'pronoun',
+    'reziprokpronomen': 'pronoun',
+    'subjunktion': 'conjunction',
+    'substantiv': 'noun',
+    'superlativ': 'adjective',
+    'temporaladverb': 'adverb',
+    'verb': 'verb',
+    'vergleichspartikel': 'particle',
+}
+possible_pos = sorted(list(set(pos_mapping.values())))
+print(possible_pos)
+inflection_mapping = {
+    'dekliniertes gerundivum': True,
+    'erweiterter infinitiv': True,
+    'konjugierte form': True,
+    'partizip i': True,
+    'partizip ii': True
+}
+
+# 'deklinierte form',
+# komparativ, superlativ
+
+# iterate over all pages in the dump and print the title
+all_words = {}
+pages = mwxml.Dump.from_file(open(dump_path, 'rb')).pages
+count = 0
+for page in tqdm(pages, total=total_pages):
+    count += 1
+    # Skip titles with one of these characters: " ", "’", "'", "-", "."
+    if " " in page.title or "’" in page.title or "'" in page.title or "-" in page.title or "." in page.title:
+        continue
+    if not any(char.isalpha() for char in page.title):
+        continue
+
+    # Parse the page wikicode content
+    last_revision = next(page)
+
+    wikicode = mwparserfromhell.parse(last_revision.text)
+
+    # Find the language section 'fr'
+    # Regex for {{langue|fr}}
+    de_sections = wikicode.get_sections(matches=r"{{Sprache\|Deutsch}}")
+
+    parts_of_speech = {}
+    please_skip = False
+    for de_section in de_sections:
+        # Find the headlines with 'S' templates in 'fr_section' only
+        all_headlines = de_section.filter_headings()
+        for headline in all_headlines:
+            if not str(headline).startswith("=== "):
+                continue
+            parsed_headline = mwparserfromhell.parse(str(headline))
+            templates = parsed_headline.filter_templates(matches="Wortart")
+
+            for template in templates:
+                # 2nd argument has to be Deutsch
+                if len(template.params) < 2:
+                    continue
+                if template.params[1].value.strip() != "Deutsch":
+                    continue
+
+                part_of_speech = template.params[0].value.strip().lower()
+                is_inflection = False
+                allowed = None
+                if part_of_speech in pos_mapping:
+                    part_of_speech = [pos_mapping[part_of_speech]]
+                elif part_of_speech == "komparativ" or part_of_speech == "superlativ":
+                    allowed = ["adjective", "adverb"]
+                elif part_of_speech == "deklinierte form":
+                    allowed = ["noun", "adjective", "article", "pronoun"]
+                else:
+                    please_skip = True
+
+                if allowed is not None:
+                    is_inflection = True
+                    reg = r"\{\{Wortart\|%s\|Deutsch\}\}" % part_of_speech
+                    part_of_speech = []
+                    section = de_section.get_sections(
+                        matches=lambda x: re.search(reg, str(x), re.IGNORECASE))
+                    if len(section) == 0:
+                        is_inflection = False
+                        please_skip = True
+                    else:
+                        s = str(section[0])
+                        s = re.sub(r"\{\{.*?\}\}", "", s, flags=re.DOTALL)
+                        for a in allowed:
+                            if ((a == "adjective" and re.search(r"adjektiv", s, re.IGNORECASE)) or
+                                (a == "adverb" and re.search(r"adverb", s, re.IGNORECASE)) or
+                                (a == "noun" and re.search(r"substantiv|nomen", s, re.IGNORECASE)) or
+                                (a == "article" and re.search(r"artikel", s, re.IGNORECASE)) or
+                                    (a == "pronoun" and re.search(r"pronom", s, re.IGNORECASE))):
+                                part_of_speech.append(a)
+                            if ((a == "adjective" and re.search(r"adjektiv", page.title, re.IGNORECASE)) or
+                                (a == "adverb" and re.search(r"adverb", page.title, re.IGNORECASE)) or
+                                (a == "noun" and re.search(r"substantiv|nomen", page.title, re.IGNORECASE)) or
+                                (a == "article" and re.search(r"artikel", page.title, re.IGNORECASE)) or
+                                    (a == "pronoun" and re.search(r"pronom", page.title, re.IGNORECASE))):
+                                please_skip = True
+
+                # Part of speech needs to be an array
+                if type(part_of_speech) is list:
+                    for pos in part_of_speech:
+                        if pos not in parts_of_speech:
+                            parts_of_speech[pos] = is_inflection
+                        else:
+                            parts_of_speech[pos] = parts_of_speech[pos] or is_inflection
+
+    if please_skip:
+        continue
+
+    # Create one string of the sorted parts of speech, using _i if it is a inflection
+    # Example: noun_verb_f
+    pos_string = "_".join([pos + ("_i" if parts_of_speech[pos] else "")
+                          for pos in sorted(parts_of_speech.keys())])
+    if pos_string == "":
+        continue
+    if pos_string not in all_words:
+        all_words[pos_string] = {
+            "pos": parts_of_speech,
+            "words": []
+        }
+    all_words[pos_string]["words"].append(page.title)
+
+    if count > total_pages:
+        break
+
+    if count % 2500 == 0:
+        with open("out/de/pos.json", "w") as f:
+            json.dump(all_words, f, ensure_ascii=False)
+
+with open("out/de/pos.json", "w") as f:
+    json.dump(all_words, f, ensure_ascii=False)
+print(count)

--- a/evals/registry/data/german-part-of-speech/promptDe.txt
+++ b/evals/registry/data/german-part-of-speech/promptDe.txt
@@ -1,0 +1,10 @@
+Act as a German language part-of-speech classifier. You will be prompted with a single German word. Return an unsorted comma-separated list for all the parts of speech the word could possibly be, in any context. Take care to consider if the word is any kind of inflection. If so, include the part of speech for the main word.
+Answer with the comma-separated list only. Use single spaces after the commas. End the list with a dot. Do not include any explanations. Only include parts of speech from the following list, ignoring possible other parts of speech:
+adjective, adverb, article, conjunction, interjection, noun, particle, preposition, pronoun, verb
+**Example prompt 1**: alle
+**Example output 1**: adverb, noun, pronoun.
+**Example prompt 2**: künftig
+**Example output 2**: adjective, adverb.
+**Example prompt 3**: Sommelier
+**Example output 3**: noun.
+**Prompt**:

--- a/evals/registry/data/german-part-of-speech/samples.jsonl
+++ b/evals/registry/data/german-part-of-speech/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b52c5bdec0c841b42430daec62e14836f3fb7f8b59355c5724c46320375f7ef
+size 1027889

--- a/evals/registry/evals/german-part-of-speech.yaml
+++ b/evals/registry/evals/german-part-of-speech.yaml
@@ -1,0 +1,8 @@
+german-part-of-speech:
+  id: german-part-of-speech.dev.v0
+  description: Test the model's knowledge what part of speech a given word can have in German, using data from de.wiktionary.org (as of 2023-05-20)
+  metrics: [accuracy]
+german-part-of-speech.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: german-part-of-speech/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, pelase note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑
### Eval name
> german-part-of-speech

### Eval description

> For a given German word, the model is asked to list all possible parts of speech (multiple choice). The model is also asked to think about the word as an inflection of another word. The models output is tested against annotations extracted from de.wiktionary.org. This is a follow up to #1039 

### What makes this a useful eval?

> Part of speech analysis is a basic task in language / grammar classes. While it is usually done in the context of a sentence, coming up with possible uses in lack of a sentence requires a certain amount of creativity and language understanding, or very good recall of information that is usually sparse outside of dictionaries. The task in this eval could be seen as a combination of part of speech analysis and an easy-to-evaluate form of the question "How could x be used in a sentence".

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> To build the dataset, all 1.000.000+ entries of the German wiktionary were parsed. Excluded from this list were all phrases, abbreviations, symbols, names, toponyms and any words with at least one possible part of speech not fitting the categories given in the prompt. Also I had to exclude some entries where the part of speech could not be determined automatically from the wikitext.
> From this set, words were sampled so that each combination of the parts of speech existing in the dataset would be equally likely in the tests. This way the model is tested to respond with all possible uses of a word and not just the most common ones. > For combinations that fit a lot of words, the uniform sampling led to a bias towards rarely used words.
> The labels of each word were taken from the corresponding page at de.wiktionary.org/wiki/{word}. The information taken from each page was: the word, the part of speech this word can have in German and whether the word is an abbreviation or not.
> This means only factual data was taken and is therefore in the public domain.

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Act as a German language part-of-speech classifier. You will be prompted with a single German word. Return an unsorted comma-separated list for all the parts of speech the word could possibly be, in any context. Take care to consider if the word is any kind of inflection. If so, include the part of speech for the main word.\nAnswer with the comma-separated list only. Use single spaces after the commas. End the list with a dot. Do not include any explanations. Only include parts of speech from the following list, ignoring possible other parts of speech:\nadjective, adverb, article, conjunction, interjection, noun, particle, preposition, pronoun, verb\n**Example prompt 1**: alle\n**Example output 1**: adverb, noun, pronoun.\n**Example prompt 2**: künftig\n**Example output 2**: adjective, adverb.\n**Example prompt 3**: Sommelier\n**Example output 3**: noun.\n**Prompt**:"}, {"role": "user", "content": "anstelle"}], "ideal": ["preposition, adverb, verb.", "preposition, verb, adverb.", "adverb, preposition, verb.", "adverb, verb, preposition.", "verb, preposition, adverb.", "verb, adverb, preposition."]}
{"input": [{"role": "system", "content": "Act as a German language part-of-speech classifier. You will be prompted with a single German word. Return an unsorted comma-separated list for all the parts of speech the word could possibly be, in any context. Take care to consider if the word is any kind of inflection. If so, include the part of speech for the main word.\nAnswer with the comma-separated list only. Use single spaces after the commas. End the list with a dot. Do not include any explanations. Only include parts of speech from the following list, ignoring possible other parts of speech:\nadjective, adverb, article, conjunction, interjection, noun, particle, preposition, pronoun, verb\n**Example prompt 1**: alle\n**Example output 1**: adverb, noun, pronoun.\n**Example prompt 2**: künftig\n**Example output 2**: adjective, adverb.\n**Example prompt 3**: Sommelier\n**Example output 3**: noun.\n**Prompt**:"}, {"role": "user", "content": "heute"}], "ideal": ["adverb, verb.", "verb, adverb."]}
{"input": [{"role": "system", "content": "Act as a German language part-of-speech classifier. You will be prompted with a single German word. Return an unsorted comma-separated list for all the parts of speech the word could possibly be, in any context. Take care to consider if the word is any kind of inflection. If so, include the part of speech for the main word.\nAnswer with the comma-separated list only. Use single spaces after the commas. End the list with a dot. Do not include any explanations. Only include parts of speech from the following list, ignoring possible other parts of speech:\nadjective, adverb, article, conjunction, interjection, noun, particle, preposition, pronoun, verb\n**Example prompt 1**: alle\n**Example output 1**: adverb, noun, pronoun.\n**Example prompt 2**: künftig\n**Example output 2**: adjective, adverb.\n**Example prompt 3**: Sommelier\n**Example output 3**: noun.\n**Prompt**:"}, {"role": "user", "content": "Mist"}], "ideal": ["noun, interjection.", "interjection, noun."]}
{"input": [{"role": "system", "content": "Act as a German language part-of-speech classifier. You will be prompted with a single German word. Return an unsorted comma-separated list for all the parts of speech the word could possibly be, in any context. Take care to consider if the word is any kind of inflection. If so, include the part of speech for the main word.\nAnswer with the comma-separated list only. Use single spaces after the commas. End the list with a dot. Do not include any explanations. Only include parts of speech from the following list, ignoring possible other parts of speech:\nadjective, adverb, article, conjunction, interjection, noun, particle, preposition, pronoun, verb\n**Example prompt 1**: alle\n**Example output 1**: adverb, noun, pronoun.\n**Example prompt 2**: künftig\n**Example output 2**: adjective, adverb.\n**Example prompt 3**: Sommelier\n**Example output 3**: noun.\n**Prompt**:"}, {"role": "user", "content": "Rotschöpfe"}], "ideal": ["noun."]}
{"input": [{"role": "system", "content": "Act as a German language part-of-speech classifier. You will be prompted with a single German word. Return an unsorted comma-separated list for all the parts of speech the word could possibly be, in any context. Take care to consider if the word is any kind of inflection. If so, include the part of speech for the main word.\nAnswer with the comma-separated list only. Use single spaces after the commas. End the list with a dot. Do not include any explanations. Only include parts of speech from the following list, ignoring possible other parts of speech:\nadjective, adverb, article, conjunction, interjection, noun, particle, preposition, pronoun, verb\n**Example prompt 1**: alle\n**Example output 1**: adverb, noun, pronoun.\n**Example prompt 2**: künftig\n**Example output 2**: adjective, adverb.\n**Example prompt 3**: Sommelier\n**Example output 3**: noun.\n**Prompt**:"}, {"role": "user", "content": "vornüber"}], "ideal": ["adverb."]}
  ```
</details>
