### PR TITLE
add korean abbreviated slang eval

### DIFF
--- a/evals/registry/data/korean-abbreviated-slang/samples.jsonl
+++ b/evals/registry/data/korean-abbreviated-slang/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a9f26047fb9e8bd676c66d47962bcf300ceafd92eff30f046ee8d9d1e1ab844
+size 9264

--- a/evals/registry/evals/korean-abbreviated-slang.yaml
+++ b/evals/registry/evals/korean-abbreviated-slang.yaml
@@ -1,0 +1,9 @@
+korean-abbreviated-slang:
+  id: korean-abbreviated-slang.dev.v0
+  description: Evaluates GPT can identify common slang Korean words that are abbreviations of phrases.
+  metrics: [accuracy]
+
+korean-abbreviated-slang.dev.v0:
+  class: evals.elsuite.basic.fuzzy_match:FuzzyMatch
+  args:
+    samples_jsonl: korean-abbreviated-slang/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

### Eval name

korean-abbreviated-slang

### Eval description

The eval aims to assess the model's proficiency in recognizing and generating the full form of Korean slangs that are derived from abbreviations of specific phrases. To measure accuracy, the test utilizes FuzzyMatch, which allows for minor differences in phrase wording. If the model's output contains all the keywords that the abbreviation symbolizes, the F1 score will indicate a high score, resulting in an accuracy score of 1.

### What makes this a useful eval?

Improved understanding of colloquial language: Korean abbreviated slang is commonly used in informal conversations, online platforms, and social media. By incorporating it into the evaluation test for GPT, you can enhance the model's comprehension and generation of colloquial expressions, allowing it to produce more natural and contextually appropriate responses.

Enhanced user engagement: Incorporating Korean abbreviated slang into GPT can make the model more relatable and engaging for Korean users, particularly the younger generation who frequently use these slangs. Users are more likely to find the responses more authentic and familiar, leading to increased satisfaction and usage of the model.

Adapting to evolving language trends: Language is constantly evolving, and new slang terms emerge regularly, especially in online communities. By including Korean abbreviated slang in the evaluation test, you can ensure that GPT stays up to date with the latest linguistic trends and remains relevant in contemporary conversations.

Reflecting cultural context: Language and culture are closely intertwined, and slang terms often carry cultural connotations. By incorporating Korean abbreviated slang into GPT, you can help the model better understand and reflect the cultural context in its responses. This can contribute to more accurate and culturally sensitive interactions, fostering better communication between the model and users.

Training data diversity: Including Korean abbreviated slang in the evaluation test expands the diversity of training data for GPT. This can lead to better generalization and performance of the model in understanding and generating informal language. By exposing GPT to a wider range of language styles, you can help improve its overall language capabilities and adaptability.

Realistic and natural conversations: Korean abbreviated slang is prevalent in everyday conversations, particularly among younger individuals. By integrating it into GPT's evaluation test, you can simulate more realistic and natural conversations, enabling the model to generate responses that align with the way people actually speak in informal settings.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value
gpt-3.5-score: 33

## Eval structure 🏗️

Your eval should

- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [ ] I have filled out all required fields of this form
- [ ] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input": [{"role": "system", "content": "The following is a commonly used korean slang that is an abbreviation of a phrase. Type the full form of the abbreviation. Don't add anything else to the response. Only respond in Korean."}, {"role": "user", "content": "낄끼빠빠"}], "ideal": "낄 때 끼고 빠질 때 빠져"}
{"input": [{"role": "system", "content": "The following is a commonly used korean slang that is an abbreviation of a phrase. Type the full form of the abbreviation. Don't add anything else to the response. Only respond in Korean."}, {"role": "user", "content": "마상"}], "ideal": "마음에 상처"}
{"input": [{"role": "system", "content": "The following is a commonly used korean slang that is an abbreviation of a phrase. Type the full form of the abbreviation. Don't add anything else to the response. Only respond in Korean."}, {"role": "user", "content": "스불쟈"}], "ideal": "스스로 불러온 재앙"}
{"input": [{"role": "system", "content": "The following is a commonly used korean slang that is an abbreviation of a phrase. Type the full form of the abbreviation. Don't add anything else to the response. Only respond in Korean."}, {"role": "user", "content": "마기꾼"}], "ideal": "마스크 사기꾼"}
{"input": [{"role": "system", "content": "The following is a commonly used korean slang that is an abbreviation of a phrase. Type the full form of the abbreviation. Don't add anything else to the response. Only respond in Korean."}, {"role": "user", "content": "성덕"}], "ideal": "성공한 덕후"}
  ```
</details>
