### PR TITLE
Contrib population span extraction

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 evals/registry/data/**/*.jsonl filter=lfs diff=lfs merge=lfs -text
-evals/registry/data/population_span_extraction/samples.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 evals/registry/data/**/*.jsonl filter=lfs diff=lfs merge=lfs -text
+evals/registry/data/population_span_extraction/samples.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/evals/registry/data/population_span_extraction/samples.jsonl
+++ b/evals/registry/data/population_span_extraction/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d75d73da796eacae15d03b59da8578f496ca3b6450d9a77cb1d28670e558e628
+size 2323327

--- a/evals/registry/evals/population_span_extraction.yaml
+++ b/evals/registry/evals/population_span_extraction.yaml
@@ -1,0 +1,12 @@
+# Register the eval by adding a file to evals/registry/evals/<eval_name>.yaml
+population_span_extraction:
+  id: population_span_extraction.dev.v0
+  metrics: [accuracy]
+
+population_span_extraction.dev.v0:
+  # Assuming that the response can contain "significant variation" --> modelbased classify
+  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
+  args:
+    samples_jsonl: population_span_extraction/samples.jsonl
+    eval_type: cot_classify
+    modelgraded_spec: fact

--- a/evals/registry/evals/population_span_extraction.yaml
+++ b/evals/registry/evals/population_span_extraction.yaml
@@ -2,6 +2,7 @@
 population_span_extraction:
   id: population_span_extraction.dev.v0
   metrics: [accuracy]
+  description: The model is shown abstracts of clinical drug trials and tasked with extracting the text spans that specify the population demographic of the shown abstract. The population demographic can be but is not necessarily specified in multiple seperate spans.
 
 population_span_extraction.dev.v0:
   # Assuming that the response can contain "significant variation" --> modelbased classify


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, __failure to follow the guidelines below will result in the PR being closed automatically__. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access granted. 🚨

__PLEASE READ THIS__:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, pelase note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑
### Eval name
#### Population Span Extraction
The **<eval_name>** is **population_span_extraction**
ID is **population_span_extraction.dev.v0**

### Eval description

The model is shown abstracts of clinical drug trials and tasked with extracting the text spans that specify the population demographic of the shown abstract. The population demographic can be but is not necessarily specified in multiple seperate spans. 

### What makes this a useful eval?

The Repository specifically asks for "Real-world use cases". Extracting population spans from clinical study trials is immensly useful to researchers who have to go over and compare large amounts of clinical drug trials.

The eval dataset is generated with multiple different prompts and statisfies all further critera posed by Open AI.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can  create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high quality examples.**

## Eval structure 🏗️

