### PR TITLE
[Eval] Mapping arrays to matricies

### DIFF
--- a/evals/registry/data/mapping_to_matricies/data_generator.py
+++ b/evals/registry/data/mapping_to_matricies/data_generator.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+def generate_binary_array_and_factors(N):
+    # Generate binary array
+    binary_array = np.random.randint(2, size=N)
+    # Generate array of factor pairs
+    factor_pairs = [(i, N//i) for i in range(2, int(np.sqrt(N)) + 1) if N % i == 0]
+    # Return both
+    return binary_array.tolist(), factor_pairs
+
+def generate_one_sample_json_string(binary_array_str, dimensions_str, answer_str):
+    base_string = '{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\\\"Final Row\\\":[...]}"}, {"role": "user", "content": "Array: ' + binary_array_str + '\\nGrid Dimensions: ' + dimensions_str + '"}], "ideal": "{\\"Final Row\\":' + answer_str + '}"}'
+    return base_string
+
+def write_lines_to_file(min_array_len, max_array_len, filename, max_lines = 50):
+    num_lines = 0;
+    # Open the file for writing
+    with open(filename, 'w') as file:
+        # Loop through all possible array lengths
+        for i in range(min_array_len, max_array_len + 1):
+            # Generate a binary array and its factors
+            (arr, pairs) = generate_binary_array_and_factors(i)
+            # Loop through all the factors
+            for j in range(len(pairs)):
+              # Get the dimensions of the subarray
+              dims = str(pairs[j][0]) + 'x' + str(pairs[j][1])
+              # Get the subarray as a string and remove spaces
+              ans = str(arr[-pairs[j][1]:]).replace(' ', '')
+              # Generate a JSON string with the array, dimensions, and answer
+              line = generate_one_sample_json_string(str(arr).replace(' ', ''), dims, ans)
+              # Write the JSON string to the file
+              file.write(line + '\n')
+              # Increment the number of lines written
+              num_lines += 1
+              # If we've written the maximum number of lines, stop generating more lines
+              if num_lines == max_lines:
+                  return
+
+# generate 1k samples (i.e. lines of json) and write to file: samples.jsonl
+write_lines_to_file(40, 500, 'samples.jsonl', 1000)

--- a/evals/registry/data/mapping_to_matricies/samples.jsonl
+++ b/evals/registry/data/mapping_to_matricies/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3ea858d95d3707546e4a2520af209ade9541bab0a4dd5731b61f3bc63693f65
+size 1348816

--- a/evals/registry/evals/mapping_to_matricies.yaml
+++ b/evals/registry/evals/mapping_to_matricies.yaml
@@ -1,0 +1,8 @@
+mapping_to_matricies:
+  id: mapping_to_matricies.dev.v0
+  metrics: [accuracy]
+
+mapping_to_matricies.dev.v0:
+  class: evals.elsuite.basic.includes:Includes
+  args:
+    samples_jsonl: mapping_to_matricies/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

### Eval name

mapping_to_matricies

### Eval description

Given an array of binary values (0 or 1), a request is made for the array to be mapped to a two-dimensional array. The length of the original array must be evenly divisible by the dimensions of the two-dimensional array (i.e. an array of length 12 is evenly mappable onto a 3x4 two-dimensional array). An evaluation is made by comparing the final row of the mapped 2D array with the corresponding values of the original array. To further demonstrate that the failure cases are not due to poor prompting, I've included instructions in the prompt to present some rationale in the response -- it is evident therein that the LLM indeed understands the task, but fails to accomplish it. In fact, when asked to verify the answer, the LLM appears to double down and effectively "re-write" its own memory of the original input array so that it can claim that its answer was valid.

A small python script that was used for generating the samples has been included at `/evals/registry/data/mapping_to_matricies/data_generator.py`

### What makes this a useful eval?

This eval demonstrates a task that a human can easily do, but LLMs have trouble accomplishing. Further, it also demonstrates that the LLM understands the task accurately, but confidently and consistently provides the wrong answer; and when asked to check its answer, it alters its own understanding of the original user input so that it can claim to be correct.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should

- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [0,1,1,0,0,0,1,0,1,1,1,0,1,1,0,0,0,1,1,0,1,1,0,1,0,0,1,0,1,0,1,0,1,0,0,0,0,0,0,1]\nGrid Dimensions: 2x20"}], "ideal": "{\"Final Row\":[1,1,0,1,0,0,1,0,1,0,1,0,1,0,0,0,0,0,0,1]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [0,1,1,0,0,0,1,0,1,1,1,0,1,1,0,0,0,1,1,0,1,1,0,1,0,0,1,0,1,0,1,0,1,0,0,0,0,0,0,1]\nGrid Dimensions: 4x10"}], "ideal": "{\"Final Row\":[1,0,1,0,0,0,0,0,0,1]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [0,1,1,0,0,0,1,0,1,1,1,0,1,1,0,0,0,1,1,0,1,1,0,1,0,0,1,0,1,0,1,0,1,0,0,0,0,0,0,1]\nGrid Dimensions: 5x8"}], "ideal": "{\"Final Row\":[1,0,0,0,0,0,0,1]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [1,0,1,0,0,0,0,0,0,0,1,1,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,0,1,1,1,1,0,0,0,1,1,0]\nGrid Dimensions: 2x21"}], "ideal": "{\"Final Row\":[1,1,1,1,1,1,0,0,1,1,0,1,1,1,1,0,0,0,1,1,0]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [1,0,1,0,0,0,0,0,0,0,1,1,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,0,1,1,1,1,0,0,0,1,1,0]\nGrid Dimensions: 3x14"}], "ideal": "{\"Final Row\":[0,1,1,0,1,1,1,1,0,0,0,1,1,0]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [1,0,1,0,0,0,0,0,0,0,1,1,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,0,1,1,1,1,0,0,0,1,1,0]\nGrid Dimensions: 6x7"}], "ideal": "{\"Final Row\":[1,0,0,0,1,1,0]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [1,0,0,1,0,0,1,1,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,1,1,1,1,1,0,0,0,1,0,1,1,0,1,1,0,1,0,0,1,1]\nGrid Dimensions: 2x22"}], "ideal": "{\"Final Row\":[0,1,1,1,1,1,0,0,0,1,0,1,1,0,1,1,0,1,0,0,1,1]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [1,0,0,1,0,0,1,1,0,0,0,0,1,0,0,0,0,0,0,1,0,0,0,1,1,1,1,1,0,0,0,1,0,1,1,0,1,1,0,1,0,0,1,1]\nGrid Dimensions: 4x11"}], "ideal": "{\"Final Row\":[1,1,0,1,1,0,1,0,0,1,1]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [0,0,1,1,0,1,1,1,1,0,1,0,0,0,1,1,0,0,1,0,0,0,0,1,1,1,1,1,1,1,0,1,0,1,0,0,1,1,0,0,0,1,0,1,0]\nGrid Dimensions: 3x15"}], "ideal": "{\"Final Row\":[0,1,0,1,0,0,1,1,0,0,0,1,0,1,0]}"}
{"input": [{"role": "system", "content": "Given the user-provided binary array, map the binary array onto a grid, wherein the dimensions of the grid are as provided by the user ([num rows]x[num elements per row]), and the mapping to the grid is done from left to right, top to bottom (provide a visualization of the mapped result). Then explain in a second visualization how the final row of the grid was mapped from the corresponding final binary numbers of the array. Lastly, provide the final row of the grid, in minified JSON format, like this: {\"Final Row\":[...]}"}, {"role": "user", "content": "Array: [0,0,1,1,0,1,1,1,1,0,1,0,0,0,1,1,0,0,1,0,0,0,0,1,1,1,1,1,1,1,0,1,0,1,0,0,1,1,0,0,0,1,0,1,0]\nGrid Dimensions: 5x9"}], "ideal": "{\"Final Row\":[1,1,0,0,0,1,0,1,0]}"}
  ```
</details>
