### PR TITLE
Korean postposition 'jo-sa' particles

### DIFF
--- a/evals/registry/data/korean-postposition/samples.jsonl
+++ b/evals/registry/data/korean-postposition/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd7deb857ad17736a6b39a5492bf0572c7b5390387ab659aea964a1d6005650
+size 7599

--- a/evals/registry/evals/korean-postposition.yaml
+++ b/evals/registry/evals/korean-postposition.yaml
@@ -1,0 +1,9 @@
+korean-postposition:
+  id: korean-postposition.dev.v0
+  description: Evaluates GPT can identify correct postposition in a Korean sentence.
+  metrics: [accuracy]
+
+korean-postposition.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: korean-postposition/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

### Eval name

korean-postposition

### Eval description

The eval aims to assess the model's proficiency in identifying 'jo-sa', postposition particles that are added to words or phrases to indicate their grammatical function and clarify their relationships within a sentence of Korean words. To measure accuracy, the model is given a Korean sentence and the test utilizes Match.

### What makes this a useful eval?

Language Comprehension: Assessing a model's proficiency in recognizing 'jo-sa' particles requires it to comprehend the overall context and relationships between words within a Korean sentence. This evaluation task can provide valuable information about the model's language comprehension capabilities.

Sentence Parsing and Analysis: Identifying 'jo-sa' particles often involves parsing and analyzing the sentence structure. This evaluation can shed light on the model's ability to break down a sentence, identify different components, and determine their grammatical roles.

Error Analysis: By evaluating the model's performance on this task, we can identify specific areas where it may struggle, such as differentiating between similar particles or understanding specific contexts. This information can guide further model development and help improve its accuracy and comprehension in Korean.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [X] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [X] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [X] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [X] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should

- [X] Check that your data is in `evals/registry/data/{name}`
- [X] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [X] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [X] I have filled out all required fields of this form
- [X] I have used **Git LFS** for the Eval JSON data
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "The Korean language has a wide range of postposition particles called 'jo-sa' that play a crucial role in sentence structure. You will be given a sentence. Does the sentence use the correct 'jo-sa'? Answer with exactly one of the following: 'yes' or 'no'. Don't add anything else to the response.."}, {"role": "user", "content": "저희 음식점를 항상 방문해주셔서 감사합니다!"}], "ideal": "no"}
{"input": [{"role": "system", "content": "The Korean language has a wide range of postposition particles called 'jo-sa' that play a crucial role in sentence structure. You will be given a sentence. Does the sentence use the correct 'jo-sa'? Answer with exactly one of the following: 'yes' or 'no'. Don't add anything else to the response.."}, {"role": "user", "content": "믿음를 가지다."}], "ideal": "no"}
{"input": [{"role": "system", "content": "The Korean language has a wide range of postposition particles called 'jo-sa' that play a crucial role in sentence structure. You will be given a sentence. Does the sentence use the correct 'jo-sa'? Answer with exactly one of the following: 'yes' or 'no'. Don't add anything else to the response.."}, {"role": "user", "content": "만화를 재밌다."}], "ideal": "no"}
{"input": [{"role": "system", "content": "The Korean language has a wide range of postposition particles called 'jo-sa' that play a crucial role in sentence structure. You will be given a sentence. Does the sentence use the correct 'jo-sa'? Answer with exactly one of the following: 'yes' or 'no'. Don't add anything else to the response.."}, {"role": "user", "content": "나 피자의 좋아해"}], "ideal": "no"}
{"input": [{"role": "system", "content": "The Korean language has a wide range of postposition particles called 'jo-sa' that play a crucial role in sentence structure. You will be given a sentence. Does the sentence use the correct 'jo-sa'? Answer with exactly one of the following: 'yes' or 'no'. Don't add anything else to the response.."}, {"role": "user", "content": "이 컴퓨터 성능을 진짜 좋다!"}], "ideal": "no"}
{"input": [{"role": "system", "content": "The Korean language has a wide range of postposition particles called 'jo-sa' that play a crucial role in sentence structure. You will be given a sentence. Does the sentence use the correct 'jo-sa'? Answer with exactly one of the following: 'yes' or 'no'. Don't add anything else to the response.."}, {"role": "user", "content": "오늘 날씨를 좋네"}], "ideal": "no"}
  ```
</details>
