### PR TITLE
fixing the wording for the modelgraded 'best' model

### DIFF
--- a/evals/registry/evals/test-modelgraded.yaml
+++ b/evals/registry/evals/test-modelgraded.yaml
@@ -94,3 +94,5 @@ best.dev.v0:
     eval_type: cot_classify
     modelgraded_spec: best
     multicomp_n: from_models
+    sample_kwargs:
+      temperature: 0.4

--- a/evals/registry/modelgraded/best.yaml
+++ b/evals/registry/modelgraded/best.yaml
@@ -1,6 +1,6 @@
 best:
   prompt: |-
-    Which of the following {n} texts is best response to the following instruction?
+    Which of the following {n} texts is the best response to the following instruction?
 
     Instruction: {input}
 


### PR DESCRIPTION
Note that this isn't in use anywhere CURRENTLY

May as well fix this now before anyone starts using it.