### PR TITLE
fix #616 faliekant

### DIFF
--- a/evals/registry/data/dutch-lexicon/samples.jsonl
+++ b/evals/registry/data/dutch-lexicon/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2990d7a68b286b6c48fdeab36f4951770cae0286f5b2f4b5e14556e846fda8eb
-size 39678
+oid sha256:79ab70053ecaf1addb365827c7ba46cc7629abbfd8e8822443c09f5b4109cfaa
+size 39461


### PR DESCRIPTION
This is a fix for a problem with 
https://github.com/openai/evals/blob/19352afd7ba6290b3320d2fe60a990efe9aaebd6/evals/registry/data/dutch-lexicon/samples.jsonl that I noted here: https://github.com/openai/evals/pull/616#issuecomment-1574431980

✅ Correct spelling (line 49): 

```json
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Dutch language? Answer with exactly one letter: Y or N."},{"role":"user","content":"faliekant"}],"ideal":"Y"}
```

✅ Incorrect spelling (line 100): 

```json
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Dutch language? Answer with exactly one letter: Y or N."},{"role":"user","content":"falikant"}],"ideal":"N"}
```

❌ But there's a mixup on line 137 - the correct spelling is marked as "not ideal":
```json
{"input":[{"role":"system","content":"You will be prompted with a single word. Does this word exist in the Dutch language? Answer with exactly one letter: Y or N."},{"role":"user","content":"faliekant"}],"ideal":"N"}
```
