### PR TITLE
Temporal Inversion Eval

### DIFF
--- a/evals/registry/data/temporal_inversion/samples.jsonl
+++ b/evals/registry/data/temporal_inversion/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45bd4fd3232d102baeea196f1b0a3b4217cd9f6bd09a2b2e91bd56873054eb62
+size 4155

--- a/evals/registry/data/temporal_inversion/samples.jsonl
+++ b/evals/registry/data/temporal_inversion/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45bd4fd3232d102baeea196f1b0a3b4217cd9f6bd09a2b2e91bd56873054eb62
-size 4155
+oid sha256:56b9f39123460a5a2799e165e359c6a3f3a8687088e13899d7e0753e7ec25e47
+size 12655

--- a/evals/registry/evals/temporal_inversion.yaml
+++ b/evals/registry/evals/temporal_inversion.yaml
@@ -1,0 +1,10 @@
+elasticsearch_version_history:
+  id: temporal_inversion.dev.v0
+  description: The Temporal Inversion Eval shows that chronological reasoning failures go far beyond just retrieving the right numbers from a table. It would, for example, give a date from 2 days ago and say that the next future version was released 2 days before today or give a date 6 days in the future and say it will be 8 days ago, which makes no sense.
+  metrics: [accuracy]
+
+temporal_inversion.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+      samples_jsonl: temporal_inversion/samples.jsonl
+


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. 
Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

### Eval name

Temporal Inversion

### Eval description

In case I wasn’t clear, I tried to prove my point that GPT can’t do chronological reasoning tasks in my previous eval and not just show that it fails to retrieve the correct numbers from a table.

Since these chronological reasoning failures go far beyond just retrieving the right numbers from a table. It would fail my chronological reasoning eval in more obvious ways, such as for the given prompt that the next version was released “-x days ago” as jargon for “the next version will be released in x days from the current date” it would fail in multiple ways on ChatGPT, the OpenAI Playground, Bing Chat, and so on.

It would, for example, give a date from 2 days ago and say that the next future version was released 2 days before today or give a date 6 days in the future and say it was 8 days ago, which makes no sense and it would ignore my prompt instruction to append a minus sign before the amount of days ago. Or it would say that the next version “has not been released yet” or “expected to be released in Q3 2021”, which is inaccurate and also does not follow the instructions given by the prompt to use the format “-x days ago”, aside from simply giving the wrong amount of days all the time. Often it would also give a further away upgrade release version instead of a closer bug fix release next version match, while disregarding standard version numbering logic from 0,1,2 and so.


### What makes this a useful eval?

It helps to evaluate the correct reasoning of chronological orders...

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 5 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> It adds a little logic puzzle in the form of the given prompt that the next version was released “-x days ago” as jargon for “the next version will be released in x days from the current date” Also, these given edge cases showcase that allowing the model to freely browse the web with the WebPilot plugin or Bing AI can just confuse the model even further instead of improving the results…

## Eval structure 🏗️

Your eval should

- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [X] I have filled out all required fields of this form
- [X] I have used **Git LFS** for the Eval JSON data
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  {"input":[{"role":"user","content":"Please provide the most recent version of Elasticsearch as of July 8, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year, which was x day ago. The previous version, Elasticsearch x.y.z, was released on month day, year, which was x days ago. The next version, Elasticsearch x.y.z, was released on month day, year, which was -x days ago.'"}],"ideal":"As of July 8, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.3, which was released on July 7, 2021, which was 1 day ago. The previous version, Elasticsearch 7.13.2, was released on June 14, 2021, which was 24 days ago. The next version, Elasticsearch 7.13.4, was released on July 20, 2021, which was -12 days ago."}
{"input":[{"role":"user","content":"Please provide the most recent version of Elasticsearch as of June 15, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year, which was x day ago. The previous version, Elasticsearch x.y.z, was released on month day, year, which was x days ago. The next version, Elasticsearch x.y.z, was released on month day, year, which was -x days ago.'"}],"ideal":"As of June 15, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.2, which was released on June 14, 2021, which was 1 day ago. The previous version, Elasticsearch 7.13.1, was released on June 2, 2021, which was 13 days ago. The next version, Elasticsearch 7.13.3, was released on July 7, 2021, which was -22 days ago."}
{"input":[{"role":"user","content":"Please provide the most recent version of Elasticsearch as of June 3, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year, which was x day ago. The previous version, Elasticsearch x.y.z, was released on month day, year, which was x days ago. The next version, Elasticsearch x.y.z, was released on month day, year, which was -x days ago.'"}],"ideal":"As of June 3, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.1, which was released on June 2, 2021, which was 1 day ago. The previous version, Elasticsearch 7.13.0, was released on May 25, 2021, which was 9 days ago. The next version, Elasticsearch 7.13.2, was released on June 14, 2021, which was -11 days ago."}
{"input":[{"role":"user","content":"Please provide the most recent version of Elasticsearch as of May 26, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year, which was x day ago. The previous version, Elasticsearch x.y.z, was released on month day, year, which was x days ago. The next version, Elasticsearch x.y.z, was released on month day, year, which was -x days ago.'"}],"ideal":"As of May 26, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.0, which was released on May 25, 2021, which was 1 day ago. The previous version, Elasticsearch 7.12.1, was released on April 27, 2021, which was 29 days. The next version, Elasticsearch 7.13.1, was released on June 2, 2021, which was -7 days ago."}
{"input":[{"role":"user","content":"Please provide the most recent version of Elasticsearch as of April 28, 2021, in the following format: 'As of the given date, the most recent version of Elasticsearch was Elasticsearch x.y.z, which was released on month day, year, which was x day ago. The previous version, Elasticsearch x.y.z, was released on month day, year, which was x days ago. The next version, Elasticsearch x.y.z, was released on month day, year, which was -x days ago.'"}],"ideal":"As of April 28, 2021, the most recent version of Elasticsearch was Elasticsearch 7.12.1, which was released on April 27, 2021, which was 1 day ago. The previous version, Elasticsearch 7.12.0, was released on March 23, 2021, which was 36 days ago. The next version, Elasticsearch 7.13.0, was released on May 25, 2021, which was -27 days ago."}
  ```
</details>

Example Expected Answer: “As of July 8, 2021, the most recent version of Elasticsearch was Elasticsearch 7.13.3, which was released on July 7, 2021, which was 1 day ago. The previous version, Elasticsearch 7.13.2, was released on June 14, 2021, which was 24 days ago. The next version, Elasticsearch 7.13.4, was released on July 20, 2021, which was -12 days ago.”

Answer given by OpenAI Playground: “As of July 8, 2021, the most recent version of Elasticsearch was Elasticsearch 8.1.1, which was released on April 14, 2021, which was 76 days ago. The previous version, Elasticsearch 8.0.2, was released on March 11, 2021, which was 100 days ago. The next version, Elasticsearch 8.2.0, was released on August 10, 2021, which was 30 days ago.”

Errors aside from the incorrectly retrieved version numbers and the release dates: There are 85 days between April 14 and July 8, not 76 days. There are 119 days between March 11 and July 8, not 100 days.  There are -33 days between August 10 and July 8, not +30 days. It also seems to fail to understand the nuances of the next version meaning the next bug fix release and not the next major upgrade release as a form of reasoning sanity check! It also didn’t seem to catch with common sense reasoning that 8.1.1 might be preceded by 8.1.0 instead of 8.0.2

In conclusion: Lots of basic reasoning failures, not just lookup failures. Also, remember that these given edge cases showcase that allowing the model to freely browse the web with the WebPilot plugin or Bing AI can just confuse the model even further instead of improving the results…
