### PR TITLE
Catch errors from OpenAI API to make it work for custome endpoint

### DIFF
--- a/evals/registry.py
+++ b/evals/registry.py
@@ -84,9 +84,10 @@ class Registry:
     def api_model_ids(self):
         try:
             return [m["id"] for m in openai.Model.list()["data"]]
-        except openai.error.OpenAIError:
+        except openai.error.OpenAIError as err:
             # Errors can happen when running eval with completion function that uses custom
             # API endpoints and authentication mechanisms.
+            logger.warning(f"Could not fetch API model IDs from OpenAI API: {err}")
             return []
 
     def make_completion_fn(self, name: str) -> CompletionFn:

--- a/evals/registry.py
+++ b/evals/registry.py
@@ -82,7 +82,12 @@ class Registry:
 
     @cached_property
     def api_model_ids(self):
-        return [m["id"] for m in openai.Model.list()["data"]]
+        try:
+            return [m["id"] for m in openai.Model.list()["data"]]
+        except openai.error.OpenAIError:
+            # Errors can happen when running eval with completion function that uses custom
+            # API endpoints and authentication mechanisms.
+            return []
 
     def make_completion_fn(self, name: str) -> CompletionFn:
         """


### PR DESCRIPTION
We'd like to use this eval framework to measure the quality of a Langchain agent. We use a custom endpoint and auth token header instead of the standard OpenAI API key. Everything works well except this openai.Model.list() call requires the OpenAI API key and there is no way for us to override the request headers. 
