### PR TITLE
ElasticSearchHistory Mismatch

### DIFF
--- a/evals/registry/data/elasticsearch_version_history/samples.jsonl
+++ b/evals/registry/data/elasticsearch_version_history/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d134af2fec8115bba9c5347b3e1c8ba8a2138cff7218e5082f718a6da2e9abb
+size 3491

--- a/evals/registry/evals/elasticsearch_version_history.yaml
+++ b/evals/registry/evals/elasticsearch_version_history.yaml
@@ -1,0 +1,10 @@
+elasticsearch_version_history:
+  id: elasticsearch_version_history.dev.v0
+  description: This evaluation aims to test the model's ability to accurately recall the Elasticsearch version history, before the cut-off date of September 2021, including the release dates of different versions without hallucinations as given by the ground truth https://www.elastic.co/downloads/past-releases/#elasticsearch 
+  metrics: [accuracy]
+
+elasticsearch_version_history.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+      samples_jsonl: elasticsearch_version_history/samples.jsonl
+


### PR DESCRIPTION
This evaluation aims to test the model's ability to accurately recall the Elasticsearch version history, before the cut-off date of September 2021, including the release dates of different versions without hallucinations as given by the ground truth https://www.elastic.co/downloads/past-releases/#elasticsearch

# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

## ElasticSearch History Mismatch



### What makes this a useful eval?

It shows that GPT-3.5 (as well as GPT-4) can't keep track of chronological software version histories without hallucinations and making up release dates and version numbers.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [X] Prompt-engineered failures where a human can easily do the task, but either GPT-4 or GPT-3.5-Turbo could not at all.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 5 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should

- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address tdq459rcfm@privaterelay.appleid.com

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [X] I have filled out all required fields of this form
- [X] I have used **Git LFS** for the Eval JSON data
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

