### PR TITLE
[Eval] Identify Chinese Chu Ci title

### DIFF
--- a/evals/registry/data/chinese_chu_ci/samples.jsonl
+++ b/evals/registry/data/chinese_chu_ci/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:144bef05c48a43bcb57bb39e7b30edb4df3f9db8e2edbc438ffc16667cb18084
+size 3059

--- a/evals/registry/data/chinese_chu_ci/samples.jsonl
+++ b/evals/registry/data/chinese_chu_ci/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:144bef05c48a43bcb57bb39e7b30edb4df3f9db8e2edbc438ffc16667cb18084
-size 3059
+oid sha256:c65ccdcf4ec3b4d2928c937f78a381d27f99e9127304084531d058ba01f3d2ae
+size 3389

--- a/evals/registry/evals/chinese_chu_ci.yaml
+++ b/evals/registry/evals/chinese_chu_ci.yaml
@@ -1,5 +1,6 @@
 chinese_chu_ci:
   id: chinese_chu_ci.dev.v0
+  description: Given a Chinese Chu Ci content, return the name of it.
   metrics: [accuracy]
 
 chinese_chu_ci.dev.v0:

--- a/evals/registry/evals/chinese_chu_ci.yaml
+++ b/evals/registry/evals/chinese_chu_ci.yaml
@@ -1,0 +1,8 @@
+chinese_chu_ci:
+  id: chinese_chu_ci.dev.v0
+  metrics: [accuracy]
+
+chinese_chu_ci.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: chinese_chu_ci/samples.jsonl


### PR DESCRIPTION
## Eval details 📑

### Eval name

 Identify Chinese Chu Ci title

### Eval description

Given a Chinese Chu Ci content, return the title of it.

### What makes this a useful eval?

> The Chu ci, variously translated as Verses of Chu, Songs of Chu, or Elegies of Chu, is an ancient anthology of Chinese poetry including works traditionally attributed mainly to Qu Yuan and Song Yu from the Warring States period (ended 221 BC), and also a large number of works composed several centuries later, during the Han dynasty. 
> from [Chuci —— Wikipedia](https://en.wikipedia.org/wiki/Chu_Ci)

As I notice there are simmilar PRs to improve the Tang poetry /Song Ci author Identify. I try to add a Chu Ci Identify. 

The difference of this eval is that Chu Ci are mostly written by Qu yuan and Song Yu, So the more useful situation is to return the title of the given Chu ci content.

Right now, GPT-3.5  returns very random guesses on the titles of the Chu Ci ,just about 6% accuracy.

<img width="1839" alt="image" src="https://github.com/openai/evals/assets/28616219/e62a94bb-7ca0-4de5-853c-f609235d67c3">


## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

All Chu Ci in this eval are random picked from 楚辞名篇鉴赏辞典 a Chu Ci collection published by Shanghai Lexicographical Publishing House (上海辞书出版社) in 2009. The Chu ci themselves are in public domain since they are written over 2000 years ago. All the poems are double-checked against Google search result to make sure we have put in the right title for the each Chu Ci.

## Eval structure 🏗️

Your eval should

- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n民生各有所乐兮，余独好修以为常。"}], "ideal": ["《离骚》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n何方圆之能周兮，夫孰异道而相安？"}], "ideal": ["《离骚》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n沅有茝兮澧有兰，思公子兮未敢言。"}], "ideal": ["《九歌·湘夫人》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n时不可兮骤得，聊逍遥兮容与。"}], "ideal": ["《九歌·湘夫人》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n愁人兮奈何，愿若今兮无亏。固人命兮有当，孰离合兮可为。"}], "ideal": ["《九歌·大司命》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n怨公子兮怅忘归，君思我兮不得闲。"}], "ideal": ["《九歌·山鬼》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n身既死兮神以灵，魂魄毅兮为鬼雄。"}], "ideal": ["《九歌·国殇》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n芳与泽其杂糅兮，羌芳华自中出。"}], "ideal": ["《九章·思美人》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n世溷浊而不清，蝉翼为重，千钧为轻。黄钟毁弃，瓦釜雷鸣。谗人高张，贤士无名。"}], "ideal": ["《卜居》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n夫尺有所短，寸有所长；物有所不足，智有所不明；数有所不逮，神有所不通。"}], "ideal": ["《卜居》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n举世皆浊我独清，众人皆醉我独醒，是以见放。"}], "ideal": ["《渔父》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n新沐者必弹冠，新浴者必振衣。"}], "ideal": ["《渔父》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n悲哉秋之为气也！萧瑟兮草木摇落而变衰。"}], "ideal": ["《九辩》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n苏世独立，横而不流兮。"}], "ideal": ["《橘颂》"]}
{"input": [{"role": "user", "content": "下面这段内容出自哪篇楚辞？请仅回复楚辞名。 例如：《离骚》\n---\n善不由外来兮，名不可以虚作。"}], "ideal": ["《九章·抽思》"]}

  ```
</details>