Your eval should
- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your yaml is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (https://platform.openai.com/docs/usage-policies).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgement

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data 

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input": [{"role": "system", "content": "Where in the following abstract do the authors specify how the clinical drug trials population demographic is defined."}, {"role": "user", "content": "The telephone lifestyle intervention 'Hartcoach' has modest impact on coronary risk factors: A randomised multicentre trial.\n\nBACKGROUND Unhealthy diets and inactivity are still common among patients with cardiovascular diseases. This study evaluates the effects of the telephonic lifestyle intervention 'Hartcoach' on risk factors and self-management in patients with recent coronary events. DESIGN This was a randomised trial in five Dutch hospitals. METHODS Patients (18-80 years), less than eight weeks after hospitalisation for acute myocardial infarction or (un)stable angina pectoris were randomised to the Hartcoach-group, who received telephonic coaching every four weeks for a period of six months (in addition to usual care), and a control group receiving usual care only. Simple random allocation was used (without relation to prior assignment). Measurements were taken by research nurses blinded for group allocation. Differences after six months of participation were compared using linear or logistic regression models with treatment-group and baseline score for the outcome under analysis as covariates, resulting in adjusted mean change (b). RESULTS Altogether 374 patients were randomised (173 Hartcoach + usual care, 201 usual care only). Follow-up was obtained in 331 patients who still participated after six months. Hartcoach had significant favourable effects on body mass index (BMI) (b = -0.32; 95% CI:(-0.63- -0.003)), waist circumference (b = -1.71; 95% CI:(-2.73- -0.70)), physical activity (b = 15.08 (score); 95% CI:(0.13, 30.04)) daily intake of vegetables (b = 13.41; 95% CI:(1.10-25.71)), self-management (b = 0.11; 95% CI:(0.00-0.23)) and anxiety (b = -0.65; 95% CI:(-1.25- -0.06)). Hartcoach slightly increased the total number of risk scores on target (b = 0.45; 95% CI:(0.17-0.73)). CONCLUSIONS Hartcoach has modest impact on BMI, waist circumference, physical activity, intake of vegetables, self-management and anxiety. Therefore, it may be a useful maintenance programme in addition to usual care, to support patients with recent coronary events to improve self-management and reduce risk factors."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'patients with recent coronary events', 'Patients (18-80 years), less than eight weeks after hospitalisation for acute myocardial infarction or (un)stable angina pectoris'"}
{"input": [{"role": "system", "content": "I have an abstract for a clinical drug trial. I want to know which parts of the abstract contain information on the trials population demographic. Please extract these parts for me."}, {"role": "user", "content": "Addressing challenges of clinical trials in acute pain: The Pain Management of Vaso-occlusive Crisis in Children and Young Adults with Sickle Cell Disease Study.\n\nBACKGROUND/AIMS Neuropathic pain is a known component of vaso-occlusive pain in sickle cell disease; however, drugs targeting neuropathic pain have not been studied in this population. Trials of acute pain are complicated by the need to obtain consent, to randomize participants expeditiously while optimally treating pain. We describe the challenges in designing and implementing the Pain Management of Vaso-occlusive Crisis in Children and Young Adults with Sickle Cell Disease Study (NCT01954927), a phase II, randomized, double-blind, placebo-controlled trial to determine the effect of gabapentin for vaso-occlusive crisis. METHODS In the Pain Management of Vaso-occlusive Crisis in Children and Young Adults with Sickle Cell Disease Study, we aim to assess the analgesic effect of gabapentin during vaso-occlusive crisis. Difficulties we identified included avoiding delay of notification of study staff of potential participants which we resolved by automated notification. Concern for rapid randomization and drug dispensation was addressed through careful planning with an investigational pharmacy and a single liquid formulation. We considered obtaining consent during well-visits to avoid the time constraints with acute presentations, but the large number of patients and limited duration that consent is valid made this impractical. RESULTS In all, 79% of caregivers/children approached have agreed to participate. The trial is currently active, and enrollment is at 45.8% of that targeted (76 of 166) and expected to continue for two more years. Maintaining staff availability after-hours remains problematic, with 8% of screened patients missed for lack of available staff. LESSONS LEARNED Lessons learned in designing a trial to expedite procedures in the acute pain setting include (1) building study evaluations upon a standard-of-care backbone; (2) implementing a simple study design to facilitate consent and data capture; (3) assuring ample, well-trained study staff; and (4) utilizing technology to automate procedures whenever possible. CONCLUSION This study design has circumvented many of the logistical barriers usually associated with acute pain trials and may serve as a prototype for future studies."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'Vaso-occlusive Crisis in Children and Young Adults'"}
{"input": [{"role": "system", "content": "Extract the Population Demographic information from the provided abstract."}, {"role": "user", "content": "Sensor and software use for the glycaemic management of insulin-treated type 1 and type 2 diabetes patients.\n\nLowering glucose levels, while avoiding hypoglycaemia, can be challenging in insulin-treated patients with diabetes. We evaluated the role of ambulatory glucose profile in optimising glycaemic control in this population. Insulin-treated patients with type 1 and type 2 diabetes were recruited into a prospective, multicentre, 100-day study and randomised to control (n = 28) or intervention (n = 59) groups. The intervention group used ambulatory glucose profile, generated by continuous glucose monitoring, to assess daily glucose levels, whereas the controls relied on capillary glucose testing. Patients were reviewed at days 30 and 45 by the health care professional to adjust insulin therapy. Comparing first and last 2 weeks of the study, ambulatory glucose profile-monitored type 2 diabetes patients (n = 28) showed increased time in euglycaemia (mean \u00b1 standard deviation) by 1.4 \u00b1 3.5 h/day (p = 0.0427) associated with reduction in HbA1c from 77 \u00b1 15 to 67 \u00b1 13 mmol/mol (p = 0.0002) without increased hypoglycaemia. Type 1 diabetes patients (n = 25) showed reduction in hypoglycaemia from 1.4 \u00b1 1.7 to 0.8 \u00b1 0.8 h/day (p = 0.0472) associated with a marginal HbA1c decrease from 75 \u00b1 10 to 72 \u00b1 8 mmol/mol (p = 0.0508). Largely similar findings were observed comparing intervention and control groups at end of study. In conclusion, ambulatory glucose profile helps glycaemic management in insulin-treated diabetes patients by increasing time spent in euglycaemia and decreasing HbA1c in type 2 diabetes patients, while reducing hypoglycaemia in type 1 diabetes patients."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'insulin-treated type 1 and type 2 diabetes patients', 'insulin-treated patients with diabetes', 'Insulin-treated patients with type 1 and type 2 diabetes'"}
{"input": [{"role": "system", "content": "The Following text is an abstract of a clinical drug trial that specifies a population demographic. I want you to extract the text spans that contain these informations."}, {"role": "user", "content": "Efficacy and safety profile of memantine in patients with cognitive impairment in multiple sclerosis: A randomized, placebo-controlled study.\n\nUNLABELLED Memantine, an uncompetitive antagonist of N-methyl-D-aspartate (NMDA)-type glutamate receptors that was approved for the treatment of moderate to severe Alzheimer's disease, has been negatively evaluated for the treatment of cognitive disorders of multiple sclerosis, but these studies were conducted only during short-term administration and on a heterogeneous group of patients with different forms of the disease. In addition, many adverse reactions were observed in these patients. AIMS The purpose of the \"EMERITE\" (NCT01074619) study was to examine the efficacy and safety of the long-term administration of memantine as a symptomatic treatment for cognitive disorders in patients with relapsing-remitting multiple sclerosis (RR-MS). METHODS The study was supported by the French Ministry of Health and received additional support from Lundbeck. In this double-blind, placebo-controlled, parallel group, randomized trial, the participants were assigned to receive memantine (20 mg/day) or a placebo for 52 weeks. The participants included males and females, 18-60 years of age, with a diagnosis of RR-MS and presenting with a cognitive complaint and/or demonstrating moderate cognitive impairment. The data were collected in the Department of Neurology in 19 French centers. The primary outcome was the Paced Auditory Serial Addition Test (PASAT) score at week 52. Secondary measurements included additional neuropsychological tests and the annualized relapse rate. The scores were adjusted according to the baseline scores in the analysis. The safety was assessed by the number of adverse events. The random sequence was generated using the Excel software. At each center, only the pharmacist had access to the allocation sequence and could be asked to unblind the trial. RESULTS Fifty patients were allocated to the memantine group, and 43 to the placebo group. The intent-to-treat (ITT) population included 31 patients in each group. After adjusting for the PASAT scores at baseline, the PASAT scores at the end point did not differ between the memantine and the placebo groups (p=0.88). Adjusted mean score difference (memantine minus placebo), was -0.40 (95% confidence interval: -5.5; +4.7). No significant differences were observed for the secondary outcomes (short term memory and attention scores, EDSS, and relapse rate). The findings remained unchanged after multiple imputation of the missing values. Neurological and psychiatric adverse events were significantly higher in the memantine group than in the placebo group, and these parameters were higher than those reported in the product literature of memantine. CONCLUSIONS No differences between the placebo and memantine groups were observed. Nevertheless, the tolerability of memantine was significantly worse than expected."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'patients with cognitive impairment in multiple sclerosis', 'patients with relapsing-remitting multiple sclerosis (RR-MS)', 'males and females, 18-60 years of age, with a diagnosis of RR-MS and presenting with a cognitive complaint and/or demonstrating moderate cognitive impairment'"}
{"input": [{"role": "system", "content": "Where in the following abstract do the authors specify how the clinical drug trials population demographic is defined."}, {"role": "user", "content": "Alemtuzumab improves neurological functional systems in treatment-naive relapsing-remitting multiple sclerosis patients.\n\nBACKGROUND Individual functional system scores (FSS) of the Expanded Disability Status Scale (EDSS) play a central role in determining the overall EDSS score in patients with early-stage multiple sclerosis (MS). Alemtuzumab treatment improves preexisting disability for many patients; however, it is unknown whether improvement is specific to certain functional systems. OBJECTIVE We assessed the effect of alemtuzumab on individual FSS of the EDSS. METHODS CAMMS223 was a 36-month, rater-blinded, phase 2 trial; treatment-naive patients with active relapsing-remitting MS, EDSS \u22643, and symptom onset within 3 years were randomized to annual courses of alemtuzumab or subcutaneous interferon beta-1a (SC IFNB-1a) 44 \u03bcg three times weekly. RESULTS Alemtuzumab-treated patients had improved outcomes versus SC IFNB-1a patients on most FSS at Month 36; the greatest effect occurred for sensory, pyramidal, and cerebellar FSS. Among patients who experienced 6-month sustained accumulation of disability, clinical worsening occurred most frequently in the brainstem and sensory systems. For patients with 6-month sustained reduction in preexisting disability, pyramidal and sensory systems contributed most frequently to clinical improvement. CONCLUSIONS Alemtuzumab demonstrated a broad treatment effect in improving preexisting disability. These findings may influence treatment decisions in patients with early, active relapsing-remitting MS displaying neurological deficits. ClinicalTrials.gov Identifier NCT00050778."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'treatment-naive relapsing-remitting multiple sclerosis patients', 'patients with early-stage multiple sclerosis (MS)', 'treatment-naive patients with active relapsing-remitting MS, EDSS \u22643, and symptom onset within 3 years'"}
{"input": [{"role": "system", "content": "The Following text is an abstract of a clinical drug trial that specifies a population demographic. I want you to extract the text spans that contain these informations."}, {"role": "user", "content": "Efficacy and Safety of Canagliflozin in Individuals Aged 75 and Older with Type 2 Diabetes Mellitus: A Pooled Analysis.\n\nOBJECTIVES To compare the efficacy and safety of canagliflozin, a sodium glucose co-transporter 2 inhibitor developed to treat type 2 diabetes mellitus (T2DM), in individuals younger than 75 and those aged 75 and older. DESIGN Randomized Phase 3 studies. SETTING International study centers. PARTICIPANTS Adults with T2DM. MEASUREMENTS Changes from baseline in glycosylated hemoglobin (HbA1c ), fasting plasma glucose (FPG), blood pressure (BP), and body weight were measured. Efficacy was evaluated using pooled data from six randomized, double-blind, placebo-controlled studies (N = 4,158; n = 3,975 aged <75, n = 183 aged \u226575). Safety was assessed based on adverse event (AE) reports from eight randomized, double-blind, placebo- and active-controlled studies (N = 9,439; n = 8,949 aged <75, n = 490 aged \u226575). RESULTS Canagliflozin 100 and 300 mg were associated with placebo-subtracted mean reductions in HbA1c in participants younger than 75 (-0.69% and -0.85%, respectively) and aged 75 and older (-0.65% and -0.55%, respectively). Dose-related reductions in FPG, body weight, and BP were seen with canagliflozin 100 and 300 mg in participants in both age groups. Overall AE incidence was 67.1% with canagliflozin 100 mg, 68.6% with canagliflozin 300 mg, and 65.9% with non-canagliflozin (pooled group of comparators in all studies) in participants younger than 75, and 72.4%, 79.1%, and 72.3%, respectively, in those aged 75 and older, with a similar safety profile in both groups. The incidence of volume depletion-related AEs was 2.2%, 3.1%, and 1.4% in participants younger than 75 with canagliflozin 100 and 300 mg and non-canagliflozin, respectively, and 4.9%, 8.7%, and 2.6%, respectively, in those aged 75 and older. CONCLUSION Canagliflozin improved glycemic control, body weight, and BP in participants aged 75 and older. The overall incidence of AEs was high across treatment groups in participants aged 75 and older and higher than in those younger than 75. The safety profile of canagliflozin was generally similar in both age groups, with a higher incidence of AEs related to volume depletion observed with canagliflozin in participants aged 75 and older than in those younger than 75. These findings support canagliflozin, starting with the 100-mg dose, as an effective therapeutic option for older adults with T2DM."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'Individuals Aged 75 and Older with Type 2 Diabetes Mellitus', 'individuals younger than 75 and those aged 75 and older', 'Adults with T2DM'"}
{"input": [{"role": "system", "content": "I am unsure whether this abstract for a clinical drug trial specifies a population demographic. Read the abstract, find out if the population demographic is described. If it does, extract the text spans that do so."}, {"role": "user", "content": "An evaluation of a ptarget-controlled infusion of propofol]C or propofol-alfentanil admixture for sedation in dogs.\n\nOBJECTIVES To evaluate sedation quality and cardiorespiratory variables in dogs sedated using a target-controlled infusion of propofol or propofol-alfentanil admixture. METHODS A total of 60 dogs undergoing diagnostic imaging were randomly assigned to one of three sedation protocols: propofol alone; propofol with a low concentration of 12 \u00b5g of alfentanil per mL of propofol; or propofol with a higher concentration of 24 \u00b5g of alfentanil per mL of propofol. Target-controlled infusion was initiated at a propofol target concentration of 1\u00b75 \u00b5g/mL and increased until lateral recumbency was achieved. Times to adopt lateral recumbency and recover, pulse rate, respiratory rate, oscillometric mean arterial pressure and oxygen saturation were recorded. Quality of sedation onset and recovery were scored. RESULTS Propofol target at lateral recumbency differed significantly (P=0\u00b701) between groups with median (range) values of 3\u00b70 (1\u00b75 to 5\u00b75), 2\u00b70 (2 to 4\u00b75) and 2\u00b725 (1\u00b75 to 3\u00b75) \u00b5g/mL for propofol alone, propofol with the lower concentration of alfentanil and propofol with the higher concentration of alfentanil groups, respectively. Time to lateral recumbency was longer and quality of onset less smooth for the propofol group. Pulse rate change differed significantly (P<0\u00b7001) between groups (mean pulse rate change at onset of sedation: propofol group +2 \u00b124 bpm, low concentration alfentanil group -30 \u00b124 bpm, higher concentration alfentanil group -26 \u00b123 bpm). Hypoxaemia (SpO2 <90%) occurred in 1, 3 and 13 dogs, in the propofol group, the low concentration alfentanil group and the higher concentration of alfentanil group, respectively (P<0\u00b7001). CLINICAL SIGNIFICANCE Addition of alfentanil to propofol target-controlled infusion did not confer cardiovascular benefits and, at the higher concentration, alfentanil increased the incidence of hypoxaemia."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'dogs', '60 dogs'"}
{"input": [{"role": "system", "content": "I am unsure whether this abstract for a clinical drug trial specifies a population demographic. Read the abstract, find out if the population demographic is described. If it does, extract the text spans that do so."}, {"role": "user", "content": "Modification of a traditional breakfast leads to increased satiety along with attenuated plasma increments of glucose, C-peptide, insulin, and glucose-dependent insulinotropic polypeptide in humans.\n\nOur hypothesis was that carbohydrate, fat, and protein contents of meals affect satiety, glucose homeostasis, and hormone secretion. The objectives of this crossover trial were to examine satiety, glycemic-insulinemic response, and plasma peptide levels in response to 2 different recommended diabetes diets with equivalent energy content. One traditional reference breakfast and one test breakfast, with lower carbohydrate and higher fat and protein content, were randomly administered to healthy volunteers (8 men, 12 women). Blood samples were collected, and satiety was scored on a visual analog scale before and 3 hours after meals. Plasma glucose was measured, and levels of C-peptide, ghrelin, glucagon, glucagon-like peptide-1, glucose-dependent insulinotropic polypeptide (GIP), insulin, plasminogen activator inhibitor-1, and adipokines were analyzed by Luminex. Greater satiety, visual analog scale, and total and delta area under the curve (P < .001), and lower glucose postprandial peak (max) and change from baseline (dmax; P < .001) were observed after test meal compared with reference meal. Postprandial increments of C-peptide, insulin, and GIP were suppressed after test meal compared with reference meal (total delta area under the curve [P = .03, .006, and .004], delta area under the curve [P = .006, .003, and .02], max [P = .01, .007, and .002], and dmax [P = .004, .008, and .007], respectively). Concentrations of other peptides were similar between meals. A lower carbohydrate and higher fat and protein content provides greater satiety and attenuation of C-peptide, glucose, insulin, and GIP responses compared with the reference breakfast but does not affect adipokines, ghrelin, glucagon, glucagon-like peptide-1, and plasminogen activator inhibitor-1."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'humans', 'healthy volunteers (8 men, 12 women)'"}
{"input": [{"role": "system", "content": "Does this abstract contain information on the drug trials populations demographic. Respond with the text spans that contain this information."}, {"role": "user", "content": "Prediction of disease-free survival using relative change in FDG-uptake early during neoadjuvant chemoradiotherapy for potentially curable esophageal cancer: A prospective cohort study.\n\n18F-Fluorodeoxyglucose positron emission tomography (FDG-PET) has been investigated as a tool for monitoring response to neoadjuvant chemo- and chemoradiotherapy (CT and CRT, respectively) and as a predictor for survival in patients with esophageal cancer. In contrast to patients who undergo neoadjuvant CT, it is not known whether patients who are clinically identified as responders after neoadjuvant CRT show better disease-free survival (DFS) than patients identified as nonresponders. The aim of the study was to determine the predictive value of FDG-uptake measured prior to and early during neoadjuvant CRT. Patients treated with neoadjuvant CRT between 2004 and 2009 within a randomized trial were included. FDG-uptake was measured at baseline and after 14 days of CRT. According to the PERCIST-criteria, patients were allocated to have metabolic response, stable disease, or progression. Patients were followed until recurrence of disease or death. The predictive value of FDG-PET was determined with univariable and multivariable analysis in patients who underwent potentially curative surgery. One-hundred and six patients were included in the analysis. Minimal follow-up for surviving patients was 60 months. No significant differences in DFS were found between patients with metabolic response, stable disease, or progression, with 5-year DFS rates of 66%, 53%, and 67%, respectively (P = 0.39). Relative change in FDG uptake after 14 days of CRT is not associated with DFS in patients with esophageal cancer undergoing neoadjuvant chemoradiotherapy followed by surgery. These measurements should not be used for prognostication in this specific group of patients."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'potentially curable esophageal cancer'"}
{"input": [{"role": "system", "content": "Extract the text spans containing information on the Population Demographic from the following abstract."}, {"role": "user", "content": "A randomized, double-blind, crossover, placebo-controlled clinical trial to assess effects of the single ingestion of a tablet containing lactoferrin, lactoperoxidase, and glucose oxidase on oral malodor.\n\nBACKGROUND The main components of oral malodor have been identified as volatile sulfur compounds (VSCs) including hydrogen sulfide (H2S) and methyl mercaptan (CH3SH). VSCs also play an important role in the progression of periodontal disease. The aim of the present study was to assess the effects of the single ingestion of a tablet containing 20 mg of lactoferrin, 2.6 mg of lactoperoxidase, and 2.6 mg of glucose oxidase on VSCs in the mouth. METHOD Subjects with VSCs greater than the olfactory threshold in their mouth air ingested a test or placebo tablet in two crossover phases. The concentrations of VSCs were monitored at baseline and 10 and 30 min after ingestion of the tablets using portable gas chromatography. RESULTS Thirty-nine subjects were included in the efficacy analysis based on a full analysis set (FAS). The concentrations of total VSCs and H2S at 10 min were significantly lower in the test group than in the placebo group (-0.246 log ng/10 ml [95 % CI -0.395 to -0.098], P = 0.002; -0.349 log ng/10 ml; 95 % CI -0.506 to -0.192; P < 0.001, respectively). In the subgroup analysis, a significant difference in the concentration of total VSCs between the groups satietywas also observed when subjects were fractionated by sex (male or female) and age (20-55 or 56-65 years). The reducing effect on total VSCs positively correlated with the probing pocket depth (P = 0.035). CONCLUSIONS These results suggest that the ingestion of a tablet containing lactoferrin, lactoperoxidase, and glucose oxidase has suppressive effects on oral malodor. TRIAL REGISTRATION This trial was registered with the University Hospital Medical Information Network Clinical Trial Registry (number: UMIN000015140 , date of registration: 16/09/2014)."}], "ideal": "In the abstract, population demographics are defined by the following spans: 'Subjects with VSCs greater than the olfactory threshold in their mouth air'"}
  ```
</details>