```

{"spec": {"completion_fns": ["gpt-3.5-turbo"], "eval_name": "elasticsearch_version_history.dev.v0", "base_eval": "elasticsearch_version_history", "split": "dev", "run_config": {"completion_fns": ["gpt-3.5-turbo"], "eval_spec": {"cls": "evals.elsuite.basic.match:Match", "args": {"samples_jsonl": "elasticsearch_version_history/samples.jsonl"}, "key": "elasticsearch_version_history.dev.v0", "group": "elasticsearch_version_history"}, "seed": 20220722, "max_samples": null, "command": "oaieval.py gpt-3.5-turbo elasticsearch_version_history", "initial_settings": {"visible": true}}, "created_by": "", "run_id": "230610031634V7KNDLWK", "created_at": "2023-06-10 03:16:34.821550"}}
{"final_report": {"accuracy": 0.0}}
{"run_id": "230610031634V7KNDLWK", "event_id": 0, "sample_id": "elasticsearch_version_history.dev.1", "type": "sampling", "data": {"prompt": [{"role": "user", "content": "Please provide the most recent version of Elasticsearch as of June 15, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year. The previous version, Elasticsearch x.y.z, was released on month day, year. The next version, Elasticsearch x.y.z, was released on month day, year.'"}], "sampled": ["As of June 15, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.2, which was released on June 10, 2021. The previous version, Elasticsearch 7.13.1, was released on May 27, 2021. The next version, Elasticsearch 7.14.0, is expected to be released in the near future."]}, "created_by": "", "created_at": "2023-06-10 03:16:39.637934+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 1, "sample_id": "elasticsearch_version_history.dev.1", "type": "match", "data": {"correct": false, "expected": "As of June 15, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.2, which was released on June 14, 2021. The previous version, Elasticsearch 7.13.1, was released on June 2, 2021. The next version, Elasticsearch 7.13.3, was released on July 7, 2021.", "picked": null, "sampled": "As of June 15, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.2, which was released on June 10, 2021. The previous version, Elasticsearch 7.13.1, was released on May 27, 2021. The next version, Elasticsearch 7.14.0, is expected to be released in the near future.", "options": ["As of June 15, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.2, which was released on June 14, 2021. The previous version, Elasticsearch 7.13.1, was released on June 2, 2021. The next version, Elasticsearch 7.13.3, was released on July 7, 2021."]}, "created_by": "", "created_at": "2023-06-10 03:16:39.638008+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 2, "sample_id": "elasticsearch_version_history.dev.3", "type": "sampling", "data": {"prompt": [{"role": "user", "content": "Please provide the most recent version of Elasticsearch as of May 26, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year. The previous version, Elasticsearch x.y.z, was released on month day, year. The next version, Elasticsearch x.y.z, was released on month day, year.'"}], "sampled": ["As of May 26, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.0, which was released on May 25, 2021. The previous version, Elasticsearch 7.12.1, was released on April 29, 2021. The next version, Elasticsearch 7.14.0, has not yet been released."]}, "created_by": "", "created_at": "2023-06-10 03:16:39.639490+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 3, "sample_id": "elasticsearch_version_history.dev.3", "type": "match", "data": {"correct": false, "expected": "As of May 26, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.0, which was released on May 25, 2021. The previous version, Elasticsearch 7.12.1, was released on April 27, 2021. The next version, Elasticsearch 7.13.1, was released on June 2, 2021.", "picked": null, "sampled": "As of May 26, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.0, which was released on May 25, 2021. The previous version, Elasticsearch 7.12.1, was released on April 29, 2021. The next version, Elasticsearch 7.14.0, has not yet been released.", "options": ["As of May 26, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.0, which was released on May 25, 2021. The previous version, Elasticsearch 7.12.1, was released on April 27, 2021. The next version, Elasticsearch 7.13.1, was released on June 2, 2021."]}, "created_by": "", "created_at": "2023-06-10 03:16:39.639515+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 4, "sample_id": "elasticsearch_version_history.dev.4", "type": "sampling", "data": {"prompt": [{"role": "user", "content": "Please provide the most recent version of Elasticsearch as of April 28, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year. The previous version, Elasticsearch x.y.z, was released on month day, year. The next version, Elasticsearch x.y.z, was released on month day, year.'"}], "sampled": ["As of April 28, 2021, the most recent version of Elasticsearch was Elasticsearch 7.12.1, which was released on April 15, 2021. The previous version, Elasticsearch 7.12.0, was released on March 31, 2021. The next version, Elasticsearch 7.13.0, is expected to be released in May 2021."]}, "created_by": "", "created_at": "2023-06-10 03:16:39.640387+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 5, "sample_id": "elasticsearch_version_history.dev.4", "type": "match", "data": {"correct": false, "expected": "As of April 28, 2021, the most recent version of Elasticsearch was Elasticsearch 7.12.1, which was released on April 27, 2021. The previous version, Elasticsearch 7.12.0, was released on March 23, 2021. The next version, Elasticsearch 7.13.0, was released on May 25, 2021.", "picked": null, "sampled": "As of April 28, 2021, the most recent version of Elasticsearch was Elasticsearch 7.12.1, which was released on April 15, 2021. The previous version, Elasticsearch 7.12.0, was released on March 31, 2021. The next version, Elasticsearch 7.13.0, is expected to be released in May 2021.", "options": ["As of April 28, 2021, the most recent version of Elasticsearch was Elasticsearch 7.12.1, which was released on April 27, 2021. The previous version, Elasticsearch 7.12.0, was released on March 23, 2021. The next version, Elasticsearch 7.13.0, was released on May 25, 2021."]}, "created_by": "", "created_at": "2023-06-10 03:16:39.640411+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 6, "sample_id": "elasticsearch_version_history.dev.2", "type": "sampling", "data": {"prompt": [{"role": "user", "content": "Please provide the most recent version of Elasticsearch as of June 3, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year. The previous version, Elasticsearch x.y.z, was released on month day, year. The next version, Elasticsearch x.y.z, was released on month day, year.'"}], "sampled": ["As of June 3, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.0, which was released on May 25, 2021. The previous version, Elasticsearch 7.12.1, was released on May 6, 2021. The next version, Elasticsearch 7.14.0, has not been released yet."]}, "created_by": "", "created_at": "2023-06-10 03:16:39.641451+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 7, "sample_id": "elasticsearch_version_history.dev.2", "type": "match", "data": {"correct": false, "expected": "As of June 3, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.1, which was released on June 2, 2021. The previous version, Elasticsearch 7.13.0, was released on May 25, 2021. The next version, Elasticsearch 7.13.2, was released on June 14, 2021.", "picked": null, "sampled": "As of June 3, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.0, which was released on May 25, 2021. The previous version, Elasticsearch 7.12.1, was released on May 6, 2021. The next version, Elasticsearch 7.14.0, has not been released yet.", "options": ["As of June 3, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.1, which was released on June 2, 2021. The previous version, Elasticsearch 7.13.0, was released on May 25, 2021. The next version, Elasticsearch 7.13.2, was released on June 14, 2021."]}, "created_by": "", "created_at": "2023-06-10 03:16:39.641464+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 8, "sample_id": "elasticsearch_version_history.dev.0", "type": "sampling", "data": {"prompt": [{"role": "user", "content": "Please provide the most recent version of Elasticsearch as of July 8, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year. The previous version, Elasticsearch x.y.z, was released on month day, year. The next version, Elasticsearch x.y.z, was released on month day, year.'"}], "sampled": ["As of July 8, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.3, which was released on June 30, 2021. The previous version, Elasticsearch 7.13.2, was released on June 10, 2021. The next version, Elasticsearch 7.14.0, is expected to be released in the near future."]}, "created_by": "", "created_at": "2023-06-10 03:16:40.092803+00:00"}
{"run_id": "230610031634V7KNDLWK", "event_id": 9, "sample_id": "elasticsearch_version_history.dev.0", "type": "match", "data": {"correct": false, "expected": "As of July 8, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.3, which was released on July 7, 2021. The previous version, Elasticsearch 7.13.2, was released on June 14, 2021. The next version, Elasticsearch 7.13.4, was released on July 20, 2021.", "picked": null, "sampled": "As of July 8, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.3, which was released on June 30, 2021. The previous version, Elasticsearch 7.13.2, was released on June 10, 2021. The next version, Elasticsearch 7.14.0, is expected to be released in the near future.", "options": ["As of July 8, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.3, which was released on July 7, 2021. The previous version, Elasticsearch 7.13.2, was released on June 14, 2021. The next version, Elasticsearch 7.13.4, was released on July 20, 2021."]}, "created_by": "", "created_at": "2023-06-10 03:16:40.092874+00:00"}

```
</details>
