### PR TITLE
coq-editing: An eval for basic Coq proof handling

### DIFF
--- a/evals/registry/data/coq-editing/labeled-samples.jsonl
+++ b/evals/registry/data/coq-editing/labeled-samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca62465a32bb9eaa89cc0280feb333cf36cc2307d48e785d8ec3b3cfd3640ada
+size 135924

--- a/evals/registry/data/coq-editing/samples.jsonl
+++ b/evals/registry/data/coq-editing/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd23677f8a4fef1c788ea8da9aa1c11421e6e8844ca16a7868c653a9db1a5315
+size 50366

--- a/evals/registry/evals/coq-editing.yaml
+++ b/evals/registry/evals/coq-editing.yaml
@@ -1,0 +1,23 @@
+coq-editing:
+  id: coq-editing.dev.v0
+  description: Test the model's ability to correctly diagnose Coq error messages, and interpret and edit Coq code.
+  metrics: [accuracy]
+coq-editing.dev.v0:
+  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
+  args:
+    samples_jsonl: coq-editing/samples.jsonl
+    eval_type: cot_classify
+    modelgraded_spec: closedqa
+
+# a meta-evaluation of the above modelgraded eval
+# this example uses a labeled dataset with "completion" and "choice"
+coq-editing-meta:
+  id: coq-editing-meta.dev.v0
+  metrics: [accuracy]
+coq-editing-meta.dev.v0:
+  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
+  args:
+    samples_jsonl: coq-editing/labeled-samples.jsonl
+    eval_type: cot_classify
+    modelgraded_spec: closedqa
+    metaeval: true


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

### Eval name

coq-editing

### Eval description

Some basic tests of the model's ability to correctly diagnose Coq error messages, and interpret and edit Coq code.

### What makes this a useful eval?

GPT-4 seems quite good at coding in Python, but the feedback it can get from a Python interpreter on code correctness is quite limited.  By contrast, GPT-4 is quite bad at proving theorems.  The feedback GPT can get on (English) theorem proving is even more limited, to the point where I think it would be pretty hard to make an adequate theorem proving eval where GPT manages to pass the metaeval (correctly evaluating proofs) without simultaneously having the theorems be simple enough that it can trivially pass the eval (generating the proofs).

However, if we can get GPT to translate English proofs to a theorem prover like Coq, then we can get detailed high-quality feedback about the proof from the proof checker.  Alas, GPT-4 is nowhere near as good at Coq as it is at Python.

This eval is a rudimentary test of the model's ability to handle Coq on some simple tasks in this feedback loop where I've seen GPT-3.5-turbo and/or ChatGPT-4 fail, mostly in places where I believe GPT would have no trouble were the code in Python rather than Coq.

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world. **[Theme: proofs, translating them back and forth with Coq, integrating feedback from Coq]**
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval. **[I'm not convinced I got the rubric for the model-graded eval right, given that GPT-3.5-turbo is failing at more than 30% of the meta-evals -- maybe there's some simple prompt engineering that will make it pass the metaevals?]**
- [x] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

None of the other evals seem to be about Coq (or any other proof assistant for that matter).

Current stats on GPT-3.5-turbo:
```
[record.py:341] Final report: {'counts/Y': 6, 'counts/N': 9, 'score': 0.4}. Logged to /tmp/evallogs/230620232652PLYHKST4_gpt-3.5-turbo_coq-editing.jsonl
[2023-06-20 16:27:26,920] [oaieval.py:147] Final report:
[2023-06-20 16:27:26,920] [oaieval.py:149] counts/Y: 6
[2023-06-20 16:27:26,920] [oaieval.py:149] counts/N: 9
[2023-06-20 16:27:26,920] [oaieval.py:149] score: 0.4
[record.py:341] Final report: {'counts/N': 14, 'counts/Y': 18, 'score': 0.5625, 'metascore': 0.6875}. Logged to /tmp/evallogs/230620232727THIUXRNH_gpt-3.5-turbo_coq-editing-meta.jsonl
[2023-06-20 16:27:55,280] [oaieval.py:147] Final report:
[2023-06-20 16:27:55,280] [oaieval.py:149] counts/N: 14
[2023-06-20 16:27:55,280] [oaieval.py:149] counts/Y: 18
[2023-06-20 16:27:55,280] [oaieval.py:149] score: 0.5625
[2023-06-20 16:27:55,280] [oaieval.py:149] metascore: 0.6875
```

If, per chance, GPT-4 is capable of 90%+ of these tasks, I expect I can make them just a bit harder and get it to fail, based on what I've seen of ChatGPT-4.

## Eval structure 🏗️

Your eval should

- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval **[all data was generated by me, or GPT-3.5-turbo, or ChatGPT 4, or is the output of coqc.  Some inspiration was taken from www.codewars.com, but I think the reuse is minimal enough (mostly idea-based on what theorems to start with) that I'm not actually using data from them.]**

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- <strike>[] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push</strike>

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "TASK: Read the mathematical statement.\nIf the statement is true, describe a proof strategy.\nIf the statement is false, provide a counter-example and explain it.\nIf you can neither produce a counter-example nor a proof, indicate that you have no solution to this problem, and briefly describe the state of the art conjectures or results, if any."}, {"role": "user", "content": "For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$."}], "criteria": "The response asserts that the statement is true and describes a proof strategy."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nFORMAL PROOF:\nWe will prove that for any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\n\nLet $s : X \\to X$ be a section of $f$. This means that $f(s(x)) = x$ for all $x \\in X$.\n\nWe want to show that $s = f$. To do this, we will show that $s(x) = f(x)$ for all $x \\in X$.\n\nConsider an arbitrary element $x \\in X$. We have:\n\n$$f(s(x)) = x$$\n\nBecause $f$ is involutive, we know that $f(f(y)) = y$ for any $y \\in X$. So, we can apply $f$ to both sides of the equation:\n\n$$f(f(s(x))) = f(x)$$\n\nUsing the fact that $f$ is involutive, we get:\n\n$$s(x) = f(x)$$\n\nSince $x$ was arbitrary, this holds for all $x \\in X$. Therefore, $s = f$.\n\nThus, we have shown that for any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nTEMPLATE CODE:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma section_equal_involutive : forall {X} f s,\n  involutive f ->\n  cancel s f ->\n  forall x : X, f x = s x.\nProof. Admitted.\n\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma section_equal_involutive : forall {X} f s,\n  involutive f ->\n  cancel s f ->\n  forall x : X, f x = s x.\nProof.\n  move=> X f s H_inv H_can x.\n  rewrite -{1}(H_can x).\n  rewrite H_inv.\n  reflexivity.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 8, characters 6-8:\nError: Syntax error: [hyp] expected after 'move' (in [simple_tactic]).\n\nLine 8 is:\n  move=> X f s H_inv H_can x.\n\nCharacters 6-8 are `=>`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "criteria": "The answer explains that the error is a syntax error due to the SSReflect extension not being properly loaded due to a missing import of `ssreflect`, which is not the same as `ssr.ssrfun`.  Additionally, the answer should not mention `mathcomp`, should not suggest inserting spaces.  Answers suggesting using `intros` instead of `move=>` are also correct, as long as it does not claim that `move=>` / `=>` is invalid syntax in general."}
{"input": [{"role": "system", "content": "You are given template Coq code and a formal proof that misaligns with the template. Describe what went wrong, and suggest a fix. Write the entirety of the fixed code at the end of your response, including all relevant imports. Make sure the code you output contains all details and imports and is fully standalone."}, {"role": "user", "content": "TEMPLATE CODE:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma section_equal_involutive : forall {X} f s,\n  involutive f ->\n  cancel s f ->\n  forall x : X, f x = s x.\nProof. Admitted.\n\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nFrom Coq Require Import ssr.ssreflect.\n\nLemma section_equal_involutive : forall {X} f s,\n  involutive f ->\n  cancel s f ->\n  forall x : X, f x = s x.\nProof.\n  move=> X f s H_inv H_can x.\n  rewrite -{1}(H_can x).\n  rewrite H_inv.\n  reflexivity.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 4, characters 2-12:\nError: The reference involutive was not found in the current environment.\n\nLine 4 is:\n  involutive f ->\n\nCharacters 2-12 are `involutive`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION AND FIXED CODE:\n"}], "criteria": "The answer asserts that Coq could not find the definition for `involutive` and identifies that `involutive` is defined in `ssr.ssrfun` not `ssr.ssreflect`.  Additionally, the answer must contain a code block at the end that starts by importing both `ssreflect` (or `ssr.ssreflect`) and `ssrfun` (or `ssr.ssrfun`).  The code block *must not* contain any other requires/imports."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nFORMAL PROOF:\nLet $X$ be a set and $f : X \\to X$ be an involutive function. We will show that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\n\nCounter-example: Let $X = \\{0,1\\}$ and define $f : X \\to X$ by $f(0) = 1$ and $f(1) = 0$. Then $f$ is involutive, since $f(f(0)) = f(1) = 0$ and $f(f(1)) = f(0) = 1$. \n\nNow, we will show that there are two sections of $f$: the identity function $id_X$ and $f$ itself. \n\nFirst, let $id_X : X \\to X$ be the identity function, defined by $id_X(x) = x$ for all $x \\in X$. We can see that $id_X$ is a section of $f$ by checking that $f(id_X(0)) = f(0) = 1$ and $f(id_X(1)) = f(1) = 0$, which implies that $id_X$ satisfies the condition for being a section of $f$: $f \\circ id_X = id_X$.\n\nSecond, let $s : X \\to X$ be the function defined by $s(0) = 1$ and $s(1) = 0$. We can see that $s$ is also a section of $f$ by checking that $f(s(0)) = f(1) = 0$ and $f(s(1)) = f(0) = 1$, which implies that $s$ satisfies the condition for being a section of $f$: $f \\circ s = s$.\n\nHowever, $id_X$ and $f$ are not equal, since $id_X(0) = 0$ and $f(0) = 1$. Therefore, not every section of $f$ is equal to $f$. \n\nThus, we have shown that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\nTEMPLATE CODE:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma section_equal_involutive_counter_example : exists X f s,\n  involutive f /\\\n  cancel s f /\\\n  exists x : X, f x <> s x.\nProof. Admitted.\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma section_equal_involutive_counter_example : exists X f s,\n  involutive f /\\\n  cancel s f /\\\n  exists x : X, f x <> s x.\nProof.\n  exists bool, (fun b => negb b), (fun b => negb b).\n  split; try split.\n  - by move=> b; rewrite /involutive negb_involutive.\n  - by move=> b; rewrite /cancel.\n  - by exists false; rewrite /negb.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 10, characters 4-6:\nError: Syntax error: illegal begin of vernac.\n\nLine 10 is:\n  - by move=> b; rewrite /involutive negb_involutive.\n\nCharacters 4-6 are `by`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "criteria": "The answer explains that the error is a syntax error due to the SSReflect extension not being properly loaded due to a missing import of `ssreflect`, which is not the same as `ssr.ssrfun`.  The answer should say that the `by` tactical is defined in `ssreflect`."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nFORMAL PROOF:\nLet $X$ be a set and $f : X \\to X$ be an involutive function. We will show that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\n\nCounter-example: Let $X = \\{0,1\\}$ and define $f : X \\to X$ by $f(0) = 1$ and $f(1) = 0$. Then $f$ is involutive, since $f(f(0)) = f(1) = 0$ and $f(f(1)) = f(0) = 1$. \n\nNow, we will show that there are two sections of $f$: the identity function $id_X$ and $f$ itself. \n\nFirst, let $id_X : X \\to X$ be the identity function, defined by $id_X(x) = x$ for all $x \\in X$. We can see that $id_X$ is a section of $f$ by checking that $f(id_X(0)) = f(0) = 1$ and $f(id_X(1)) = f(1) = 0$, which implies that $id_X$ satisfies the condition for being a section of $f$: $f \\circ id_X = id_X$.\n\nSecond, let $s : X \\to X$ be the function defined by $s(0) = 1$ and $s(1) = 0$. We can see that $s$ is also a section of $f$ by checking that $f(s(0)) = f(1) = 0$ and $f(s(1)) = f(0) = 1$, which implies that $s$ satisfies the condition for being a section of $f$: $f \\circ s = s$.\n\nHowever, $id_X$ and $f$ are not equal, since $id_X(0) = 0$ and $f(0) = 1$. Therefore, not every section of $f$ is equal to $f$. \n\nThus, we have shown that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\nTEMPLATE CODE:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma section_equal_involutive_counter_example : exists X f s,\n  involutive f /\\\n  cancel s f /\\\n  exists x : X, f x <> s x.\nProof. Admitted.\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nFrom Coq Require Import ssreflect ssr.ssrfun.\n\nLemma section_equal_involutive_counter_example : exists X f s,\n  involutive f /\\\n  cancel s f /\\\n  exists x : X, f x <> s x.\nProof.\n  exists bool, (fun b => negb b), (fun b => negb b).\n  split; try split.\n  - by move=> b; rewrite /involutive negb_involutive.\n  - by move=> b; rewrite /cancel.\n  - by exists false; rewrite /negb.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 10, characters 37-52:\nError: The reference negb_involutive was not found in the current\nenvironment.\n\nLine 10 is:\n  - by move=> b; rewrite /involutive negb_involutive.\n\nCharacters 37-52 are `negb_involutive`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "criteria": "The answer either indicates that an explicit proof that `f` is an involution should be given in the code, as it is in the formal proof; or the answer indicates that `Coq.Bool.Bool` or `Bool` must be imported to access `negb_involutive`; or both.  The answer may suggest using `negbK` from `ssr.ssrbool` instead of `negb_involutive` from `Coq.Bool.Bool`, but it *must not* claim that `negb_involutive` is an invalid lemma name, that it is not in the standard library, etc."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, a translation of the formal proof into Coq code, and the error message and output. The output does not provide enough information to determine whether the error is in the translation from the formal proof to the code, or in the original formal proof. Describe what additional information is needed to determine which case applies. Describe what is required to get Coq to display this information. Then insert `Show`, `Print`, etc statements into the code to display the information. Print only the code with the inserted statements at the end of your response, including all relevant imports."}, {"role": "user", "content": "TASK: For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nFORMAL PROOF:\nLet $X$ be a set and $f : X \\to X$ be an involutive function. We will show that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\n\nCounter-example: Let $X = \\{0,1\\}$ and define $f : X \\to X$ by $f(0) = 1$ and $f(1) = 0$. Then $f$ is involutive, since $f(f(0)) = f(1) = 0$ and $f(f(1)) = f(0) = 1$. \n\nNow, we will show that there are two sections of $f$: the identity function $id_X$ and $f$ itself. \n\nFirst, let $id_X : X \\to X$ be the identity function, defined by $id_X(x) = x$ for all $x \\in X$. We can see that $id_X$ is a section of $f$ by checking that $f(id_X(0)) = f(0) = 1$ and $f(id_X(1)) = f(1) = 0$, which implies that $id_X$ satisfies the condition for being a section of $f$: $f \\circ id_X = id_X$.\n\nSecond, let $s : X \\to X$ be the function defined by $s(0) = 1$ and $s(1) = 0$. We can see that $s$ is also a section of $f$ by checking that $f(s(0)) = f(1) = 0$ and $f(s(1)) = f(0) = 1$, which implies that $s$ satisfies the condition for being a section of $f$: $f \\circ s = s$.\n\nHowever, $id_X$ and $f$ are not equal, since $id_X(0) = 0$ and $f(0) = 1$. Therefore, not every section of $f$ is equal to $f$. \n\nThus, we have shown that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nFrom Coq Require Import ssreflect ssrfun.\n\nLemma section_equal_involutive_counter_example : exists X f s,\n  involutive f /\\\n  cancel s f /\\\n  exists x : X, f x <> s x.\nProof.\n  exists bool, (fun b : bool => negb b), (fun b : bool => b).\n  split; [|split].\n  - move=> b; case: b. by []. by [].\n  - move=> b; case: b. by []. by [].\n  - exists true. by [].\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 11, characters 23-28:\nError: No applicable tactic.\n\nLine 11 is:\n  - move=> b; case: b. by []. by [].\n\nCharacters 23-28 are `by []`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nCODE WITH MORE DEBUGGING INFORMATION:\n"}], "criteria": "The answer inserts `Show.` between the first `move=> b; case: b.` and `by [].`.  The answer must not use `Show Proof`, `Show Goal`, `Show Context`, nor any other variant of `Show`.  The answer may use `Print`, but is not required to."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, a translation of the formal proof into Coq code, and the error message and output. The output does not provide enough information to determine whether the error is in the translation from the formal proof to the code, or in the original formal proof. Describe what additional information is needed to determine which case applies. Describe what is required to get Coq to display this information. Then insert `Show`, `Print`, etc statements into the code to display the information. Print only the code with the inserted statements at the end of your response, including all relevant imports."}, {"role": "user", "content": "TASK: For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nFORMAL PROOF:\nLet $X$ be a set and $f : X \\to X$ be an involutive function. We will show that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\n\nCounter-example: Let $X = \\{0,1\\}$ and define $f : X \\to X$ by $f(0) = 1$ and $f(1) = 0$. Then $f$ is involutive, since $f(f(0)) = f(1) = 0$ and $f(f(1)) = f(0) = 1$. \n\nNow, we will show that there are two sections of $f$: the identity function $id_X$ and $f$ itself. \n\nFirst, let $id_X : X \\to X$ be the identity function, defined by $id_X(x) = x$ for all $x \\in X$. We can see that $id_X$ is a section of $f$ by checking that $f(id_X(0)) = f(0) = 1$ and $f(id_X(1)) = f(1) = 0$, which implies that $id_X$ satisfies the condition for being a section of $f$: $f \\circ id_X = id_X$.\n\nSecond, let $s : X \\to X$ be the function defined by $s(0) = 1$ and $s(1) = 0$. We can see that $s$ is also a section of $f$ by checking that $f(s(0)) = f(1) = 0$ and $f(s(1)) = f(0) = 1$, which implies that $s$ satisfies the condition for being a section of $f$: $f \\circ s = s$.\n\nHowever, $id_X$ and $f$ are not equal, since $id_X(0) = 0$ and $f(0) = 1$. Therefore, not every section of $f$ is equal to $f$. \n\nThus, we have shown that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nFrom Coq Require Import ssreflect ssrfun.\n\nLemma section_equal_involutive_counter_example : exists X f s,\n  involutive f /\\\n  cancel s f /\\\n  exists x : X, f x <> s x.\nProof.\n  exists bool, (fun b : bool => negb b), (fun b : bool => b).\n  split; [|split].\n  - move=> b; case: b; by [].\n  - move=> b; case: b; by [].\n  - exists true. by [].\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 11, characters 23-28:\nError: No applicable tactic.\n\nLine 11 is:\n  - move=> b; case: b; by [].\n\nCharacters 23-28 are `by []`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nCODE WITH MORE DEBUGGING INFORMATION:\n"}], "criteria": "The answer either splits `; by [].` into `by []. by [].` and inserts `Show.` between the first `move=> b; case: b.` and `by [].`, or else constructs a tactic for displaying the context and goal and inserts this tactic between `move=> b; case: b;` and `by [].`  The answer must end the `move=> b; case b` with a `.` if `Show` is used.  Note that `case: b` creates two goals, so removing the `;` requires duplicating `by [].`.  The answer must define any context/goal display tactic it inserts, if using a tactic rather than `Show`.  The answer must not use `Show Proof`, `Show Goal`, `Show Context`, nor any other variant of `Show`.  The answer may use `Print`, but is not required to."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: The set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\nFORMAL PROOF:\nWe will prove that the set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\n\nLet $\\mathbb{N}$ be the set of natural numbers and $\\mathbb{N} \\sqcup \\mathbb{N}$ be the disjoint union of two copies of the set of natural numbers.\n\nConsider the function $f: \\mathbb{N} \\rightarrow \\mathbb{N} \\sqcup \\mathbb{N}$ defined as follows:\n\n$f(n) = \\begin{cases}\n1\\cdot n/2 & \\text{if } n \\text{ is even} \\\\\n2\\cdot(n-1)/2 & \\text{if } n \\text{ is odd}\n\\end{cases}$\n\nWe will now prove that $f$ is a bijection.\n\n1. **Injective (One-to-one)**:\n\nLet $n_1, n_2 \\in \\mathbb{N}$ such that $f(n_1) = f(n_2)$. We need to show that $n_1 = n_2$.\n\nIf both $n_1$ and $n_2$ are even, then $f(n_1) = n_1/2$ and $f(n_2) = n_2/2$. Therefore, $n_1/2 = n_2/2$, which implies that $n_1 = n_2$.\n\nIf both $n_1$ and $n_2$ are odd, then $f(n_1) = 2\\cdot(n_1-1)/2 = n_1-1$ and $f(n_2) = 2\\cdot(n_2-1)/2 = n_2-1$. Therefore, $n_1-1 = n_2-1$, which implies that $n_1 = n_2$.\n\nIf $n_1$ is even and $n_2$ is odd (or vice versa), then $f(n_1)$ and $f(n_2)$ belong to different copies of $\\mathbb{N}$ in $\\mathbb{N} \\sqcup \\mathbb{N}$, and hence cannot be equal.\n\nTherefore, $f$ is injective.\n\n2. **Surjective (Onto)**:\n\nLet $m \\in \\mathbb{N} \\sqcup \\mathbb{N}$. We need to find $n \\in \\mathbb{N}$ such that $f(n) = m$.\n\nIf $m$ belongs to the first copy of $\\mathbb{N}$ in $\\mathbb{N} \\sqcup \\mathbb{N}$, then $m = 1\\cdot k$ for some $k \\in \\mathbb{N}$. Let $n = 2k$. Then $n$ is even and $f(n) = n/2 = k = m$.\n\nIf $m$ belongs to the second copy of $\\mathbb{N}$ in $\\mathbb{N} \\sqcup \\mathbb{N}$, then $m = 2\\cdot k$ for some $k \\in \\mathbb{N}$. Let $n = 2k+1$. Then $n$ is odd and $f(n) = 2\\cdot(n-1)/2 = n-1 = 2k = m$.\n\nTherefore, $f$ is surjective.\n\nSince $f$ is both injective and surjective, it is a bijection and hence an isomorphism between $\\mathbb{N}$ and $\\mathbb{N} \\sqcup \\mathbb{N}$. Therefore, the set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\nTEMPLATE CODE:\n```coq\nRequire Import Arith.\n\nDefinition iso (A B : Type) := { f : A -> B & { g : B -> A | (forall x, g (f x) = x) /\\ (forall x, f (g x) = x) } }.\n\nTheorem nat_iso_natpnat : iso nat (nat + nat).\nProof. Admitted.\n\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nRequire Import Arith.\n\nDefinition iso (A B : Type) := { f : A -> B & { g : B -> A | (forall x, g (f x) = x) /\\ (forall x, f (g x) = x) } }.\n\nDefinition f (n : nat) : nat + nat :=\n  match even_odd_dec n with\n  | left H => inl (n / 2)\n  | right H => inr ((n - 1) / 2)\n  end.\n\nDefinition g (m : nat + nat) : nat :=\n  match m with\n  | inl k => 2 * k\n  | inr k => 2 * k + 1\n  end.\n\nLemma fg_id : forall n : nat, g (f n) = n.\nProof.\n  intros n. unfold f, g.\n  destruct (even_odd_dec n) as [He | Ho].\n  - rewrite Nat.div_mul; try lia. reflexivity.\n  - rewrite Nat.div_add_l; try lia. reflexivity.\nQed.\n\nLemma gf_id : forall m : nat + nat, f (g m) = m.\nProof.\n  intros [k | k].\n  - unfold f, g. rewrite Nat.mul_comm. simpl. rewrite Nat.div_mul; try lia. reflexivity.\n  - unfold f, g. simpl. rewrite Nat.mul_comm. rewrite Nat.add_comm. rewrite Nat.add_sub. rewrite Nat.div_add_l; try lia. reflexivity.\nQed.\n\nTheorem nat_iso_natpnat : iso nat (nat + nat).\nProof.\n  exists f. exists g. split.\n  - apply fg_id.\n  - apply gf_id.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 6, characters 8-20:\nError: The reference even_odd_dec was not found in the current environment.\n\nLine 6 is:\n  match even_odd_dec n with\n\nCharacters 8-20 are `even_odd_dec`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "criteria": "The answer indicates that `even_odd_dec` is not found.  The answer either indicates that `even_odd_dec` can be used by importing `Coq.Arith.Even`, or indicates that `even_odd_dec` used to be available in `Coq.Arith.Even` but has been removed.  The answer may suggest using `Nat.even` or `Nat.odd`, but does not have to."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, a translation of the formal proof into Coq code, and the error message and output. The output does not provide enough information to determine whether the error is in the translation from the formal proof to the code, or in the original formal proof. Describe what additional information is needed to determine which case applies. Describe what is required to get Coq to display this information. Then insert `Show`, `Print`, etc statements into the code to display the information. Print only the code with the inserted statements at the end of your response, including all relevant imports."}, {"role": "user", "content": "TASK: The set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\nFORMAL PROOF:\nLet $\\mathbb{N}$ be the set of natural numbers and $\\mathbb{N} \\sqcup \\mathbb{N}$ be the disjoint union of two copies of the set of natural numbers.\n\nConsider the function $f: \\mathbb{N} \\rightarrow \\mathbb{N} \\sqcup \\mathbb{N}$ defined as follows:\n\n$f(n) = \\begin{cases}\n1\\cdot n/2 & \\text{if } n \\text{ is even} \\\\\n2\\cdot(n-1)/2 & \\text{if } n \\text{ is odd}\n\\end{cases}$\n\nWe will now prove that $f$ is a bijection.\n\n1. **Injective (One-to-one)**:\n\nAssume $f(n_1) = f(n_2)$. We need to show that $n_1 = n_2$.\n\nCase 1: $n_1$ and $n_2$ are both even.\nIn this case, we have $f(n_1) = 1\\cdot n_1/2$ and $f(n_2) = 1\\cdot n_2/2$. Since $f(n_1) = f(n_2)$, we have $1\\cdot n_1/2 = 1\\cdot n_2/2$. Multiplying both sides by $2$ gives us $n_1 = n_2$.\n\nCase 2: $n_1$ and $n_2$ are both odd.\nIn this case, we have $f(n_1) = 2\\cdot(n_1-1)/2$ and $f(n_2) = 2\\cdot(n_2-1)/2$. Since $f(n_1) = f(n_2)$, we have $2\\cdot(n_1-1)/2 = 2\\cdot(n_2-1)/2$. Simplifying, we get $n_1-1 = n_2-1$, which implies $n_1 = n_2$.\n\nCase 3: $n_1$ is even and $n_2$ is odd, or vice versa.\nIn this case, $f(n_1)$ and $f(n_2)$ belong to different copies of $\\mathbb{N}$. Therefore, $f(n_1) \\neq f(n_2)$.\n\nSince $n_1 = n_2$ in all possible cases, we conclude that $f$ is injective.\n\n2. **Surjective (Onto)**:\n\nLet $m$ be an element of $\\mathbb{N} \\sqcup \\mathbb{N}$. We need to show that there exists $n$ in $\\mathbb{N}$ such that $f(n) = m$.\n\nCase 1: $m$ belongs to the first copy of $\\mathbb{N}$.\nIn this case, $m = 1\\cdot n/2$ for some even natural number $n$. Let $n = 2m$. Then, $f(n) = 1\\cdot n/2 = 1\\cdot (2m)/2 = m$. Therefore, $f(n) = m$.\n\nCase 2: $m$ belongs to the second copy of $\\mathbb{N}$.\nIn this case, $m = 2\\cdot(n-1)/2$ for some odd natural number $n$. Let $n = 2m+1$. Then, $f(n) = 2\\cdot(n-1)/2 = 2\\cdot((2m+1)-1)/2 = m$. Therefore, $f(n) = m$.\n\nSince every element of $\\mathbb{N} \\sqcup \\mathbb{N}$ has a preimage in $\\mathbb{N}$, we conclude that $f$ is surjective.\n\nSince $f$ is both injective and surjective, it is a bijection. Therefore, $\\mathbb{N}$ is isomorphic to $\\mathbb{N} \\sqcup \\mathbb{N}$.\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nRequire Import Arith.\nRequire Import Nat.\n\nDefinition iso (A B : Type) := { f : A -> B & { g : B -> A | (forall x, g (f x) = x) /\\ (forall x, f (g x) = x) } }.\n\nDefinition f (n : nat) : nat + nat :=\n  match Nat.even n with\n  | true => inl (n / 2)\n  | false => inr ((n - 1) / 2)\n  end.\n\nDefinition g (m : nat + nat) : nat :=\n  match m with\n  | inl n => 2 * n\n  | inr n => 2 * n + 1\n  end.\n\nLemma f_g_inverse : forall n, g (f n) = n.\nProof.\n  intros n.\n  unfold f, g.\n  destruct (Nat.even n) eqn: Hn.\n  - rewrite Nat.div_mul; auto.\n    apply Nat.even_spec in Hn. exact Hn.\n  - rewrite Nat.sub_1_r.\n    rewrite Nat.add_comm.\n    rewrite Nat.div_add; auto.\n    apply Nat.negb_true_iff in Hn.\n    apply Nat.odd_spec in Hn. exact Hn.\nQed.\n\nLemma g_f_inverse : forall m, f (g m) = m.\nProof.\n  intros m.\n  unfold f, g.\n  destruct m as [n | n].\n  - rewrite Nat.mul_comm.\n    rewrite Nat.div_mul; auto.\n    apply Nat.even_spec. exists n. reflexivity.\n  - rewrite Nat.mul_comm.\n    rewrite Nat.div_add; auto.\n    rewrite Nat.sub_1_r.\n    rewrite Nat.add_comm.\n    rewrite Nat.div_add; auto.\n    apply Nat.odd_spec. exists n. reflexivity.\nQed.\n\nTheorem nat_iso_natpnat : iso nat (nat + nat).\nProof.\n  exists f.\n  exists g.\n  split.\n  - apply f_g_inverse.\n  - apply g_f_inverse.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 23, characters 4-23:\nError:\nFound no subterm matching \"?M1064 * ?M1065 / ?M1065\" in the current goal.\n\nLine 23 is:\n  - rewrite Nat.div_mul; auto.\n\nCharacters 4-23 are `rewrite Nat.div_mul`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nCODE WITH MORE DEBUGGING INFORMATION:\n"}], "criteria": "The answer should contain a block of Coq code which inserts `Show.` after the `-` after `destruct (Nat.even n) eqn: Hn.`, but before `rewrite Nat.div_mul; auto.`, in `Lemma f_g_inverse`.  Inserting `Show` after `rewrite Nat.div_mul; auto.` is not adequate.  The answer must not use `Show Goal`, `Show Context`, `Show Proof`, nor any other variant of `Show`.  Using `Print` is okay.  The answer *must* contain a `Require Import` for `Arith`, a definition of `iso`, definitions of `f` and `g`, and proofs of lemmas `f_g_inverse`, `g_f_inverse`, and `nat_iso_natprod`.  The answer must not be missing any of these components."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: The set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\nFORMAL PROOF:\nLet $\\mathbb{N}$ be the set of natural numbers and $\\mathbb{N} \\sqcup \\mathbb{N}$ be the disjoint union of two copies of the set of natural numbers.\n\nConsider the function $f: \\mathbb{N} \\rightarrow \\mathbb{N} \\sqcup \\mathbb{N}$ defined as follows:\n\n$f(n) = \\begin{cases}\n1\\cdot n/2 & \\text{if } n \\text{ is even} \\\\\n2\\cdot(n-1)/2 & \\text{if } n \\text{ is odd}\n\\end{cases}$\n\nWe will now prove that $f$ is a bijection.\n\n1. **Injective (One-to-one)**:\n\nAssume $f(n_1) = f(n_2)$. We need to show that $n_1 = n_2$.\n\nCase 1: $n_1$ and $n_2$ are both even.\nIn this case, we have $f(n_1) = 1\\cdot n_1/2$ and $f(n_2) = 1\\cdot n_2/2$. Since $f(n_1) = f(n_2)$, we have $1\\cdot n_1/2 = 1\\cdot n_2/2$. Multiplying both sides by $2$ gives us $n_1 = n_2$.\n\nCase 2: $n_1$ and $n_2$ are both odd.\nIn this case, we have $f(n_1) = 2\\cdot(n_1-1)/2$ and $f(n_2) = 2\\cdot(n_2-1)/2$. Since $f(n_1) = f(n_2)$, we have $2\\cdot(n_1-1)/2 = 2\\cdot(n_2-1)/2$. Simplifying, we get $n_1-1 = n_2-1$, which implies $n_1 = n_2$.\n\nCase 3: $n_1$ is even and $n_2$ is odd, or vice versa.\nIn this case, $f(n_1)$ and $f(n_2)$ belong to different copies of $\\mathbb{N}$. Therefore, $f(n_1) \\neq f(n_2)$.\n\nSince $n_1 = n_2$ in all possible cases, we conclude that $f$ is injective.\n\n2. **Surjective (Onto)**:\n\nLet $m$ be an element of $\\mathbb{N} \\sqcup \\mathbb{N}$. We need to show that there exists $n$ in $\\mathbb{N}$ such that $f(n) = m$.\n\nCase 1: $m$ belongs to the first copy of $\\mathbb{N}$.\nIn this case, $m = 1\\cdot n/2$ for some even natural number $n$. Let $n = 2m$. Then, $f(n) = 1\\cdot n/2 = 1\\cdot (2m)/2 = m$. Therefore, $f(n) = m$.\n\nCase 2: $m$ belongs to the second copy of $\\mathbb{N}$.\nIn this case, $m = 2\\cdot(n-1)/2$ for some odd natural number $n$. Let $n = 2m+1$. Then, $f(n) = 2\\cdot(n-1)/2 = 2\\cdot((2m+1)-1)/2 = m$. Therefore, $f(n) = m$.\n\nSince every element of $\\mathbb{N} \\sqcup \\mathbb{N}$ has a preimage in $\\mathbb{N}$, we conclude that $f$ is surjective.\n\nSince $f$ is both injective and surjective, it is a bijection. Therefore, $\\mathbb{N}$ is isomorphic to $\\mathbb{N} \\sqcup \\mathbb{N}$.\nTEMPLATE CODE:\n```coq\nRequire Import Arith.\n\nDefinition iso (A B : Type) := { f : A -> B & { g : B -> A | (forall x, g (f x) = x) /\\ (forall x, f (g x) = x) } }.\n\nTheorem nat_iso_natpnat : iso nat (nat + nat).\nProof. Admitted.\n\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nRequire Import Arith.\nRequire Import Nat.\n\nDefinition iso (A B : Type) := { f : A -> B & { g : B -> A | (forall x, g (f x) = x) /\\ (forall x, f (g x) = x) } }.\n\nDefinition f (n : nat) : nat + nat :=\n  match Nat.even n with\n  | true => inl (n / 2)\n  | false => inr ((n - 1) / 2)\n  end.\n\nDefinition g (m : nat + nat) : nat :=\n  match m with\n  | inl n => 2 * n\n  | inr n => 2 * n + 1\n  end.\n\nLemma f_g_inverse : forall n, g (f n) = n.\nProof.\n  intros n.\n  unfold f, g.\n  destruct (Nat.even n) eqn: Hn.\n  - Show. rewrite Nat.div_mul; auto.\n    apply Nat.even_spec in Hn. exact Hn.\n  - rewrite Nat.sub_1_r.\n    rewrite Nat.add_comm.\n    rewrite Nat.div_add; auto.\n    apply Nat.negb_true_iff in Hn.\n    apply Nat.odd_spec in Hn. exact Hn.\nQed.\n\nLemma g_f_inverse : forall m, f (g m) = m.\nProof.\n  intros m.\n  unfold f, g.\n  destruct m as [n | n].\n  - rewrite Nat.mul_comm.\n    rewrite Nat.div_mul; auto.\n    apply Nat.even_spec. exists n. reflexivity.\n  - rewrite Nat.mul_comm.\n    rewrite Nat.div_add; auto.\n    rewrite Nat.sub_1_r.\n    rewrite Nat.add_comm.\n    rewrite Nat.div_add; auto.\n    apply Nat.odd_spec. exists n. reflexivity.\nQed.\n\nTheorem nat_iso_natpnat : iso nat (nat + nat).\nProof.\n  exists f.\n  exists g.\n  split.\n  - apply f_g_inverse.\n  - apply g_f_inverse.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\n1 goal\n  \n  n : nat\n  Hn : Nat.even n = true\n  ============================\n  2 * (n / 2) = n\nFile \"./Solution.v\", line 23, characters 10-29:\nError:\nFound no subterm matching \"?M1064 * ?M1065 / ?M1065\" in the current goal.\n\nLine 23 is:\n  - Show. rewrite Nat.div_mul; auto.\n\nCharacters 10-29 are `rewrite Nat.div_mul`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "criteria": "The answer indicates that `Nat.div_mul` applies to goals of the form `a * b / b = a`, which is `(a * b) / b`.  The answer should somehow indicate that this is different from `2 * (n / 2)` or `a * (b / a)` or `b * (a / b)`, which is what the goal contains."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: The set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$. Isomorphism here means that we have functions $f$ and $g$ such that $g \\circ f = \\mathrm{id}$ and $f \\circ g = \\mathrm{id}$.\nFORMAL PROOF:\nWe will prove that the set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\n\nTo do this, we will define two functions $f : \\mathbb{N} \\to \\mathbb{N} \\sqcup \\mathbb{N}$ and $g : \\mathbb{N} \\sqcup \\mathbb{N} \\to \\mathbb{N}$ and show that they satisfy the conditions for isomorphism.\n\nLet's define the function $f : \\mathbb{N} \\to \\mathbb{N} \\sqcup \\mathbb{N}$ as follows:\n\n$$f(n) =\n\\begin{cases}\n(1, m), & \\text{if } n = 2m, \\\\\n(2, m), & \\text{if } n = 2m-1,\n\\end{cases}\n$$\n\nwhere $(1, m)$ and $(2, m)$ are elements in the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\n\nNow, let's define the function $g : \\mathbb{N} \\sqcup \\mathbb{N} \\to \\mathbb{N}$ as follows:\n\n$$g(i, m) =\n\\begin{cases}\n2m, & \\text{if } i = 1, \\\\\n2m-1, & \\text{if } i = 2.\n\\end{cases}\n$$\n\nWe will now show that $f$ and $g$ satisfy the conditions for isomorphism.\n\nFirst, we will show that $g \\circ f = \\mathrm{id}_\\mathbb{N}$.\n\nLet $n \\in \\mathbb{N}$. We need to show that $(g \\circ f)(n) = n$.\n\nIf $n$ is even, i.e., $n = 2m$ for some $m \\in \\mathbb{N}$, then $(g \\circ f)(n) = g(f(n)) = g((1, m)) = 2m$. This shows that $(g \\circ f)(n) = n$.\n\nIf $n$ is odd, i.e., $n = 2m-1$ for some $m \\in \\mathbb{N}$, then $(g \\circ f)(n) = g(f(n)) = g((2, m)) = 2m-1$. This also shows that $(g \\circ f)(n) = n$.\n\nTherefore, we have shown that $g \\circ f = \\mathrm{id}_\\mathbb{N}$.\n\nNext, we will show that $f \\circ g = \\mathrm{id}_{\\mathbb{N} \\sqcup \\mathbb{N}}$.\n\nLet $(i, m) \\in \\mathbb{N} \\sqcup \\mathbb{N}$. We need to show that $(f \\circ g)(i, m) = (i, m)$.\n\nIf $i = 1$, then $(f \\circ g)(i, m) = f(g(i, m)) = f(2m) = (1, m)$. This shows that $(f \\circ g)(i, m) = (i, m)$.\n\nIf $i = 2$, then $(f \\circ g)(i, m) = f(g(i, m)) = f(2m-1) = (2, m)$. This also shows that $(f \\circ g)(i, m) = (i, m)$.\n\nTherefore, we have shown that $f \\circ g = \\mathrm{id}_{\\mathbb{N} \\sqcup \\mathbb{N}}$.\n\nSince we have shown that $g \\circ f = \\mathrm{id}_\\mathbb{N}$ and $f \\circ g = \\mathrm{id}_{\\mathbb{N} \\sqcup \\mathbb{N}}$, we can conclude that $\\mathbb{N}$ is isomorphic to $\\mathbb{N} \\sqcup \\mathbb{N}$.\nTEMPLATE CODE:\n```coq\nRequire Import Arith.\n\nDefinition iso (A B : Type) := { f : A -> B & { g : B -> A | (forall x, g (f x) = x) /\\ (forall x, f (g x) = x) } }.\n\nTheorem nat_iso_natpnat : iso nat (nat + nat).\nProof. Admitted.\n\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nRequire Import Arith.\n\nDefinition iso (A B : Type) := { f : A -> B & { g : B -> A | (forall x, g (f x) = x) /\\ (forall x, f (g x) = x) } }.\n\nDefinition f (n : nat) : nat + nat :=\n  match even_odd_dec n with\n  | left H => inl (div2 n)\n  | right H => inr (div2 (pred n))\n  end.\n\nDefinition g (x : nat + nat) : nat :=\n  match x with\n  | inl m => 2 * m\n  | inr m => 2 * m + 1\n  end.\n\nTheorem nat_iso_natpnat : iso nat (nat + nat).\nProof.\n  exists f.\n  exists g.\n  split.\n  - intros n.\n    destruct (even_odd_dec n) as [H | H].\n    + unfold g, f.\n      rewrite even_double.\n      reflexivity.\n    + unfold g, f.\n      rewrite odd_double_pred.\n      reflexivity.\n  - intros x.\n    destruct x as [m | m].\n    + unfold f, g.\n      rewrite double_div2.\n      reflexivity.\n    + unfold f, g.\n      rewrite double_div2_succ.\n      reflexivity.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 6, characters 8-20:\nError: The reference even_odd_dec was not found in the current environment.\n\nLine 6 is:\n  match even_odd_dec n with\n\nCharacters 8-20 are `even_odd_dec`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "criteria": "The answer indicates that `even_odd_dec` is not found.  The answer either indicates that `even_odd_dec` can be used by importing `Coq.Arith.Even`, or indicates that `even_odd_dec` used to be available in `Coq.Arith.Even` but has been removed.  The answer may suggest using `Nat.even` or `Nat.odd`, but does not have to."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, a translation of the formal proof into Coq code, and the error message and output. The output does not provide enough information to determine whether the error is in the translation from the formal proof to the code, or in the original formal proof. Describe what additional information is needed to determine which case applies. Describe what is required to get Coq to display this information. Then insert `Show`, `Print`, etc statements into the code to display the information. Print only the code with the inserted statements at the end of your response, including all relevant imports."}, {"role": "user", "content": "TASK: The set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$. Isomorphism here means that we have functions $f$ and $g$ such that $g \\circ f = \\mathrm{id}$ and $f \\circ g = \\mathrm{id}$.\nFORMAL PROOF:\nWe will prove that the set of natural numbers $\\mathbb{N}$ is isomorphic to the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\n\nTo do this, we will define two functions $f : \\mathbb{N} \\to \\mathbb{N} \\sqcup \\mathbb{N}$ and $g : \\mathbb{N} \\sqcup \\mathbb{N} \\to \\mathbb{N}$ and show that they satisfy the conditions for isomorphism.\n\nLet's define the function $f : \\mathbb{N} \\to \\mathbb{N} \\sqcup \\mathbb{N}$ as follows:\n\n$$f(n) =\n\\begin{cases}\n(1, m), & \\text{if } n = 2m, \\\\\n(2, m), & \\text{if } n = 2m-1,\n\\end{cases}\n$$\n\nwhere $(1, m)$ and $(2, m)$ are elements in the disjoint union $\\mathbb{N} \\sqcup \\mathbb{N}$.\n\nNow, let's define the function $g : \\mathbb{N} \\sqcup \\mathbb{N} \\to \\mathbb{N}$ as follows:\n\n$$g(i, m) =\n\\begin{cases}\n2m, & \\text{if } i = 1, \\\\\n2m-1, & \\text{if } i = 2.\n\\end{cases}\n$$\n\nWe will now show that $f$ and $g$ satisfy the conditions for isomorphism.\n\nFirst, we will show that $g \\circ f = \\mathrm{id}_\\mathbb{N}$.\n\nLet $n \\in \\mathbb{N}$. We need to show that $(g \\circ f)(n) = n$.\n\nIf $n$ is even, i.e., $n = 2m$ for some $m \\in \\mathbb{N}$, then $(g \\circ f)(n) = g(f(n)) = g((1, m)) = 2m$. This shows that $(g \\circ f)(n) = n$.\n\nIf $n$ is odd, i.e., $n = 2m-1$ for some $m \\in \\mathbb{N}$, then $(g \\circ f)(n) = g(f(n)) = g((2, m)) = 2m-1$. This also shows that $(g \\circ f)(n) = n$.\n\nTherefore, we have shown that $g \\circ f = \\mathrm{id}_\\mathbb{N}$.\n\nNext, we will show that $f \\circ g = \\mathrm{id}_{\\mathbb{N} \\sqcup \\mathbb{N}}$.\n\nLet $(i, m) \\in \\mathbb{N} \\sqcup \\mathbb{N}$. We need to show that $(f \\circ g)(i, m) = (i, m)$.\n\nIf $i = 1$, then $(f \\circ g)(i, m) = f(g(i, m)) = f(2m) = (1, m)$. This shows that $(f \\circ g)(i, m) = (i, m)$.\n\nIf $i = 2$, then $(f \\circ g)(i, m) = f(g(i, m)) = f(2m-1) = (2, m)$. This also shows that $(f \\circ g)(i, m) = (i, m)$.\n\nTherefore, we have shown that $f \\circ g = \\mathrm{id}_{\\mathbb{N} \\sqcup \\mathbb{N}}$.\n\nSince we have shown that $g \\circ f = \\mathrm{id}_\\mathbb{N}$ and $f \\circ g = \\mathrm{id}_{\\mathbb{N} \\sqcup \\mathbb{N}}$, we can conclude that $\\mathbb{N}$ is isomorphic to $\\mathbb{N} \\sqcup \\mathbb{N}$.\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\n(* 1 *) Require Import Arith.\n(* 2 *) Require Import PeanoNat.\n(* 3 *) \n(* 4 *) Definition iso (A B : Type) := { f : A -> B & { g : B -> A | (forall x, g (f x) = x) /\\ (forall x, f (g x) = x) } }.\n(* 5 *) \n(* 6 *) Definition f (n : nat) : nat + nat :=\n(* 7 *)   if Nat.even n then inl (Nat.div2 n)\n(* 8 *)   else inr (Nat.div2 (Nat.pred n)).\n(* 9 *) \n(* 10 *) Definition g (x : nat + nat) : nat :=\n(* 11 *)   match x with\n(* 12 *)   | inl m => 2 * m\n(* 13 *)   | inr m => 2 * m + 1\n(* 14 *)   end.\n(* 15 *) \n(* 16 *) Theorem nat_iso_natpnat : iso nat (nat + nat).\n(* 17 *) Proof.\n(* 18 *)   exists f.\n(* 19 *)   exists g.\n(* 20 *)   split.\n(* 21 *)   - intros n.\n(* 22 *)     unfold g, f.\n(* 23 *)     case_eq (Nat.even n); intro H.\n(* 24 *)     + rewrite <- Nat.even_spec in H.\n(* 25 *)       rewrite Nat.div2_double. reflexivity. assumption.\n(* 26 *)     + rewrite <- Nat.negb_even in H.\n(* 27 *)       rewrite <- Nat.even_spec in H.\n(* 28 *)       rewrite Nat.div2_succ_double. reflexivity. assumption.\n(* 29 *)   - intros x.\n(* 30 *)     destruct x as [m | m].\n(* 31 *)     + unfold f, g.\n(* 32 *)       rewrite Nat.double_twice. reflexivity.\n(* 33 *)     + unfold f, g.\n(* 34 *)       rewrite Nat.succ_double_twice. reflexivity.\n(* 35 *) Qed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 24, characters 15-44:\nError: Found no subterm matching \"Nat.Even ?n\" in the current goal.\n\nLine 24 is:\n(* 24 *)     + rewrite <- Nat.even_spec in H.\n\nCharacters 15-44 are `rewrite <- Nat.even_spec in H`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nCODE WITH MORE DEBUGGING INFORMATION:\n"}], "criteria": "The answer has a Coq code block that imports `Arith` and `PeanoNat`, defines `iso`, `f`, `g`, and in the theorem `nat_iso_natpnat`, after the `+` after `case_eq (Nat.even n); intro H.`, the answer inserts `Show.` before `rewrite <- Nat.even_spec in H.`.  The answer *must not* be missing any of these pieces.  The answer must not have removed the `+` after `case_eq (Nat.even n); intro H.`. The answer must not use `Show Proof`, `Show Goal`, `Show Context`, or any other variant of `Show`.  However, using `Check`, `About`, and `Print` are okay (but not required)."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nFORMAL PROOF:\nLet $X$ be a set and $f : X \\to X$ be an involutive function. We will show that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\n\nCounter-example: Let $X = \\{0,1\\}$ and define $f : X \\to X$ by $f(0) = 1$ and $f(1) = 0$. Then $f$ is involutive, since $f(f(0)) = f(1) = 0$ and $f(f(1)) = f(0) = 1$. \n\nNow, we will show that there are two sections of $f$: the identity function $id_X$ and $f$ itself. \n\nFirst, let $id_X : X \\to X$ be the identity function, defined by $id_X(x) = x$ for all $x \\in X$. We can see that $id_X$ is a section of $f$ by checking that $f(id_X(0)) = f(0) = 1$ and $f(id_X(1)) = f(1) = 0$, which implies that $id_X$ satisfies the condition for being a section of $f$: $f \\circ id_X = id_X$.\n\nSecond, let $s : X \\to X$ be the function defined by $s(0) = 1$ and $s(1) = 0$. We can see that $s$ is also a section of $f$ by checking that $f(s(0)) = f(1) = 0$ and $f(s(1)) = f(0) = 1$, which implies that $s$ satisfies the condition for being a section of $f$: $f \\circ s = s$.\n\nHowever, $id_X$ and $f$ are not equal, since $id_X(0) = 0$ and $f(0) = 1$. Therefore, not every section of $f$ is equal to $f$. \n\nThus, we have shown that the statement \"every section $s : X \\to X$ of $f$ is equal to $f$\" is false by providing a counter-example.\nTEMPLATE CODE:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma counter_example : exists X (f : X -> X),\n  involutive f /\\\n  exists s : X -> X, cancel f s /\\ s <> f.\nProof. Admitted.\n\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma counter_example : exists X (f : X -> X),\n  involutive f /\\\n  exists s : X -> X, cancel f s /\\ s <> f.\nProof.\n  exists bool, (fun b => negb b).\n  split; unfold involutive; intros; apply/boolP; case: x; reflexivity.\n  exists (fun b => negb b); split; unfold cancel, involutive; intros; apply/boolP; case: x; reflexivity.\n  by move=> H; apply/boolP; rewrite -[f true]/(negb false) H.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 8, characters 41-42:\nError:\nSyntax error: [constr_with_bindings_arg] expected after 'apply' (in [simple_tactic]).\n\nLine 8 is:\n  split; unfold involutive; intros; apply/boolP; case: x; reflexivity.\n\nCharacters 41-42 are `/`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "criteria": "The answer explains that the error is a syntax error due to the SSReflect extension not being properly loaded due to a missing import of `ssreflect`, which is not the same as `ssr.ssrfun`.  Additionally, the answer should not mention `mathcomp`, should not suggest inserting spaces.  The answer should not indicate that `apply/lemma`, `apply/`, `apply/boolP`, `/` is invalid syntax in general."}
{"input": [{"role": "system", "content": "Act as a Coq command line proof checker.  You will get a code block containing a Coq file, and you will respond with only the output of `coqc` on the command line.  Predict the output to the best of your ability, and do not include anything but the output of `coqc` in your response.  Assume all imports are present in the environment."}, {"role": "user", "content": "```coq\n(* 1 *) From Coq Require Import ssr.ssrfun.\n(* 2 *)\n(* 3 *) Lemma counter_example : exists X (f : X -> X),\n(* 4 *)  involutive f /\\\n(* 5 *)  exists s : X -> X, cancel f s /\\ s <> f.\n(* 6 *) Proof.\n(* 7 *)  exists bool, (fun b => negb b).\n(* 8 *)  split; unfold involutive; intros; apply/boolP; case: x; reflexivity.\n(* 9 *)  exists (fun b => negb b); split; unfold cancel, involutive; intros; apply/boolP; case: x; reflexivity.\n(* 10 *)  by move=> H; apply/boolP; rewrite -[f true]/(negb false) H.\n(* 11 *) Qed.\n```"}], "criteria": "The answer contains an error message of the form `File \"<some file>\", line 8, characters 48-49:`.  The error message must indicate exactly `line 8, characters 48-49`.  The error should be a Syntax error, and should indicate that something is \"expected after 'apply'\"."}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: In the context of dependent type theory, there exist two unequal types.\nFORMAL PROOF:\nLet `Empty` be the empty type and `Unit` be the unit type.\n\nWe claim that `Empty` and `Unit` are unequal types.\n\nProof by contradiction:\n\nAssume, for the sake of contradiction, that `Empty` and `Unit` are equal types. This means that there exists a function `f : Empty -> Unit` and a function `g : Unit -> Empty` such that `f` and `g` are inverses of each other.\n\nConsider the unique element `u : Unit`. Since `g` is a function from `Unit` to `Empty`, `g(u)` is of type `Empty`. However, since `Empty` has no elements, there cannot exist any element of type `Empty`. This contradicts the assumption that `g` is a well-defined function.\n\nTherefore, our assumption that `Empty` and `Unit` are equal types must be false. Hence, `Empty` and `Unit` are unequal types.\n\nTherefore, in the context of dependent type theory, there exist two unequal types.\nTEMPLATE CODE:\n```coq\n\nLemma exists_Type_ne : exists A B : Type, A <> B.\nProof. Admitted.\n\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\n(* 1 *) Require Import Coq.Logic.Classical.\n(* 2 *) \n(* 3 *) Lemma exists_Type_ne : exists A B : Type, A <> B.\n(* 4 *) Proof.\n(* 5 *)   exists Empty.\n(* 6 *)   exists unit.\n(* 7 *)   intros contra.\n(* 8 *)   destruct contra as [f g].\n(* 9 *)   assert (u : unit) by exact tt.\n(* 10 *)   pose (g_u := g u).\n(* 11 *)   contradiction (empty_ind g_u).\n(* 12 *) Qed.\n```\nERROR MESSAGE:\nstdout:\n```\n\n(* Welcome to Coq 8.15.1\nSkipping rcfile loading.\n\n<prompt>Coq < 1 || 0 < </prompt> *)\n(* 1 *) Require Import Coq.Logic.Classical.\n(* \n\n<prompt>Coq < 2 || 0 < </prompt> *)\n\n(* 2 *) \n(* 3 *) Lemma exists_Type_ne : exists A B : Type, A <> B.\n(* \n1 goal (ID 4)\n  \n  ============================\n  exists A B : Type, A <> B\n\n<prompt>exists_Type_ne < 3 |exists_Type_ne| 0 < </prompt> *)\n\n(* 4 *) Proof.\n(* \n\n<prompt>exists_Type_ne < 4 |exists_Type_ne| 0 < </prompt> *)\n\nEmpty.\n(* \nToplevel input, characters 0-5:\n> Empty\n> ^^^^^\nError: The reference Empty was not found in the current environment.\n\n<prompt>exists_Type_ne < 4 |exists_Type_ne| 0 < </prompt>\n *)\n\n```\nstderr:\n```\nFile \"./Solution.v\", line 5, characters 17-22:\nError: The reference Empty was not found in the current environment.\n\nLine 5 is:\n(* 5 *)   exists Empty.\n\nCharacters 17-22 are `Empty.`\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "criteria": "The answer must indicate that `Empty` is used without being defined, and must mention `Empty_set` and/or `False` as the standard types to use."}
{"input": [{"role": "system", "content": "TASK: Read the mathematical statement.\nIf the statement is true, describe a proof strategy.\nIf the statement is false, provide a counter-example and explain it.\nIf you can neither produce a counter-example nor a proof, indicate that you have no solution to this problem, and briefly describe the state of the art conjectures or results, if any."}, {"role": "user", "content": "For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$."}], "completion": "The statement is false. \n\nCounter-example: Let $X = \\{0, 1\\}$ and define $f : X \\to X$ as $f(0) = 1$ and $f(1) = 0$. Now, let $s : X \\to X$ be defined as $s(0) = 0$ and $s(1) = 1$. \n\nIn this case, $f$ is an involutive function and $s$ is a section of $f$, but $s$ is not equal to $f$.", "criteria": "The response asserts that the statement is true and describes a proof strategy.", "choice": "N"}
{"input": [{"role": "system", "content": "TASK: Read the mathematical statement.\nIf the statement is true, describe a proof strategy.\nIf the statement is false, provide a counter-example and explain it.\nIf you can neither produce a counter-example nor a proof, indicate that you have no solution to this problem, and briefly describe the state of the art conjectures or results, if any."}, {"role": "user", "content": "For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$."}], "completion": "An involutive function $f: X \\to X$ is a function that is its own inverse, meaning that applying $f$ twice gives the original element back: $f(f(x)) = x$ for all $x$ in $X$. A section $s: X \\to X$ of $f$ is a right inverse, meaning that applying $f$ after $s$ gives the identity: $f(s(x)) = x$ for all $x$ in $X$.\n\nWe want to show that for any section $s$ of an involutive function $f$, it holds that $s = f$. To prove this, we will use the definitions of an involutive function and a section. We'll consider an arbitrary element $x \\in X$.\n\nWe start with $f(s(x)) = x$. This equation is true because $s$ is a section of $f$ by definition.\n\nNext, we apply $f$ to both sides of the equation:\n\n$$f(f(s(x))) = f(x)$$\n\nBecause $f$ is involutive, we know that $f(f(y)) = y$ for any $y \\in X$. So, we have:\n\n$$s(x) = f(x)$$\n\nThis holds for all $x$ in $X$, so we conclude that $s = f$.\n\nTherefore, any section of an involutive function is equal to the function itself.", "criteria": "The response asserts that the statement is true and describes a proof strategy.", "choice": "Y"}
{"input": [{"role": "system", "content": "You are given a fully explicit formal proof, template Coq code, an incorrect translation of the formal proof into Coq code, and the error message and output. Explain what went wrong with the code translation. DO NOT suggest a fix, only explain what went wrong."}, {"role": "user", "content": "TASK: For any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nFORMAL PROOF:\nWe will prove that for any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\n\nLet $s : X \\to X$ be a section of $f$. This means that $f(s(x)) = x$ for all $x \\in X$.\n\nWe want to show that $s = f$. To do this, we will show that $s(x) = f(x)$ for all $x \\in X$.\n\nConsider an arbitrary element $x \\in X$. We have:\n\n$$f(s(x)) = x$$\n\nBecause $f$ is involutive, we know that $f(f(y)) = y$ for any $y \\in X$. So, we can apply $f$ to both sides of the equation:\n\n$$f(f(s(x))) = f(x)$$\n\nUsing the fact that $f$ is involutive, we get:\n\n$$s(x) = f(x)$$\n\nSince $x$ was arbitrary, this holds for all $x \\in X$. Therefore, $s = f$.\n\nThus, we have shown that for any set $X$ and any involutive function $f : X \\to X$, every section $s : X \\to X$ of $f$ is equal to $f$.\nTEMPLATE CODE:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma section_equal_involutive : forall {X} f s,\n  involutive f ->\n  cancel s f ->\n  forall x : X, f x = s x.\nProof. Admitted.\n\n```\nFORMAL PROOF TRANSLATED TO COQ:\n```coq\nFrom Coq Require Import ssr.ssrfun.\n\nLemma section_equal_involutive : forall {X} f s,\n  involutive f ->\n  cancel s f ->\n  forall x : X, f x = s x.\nProof.\n  move=> X f s H_inv H_can x.\n  rewrite -{1}(H_can x).\n  rewrite H_inv.\n  reflexivity.\nQed.\n```\nERROR MESSAGE:\nstdout:\n```\nFile \"./Solution.v\", line 8, characters 6-8:\nError: Syntax error: [hyp] expected after 'move' (in [simple_tactic]).\n\nLine 8 is:\n  move=> X f s H_inv H_can x.\n\nCharacters 6-8 are `=>`\n\n```\nstderr:\n```\n\n```\nError:\n```\n1\n```\nEXPLANATION:\n"}], "completion": "The error occurred because the `=>` tactic was used instead of the `intros` tactic to introduce the variables `X`, `f`, `s`, `H_inv`, `H_can`, and `x`. The `=>` tactic is not a valid tactic in Coq and caused a syntax error. The correct tactic to use in this case is `intros`.", "criteria": "The answer explains that the error is a syntax error due to the SSReflect extension not being properly loaded due to a missing import of `ssreflect`, which is not the same as `ssr.ssrfun`.  Additionally, the answer should not mention `mathcomp`, should not suggest inserting spaces.  Answers suggesting using `intros` instead of `move=>` are also correct, as long as it does not claim that `move=>` / `=>` is invalid syntax in general.", "choice": "N"}
  ```
</details>
