### PR TITLE
[Eval] Adds Korean foreign words evaluation

### DIFF
--- a/evals/registry/data/korean_foreign_words/samples.jsonl
+++ b/evals/registry/data/korean_foreign_words/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e5df8cef9bdf1b327ce03cfc00d012fd6e77aa00dd45347fd690c0791de47d0
-size 11947
+oid sha256:8ce7c5528e456a9ce745f0d729a968c988a5fe35ad2895f41e33d3fd5b6ff4e2
+size 14490

--- a/evals/registry/data/korean_foreign_words/samples.jsonl
+++ b/evals/registry/data/korean_foreign_words/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e46ac016628d69e059e708e4e1af10b2bdfebaf1e2e5fe9a6181dac81968b610
-size 10457
+oid sha256:4718c35a2a9f1156b496ac1cbe391efb4f668ced4ada9cf6966c2af62e3c33a3
+size 10825

--- a/evals/registry/data/korean_foreign_words/samples.jsonl
+++ b/evals/registry/data/korean_foreign_words/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4718c35a2a9f1156b496ac1cbe391efb4f668ced4ada9cf6966c2af62e3c33a3
-size 10825
+oid sha256:7e5df8cef9bdf1b327ce03cfc00d012fd6e77aa00dd45347fd690c0791de47d0
+size 11947

--- a/evals/registry/data/korean_foreign_words/samples.jsonl
+++ b/evals/registry/data/korean_foreign_words/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e46ac016628d69e059e708e4e1af10b2bdfebaf1e2e5fe9a6181dac81968b610
+size 10457

--- a/evals/registry/data/korean_foreign_words/samples.jsonl
+++ b/evals/registry/data/korean_foreign_words/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ce7c5528e456a9ce745f0d729a968c988a5fe35ad2895f41e33d3fd5b6ff4e2
-size 14490
+oid sha256:a5f06034d693a3c00388bb8604fc6af28c41769dba977bddc1ab70afd775c1c6
+size 14950

--- a/evals/registry/evals/korean_foreign_words.yaml
+++ b/evals/registry/evals/korean_foreign_words.yaml
@@ -1,0 +1,9 @@
+korean_foreign_words:
+  id: korean_foreign_words.dev.v0
+  description: Choose correctly spelled foreign words in Korean.
+  metrics: [accuracy]
+
+korean_foreign_words.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: korean_foreign_words/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

### Eval name

korean_foreign_words

### Eval description

Evaluates whether GPT can choose grammatically correct foreign words spelled in Korean that are often misused.

### What makes this a useful eval?

This can make it possible for GPT to correct grammar errors in text given by user.
 It is also important to generate sentences grammatically correct, otherwise its output may not sound credible.



## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should

- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "You will be given two foreign words in Korean. Select the correctly spelled one. Don't type anything else."}, {"role": "user", "content": "Contents 컨텐츠/콘텐츠"}], "ideal": "콘텐츠"}
{"input": [{"role": "system", "content": "You will be given two foreign words in Korean. Select the correctly spelled one. Don't type anything else."}, {"role": "user", "content": "Damage 데미지/대미지"}], "ideal": "대미지"}
{"input": [{"role": "system", "content": "You will be given two foreign words in Korean. Select the correctly spelled one. Don't type anything else."}, {"role": "user", "content": "Shader 쉐이더/셰이더"}], "ideal": "셰이더"}
{"input": [{"role": "system", "content": "You will be given two foreign words in Korean. Select the correctly spelled one. Don't type anything else."}, {"role": "user", "content": "Shell 셸/쉘"}], "ideal": "셸"}
{"input": [{"role": "system", "content": "You will be given two foreign words in Korean. Select the correctly spelled one. Don't type anything else."}, {"role": "user", "content": "Push 푸쉬/푸시"}], "ideal": "푸시"}
  ```
</details>
