### PR TITLE
Add pure Korean Eval

### DIFF
--- a/evals/registry/data/pure_korean/samples.jsonl
+++ b/evals/registry/data/pure_korean/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbc137dedf17f481f87210e08a757f91fdd75b6dbb857a3cad8b35ab707dca76
+size 39258

--- a/evals/registry/data/pure_korean/samples.jsonl
+++ b/evals/registry/data/pure_korean/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbc137dedf17f481f87210e08a757f91fdd75b6dbb857a3cad8b35ab707dca76
-size 39258
+oid sha256:69de9c704cde69faff97b8fcdadbdbc7a0f02b6f9f30e155fb3b6705cef6c5f0
+size 37358

--- a/evals/registry/evals/pure_korean.yaml
+++ b/evals/registry/evals/pure_korean.yaml
@@ -1,0 +1,9 @@
+pure_korean:
+  id: pure_korean.dev.v0
+  description: Evaluates GPT can identify pure Korean words.
+  metrics: [accuracy]
+
+pure_korean.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: pure_korean/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, pelase note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑
### Eval name
pure_korean

### Eval description

The types of Korean words can be divided into pure Korean words and words from foreign languages. This eval tests whether the model can identify pure Korean words.

### What makes this a useful eval?

Classification of Korean words can be used in many real-world areas(ex. linguistics, education). It is also important to generate sentences successfully because the types of words that make up the sentence can determine the level, tone, and nuance of the sentence.
(Accuracy of gpt-3.5-turbo on this eval is 0.57)

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "The types of Korean words can be divided into pure Korean words and words from foreign languages. You will be prompted with a single Korean word. Is this word pure Korean? Answer with exactly one of the following: 'Yes' or a 'No'. Don't add anything else to the response."}, {"role": "user", "content": "푸르니"}], "ideal": "Yes"}
{"input": [{"role": "system", "content": "The types of Korean words can be divided into pure Korean words and words from foreign languages. You will be prompted with a single Korean word. Is this word pure Korean? Answer with exactly one of the following: 'Yes' or a 'No'. Don't add anything else to the response."}, {"role": "user", "content": "풀잎피리"}], "ideal": "Yes"}
{"input": [{"role": "system", "content": "The types of Korean words can be divided into pure Korean words and words from foreign languages. You will be prompted with a single Korean word. Is this word pure Korean? Answer with exactly one of the following: 'Yes' or a 'No'. Don't add anything else to the response."}, {"role": "user", "content": "풋내"}], "ideal": "Yes"}
{"input": [{"role": "system", "content": "The types of Korean words can be divided into pure Korean words and words from foreign languages. You will be prompted with a single Korean word. Is this word pure Korean? Answer with exactly one of the following: 'Yes' or a 'No'. Don't add anything else to the response."}, {"role": "user", "content": "풍계묻이"}], "ideal": "Yes"}
{"input": [{"role": "system", "content": "The types of Korean words can be divided into pure Korean words and words from foreign languages. You will be prompted with a single Korean word. Is this word pure Korean? Answer with exactly one of the following: 'Yes' or a 'No'. Don't add anything else to the response."}, {"role": "user", "content": "하람"}], "ideal": "Yes"}
{"input": [{"role": "system", "content": "The types of Korean words can be divided into pure Korean words and words from foreign languages. You will be prompted with a single Korean word. Is this word pure Korean? Answer with exactly one of the following: 'Yes' or a 'No'. Don't add anything else to the response."}, {"role": "user", "content": "한별"}], "ideal": "Yes"}
{"input": [{"role": "system", "content": "The types of Korean words can be divided into pure Korean words and words from foreign languages. You will be prompted with a single Korean word. Is this word pure Korean? Answer with exactly one of the following: 'Yes' or a 'No'. Don't add anything else to the response."}, {"role": "user", "content": "한울"}], "ideal": "Yes"}
  ```
</details>
