### PR TITLE
Ordering Randomised VersionList

### DIFF
--- a/evals/registry/data/ordering_randomised_versionlist/samples.jsonl
+++ b/evals/registry/data/ordering_randomised_versionlist/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79fa871f6649dcf5338d9c5c6c74fa58b30ee3bca5c23d814368232ee8db52dc
-size 6390
+oid sha256:123164695072b66e3128fcd05d0232c4c4103fb6a2a8732200415a62577eba69
+size 8948

--- a/evals/registry/data/ordering_randomised_versionlist/samples.jsonl
+++ b/evals/registry/data/ordering_randomised_versionlist/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79fa871f6649dcf5338d9c5c6c74fa58b30ee3bca5c23d814368232ee8db52dc
+size 6390

--- a/evals/registry/evals/ordering_randomised_versionlist.yaml
+++ b/evals/registry/evals/ordering_randomised_versionlist.yaml
@@ -1,0 +1,10 @@
+ordering_randomised_versionlist:
+  id: ordering_randomised_versionlist.dev.v0
+  description: This evaluation aims to test prompt engineered failure cases to order a randomised version history list, but causes chronological ordering failures such as 7.5.2 -> 7.4.2 -> 7.5.1 -> 7.4.1 (incorrectly inserted 7.4.2 in between 7.5.2 and 7.5.1 in the Explainable AI chain of thoughts) and 7.5.2 -> 7.5.1 -> 7.5.0 -> 7.4.1 (incorrectly skipped over 7.4.2 in the Explainable AI chain of thoughts).
+  metrics: [accuracy]
+
+ordering_randomised_versionlist.dev.v0:
+  class: evals.elsuite.basic.includes:Includes
+  args:
+      samples_jsonl: ordering_randomised_versionlist/samples.jsonl
+


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

### Eval name

Ordering Randomised VersionList

### Eval description

This evaluation aims to test prompt engineered failure cases to order a randomised version history list, but causes chronological ordering failures such as 7.5.2 -> 7.4.2 -> 7.5.1 -> 7.4.1 (**incorrectly inserted 7.4.2 in between 7.5.2 and 7.5.1** and **incorrectly skipping over the major release version 7.5.0** in the Explainable AI chain of thoughts) and 7.5.2 -> 7.5.1 -> 7.5.0 -> 7.4.1 (incorrectly **skipped over 7.4.2** in the Explainable AI chain of thoughts).

### What makes this a useful eval?
This eval can help identify logical errors when ordering a randomised version history list. It can also help improve the Explainable AI feature by providing more accurate and consistent explanations for the ordering decisions. This eval can also measure the robustness and reliability of the prompt across different inputs and scenarios.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

This eval is high quality because it causes the succeed rate for a 5 options (ABCDE) multiple choice quiz drop from 20% correct at randomly selected answers to only 0-6% correct for GPT-3.5-Turbo. These are prompt engineered failures, causing [bigger failure rates than prior work](https://arxiv.org/pdf/2305.04388.pdf), as performing so much worse than random is unnatural for such a super easy task.

## Eval structure 🏗️

Your eval should

- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [X] I have filled out all required fields of this form
- [X] I have used **Git LFS** for the Eval JSON data
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input":[{"role":"user","content":"Here's a list of software versions: Version 7.5.0 Release Date: December 02, 2019 Version 7.4.1 Release Date: October 23, 2019 Version 7.5.1 Release Date: December 18, 2019 Version 7.5.2 Release Date: January 21, 2020 Version 7.4.2 Release Date: October 31, 2019 What was the version released three versions before 7.5.2? A. 7.4.2 B. 7.5.2 C. 7.5.1 D. 7.4.1 E. 7.5.0"}],"ideal":"A. 7.4.2"}
{"input":[{"role":"user","content":"Here's a list of software versions: Version 7.5.2 Release Date: January 21, 2020 Version 7.4.1 Release Date: October 23, 2019 Version 7.5.0 Release Date: December 02, 2019 Version 7.4.2 Release Date: October 31, 2019 Version 7.5.1 Release Date: December 18, 2019 What was the version released three versions before 7.5.2? A. 7.5.2 B. 7.5.1 C. 7.4.1 D. 7.4.2 E. 7.5.0"}],"ideal":"D. 7.4.2"}
{"input":[{"role":"user","content":"Here's a list of software versions: Version 7.5.1 Release Date: December 18, 2019 Version 7.5.0 Release Date: December 02, 2019 Version 7.4.1 Release Date: October 23, 2019 Version 7.5.2 Release Date: January 21, 2020 Version 7.4.2 Release Date: October 31, 2019 What was the version released three versions before 7.5.2? A. 7.5.0 B. 7.4.2 C. 7.5.1 D. 7.4.1 E. 7.5.2"}],"ideal":"B. 7.4.2"}
{"input":[{"role":"user","content":"Here's a list of software versions: Version 7.5.0 Release Date: December 02, 2019 Version 7.5.1 Release Date: December 18, 2019 Version 7.4.2 Release Date: October 31, 2019 Version 7.4.1 Release Date: October 23, 2019 Version 7.5.2 Release Date: January 21, 2020 What was the version released three versions before 7.5.2? A. 7.5.1 B. 7.4.1 C. 7.5.2 D. 7.5.0 E. 7.4.2"}],"ideal":"E. 7.4.2"}
{"input":[{"role":"user","content":"Here's a list of software versions: Version 7.4.2 Release Date: October 31, 2019 Version 7.5.1 Release Date: December 18, 2019 Version 7.5.0 Release Date: December 02, 2019 Version 7.5.2 Release Date: January 21, 2020 Version 7.4.1 Release Date: October 23, 2019 What was the version released three versions before 7.5.2? A. 7.4.1 B. 7.5.2 C. 7.4.2 D. 7.5.0 E. 7.5.1"}],"ideal":"C. 7.4.2"}
  ```
</details>

- The task of ordering a randomised version history list is relatively simple and straightforward for humans, but the AI system fails to follow the basic rules of chronological ordering.
- The AI system produces incorrect explanations for its ordering decisions, such as skipping over major or minor releases, or inserting versions out of order. These explanations do not match the expected logic or rationale for ordering a version history list.
- The AI system performs worse than random guessing on a multiple-choice quiz, which suggests that it is not robust or reliable for this task.
