### PR TITLE
Improve ModelGraded Evals Formatting for Enhanced GPT Compliance

### DIFF
--- a/evals/elsuite/modelgraded/classify_utils.py
+++ b/evals/elsuite/modelgraded/classify_utils.py
@@ -1,6 +1,7 @@
+import re
 import logging
 import string
-from typing import Any, Callable, Iterable, Optional, Union
+from typing import Any, Callable, Iterable, Optional, Union, Tuple, List, Dict
 
 from evals import CompletionFn
 from evals.elsuite.modelgraded.base import ModelGradedSpec
@@ -9,23 +10,32 @@ from evals.prompt.base import OpenAICreateChatPrompt, is_chat_prompt
 
 INVALID_STR = "__invalid__"
 
-
+# Mapping of evaluation types to their corresponding prompt formats
 ANSWER_PROMPTS = {
-    # e.g. "Yes"
-    "classify": "Answer the question by printing only a single choice from {choices} (without quotes or punctuation) corresponding to the correct answer with no other text.".strip(),
-    # e.g. "Yes\n The reasons are: ..."
-    "classify_cot": "First, answer by printing a single choice from {choices} (without quotes or punctuation) corresponding to the correct answer. Then, from the next line, explain your reasonings step by step.".strip(),
-    # e.g. "Let's think step by step. ...\nYes"
-    "cot_classify": """
-First, write out in a step by step manner your reasoning to be sure that your conclusion is correct. Avoid simply stating the correct answer at the outset. Then print only a single choice from {choices} (without quotes or punctuation) on its own line corresponding to the correct answer. At the end, repeat just the answer by itself on a new line.
-
-Reasoning:""".strip(),
-    "cot_classify_jp": """
-まず、一歩一歩あなたの推論を書き出してください。単に正しい答えを最初に述べることを避けてください。次に、{choices}（引用符や句読点なし）から正しい答えに対応する1つの選択肢を単独の行に書きだしてください。最後に、答えだけを新しい行に繰り返してください。
-
-推論：
-    """.strip(),
+    # choose answer only
+    "classify": "Answer the question by printing only a single answer choice from {choices}."
+    "\nYour final output should be in the following format (NOTE: Include the square brackets):"
+    "\nFinal Answer: [<choice>]",
+    # choose answer first, then explain reasoning
+    "classify_cot": "First, choose a single answer choice from {choices}."
+    "Then, on the next line, explain your reasonings step by step."
+    "\nYour final output should be in the following format (NOTE: Include the square brackets):"
+    "\nFinal Answer: [<choice>]\nReasoning: <your reasoning>",
+    # explain reasoning first, then choose answer
+    "cot_classify": "First,  explain your reasonings step by step. "
+    "Then, on the next line, choose a single answer choice from {choices}."
+    "\nYour final output should be in the following format (NOTE: Include the square brackets):"
+    "\nReasoning: <your reasoning>\nFinal Answer: [<choice>]",
+    # explain reasoning first, then choose answer (Japanese)
+    "cot_classify_jp": "まず、一歩一歩あなたの推論を書き出してください。単に正しい答えを最初に述べることを避けてください。次に、{choices}"
+    "（引用符や句読点なし）から正しい答えに対応する1つの選択肢を単独の行に書きだしてください。"
+    "最後に、答えだけを新しい行に繰り返してください。推論："
+    # If translating to Japanese, it is important to update the regex get_choice() function below
+    "\nYour final output should be in the following format (NOTE: Include the square brackets):"
+    "\nReasoning: <your reasoning>\nFinal Answer: [<choice>]",
 }
+
+# Mapping of match function identifiers to actual functions
 MATCH_FNS = {
     "include": lambda x, y: float(x in y),
     "exact": lambda x, y: float(x == y),
@@ -34,8 +44,10 @@ MATCH_FNS = {
 }
 
 
-def get_choice_strings(choice_strings: Union[list[str], str], n: Optional[int] = None):
-    # 'choice_strings' is a list of strings that specifies the possible choices
+def get_choice_strings(
+    choice_strings: Union[List[str], str], n: Optional[int] = None
+) -> List[str]:
+    """Converts 'choice_strings' input to list of strings representation."""
     if choice_strings == "from_n":
         choice_strings = [str(i + 1) for i in range(n)]
     elif choice_strings == "from_n_abc":
@@ -51,12 +63,13 @@ def get_choice_strings(choice_strings: Union[list[str], str], n: Optional[int] =
 def classify(
     mg: ModelGradedSpec,
     completion_fn: CompletionFn,
-    completion_kwargs: Optional[dict[str, Any]] = None,
-    format_kwargs: Optional[dict[str, Any]] = None,
+    completion_kwargs: Optional[Dict[str, Any]] = None,
+    format_kwargs: Optional[Dict[str, Any]] = None,
     eval_type: Optional[str] = None,
     n: Optional[int] = None,
     match_fn: str = "starts_or_endswith",
-) -> str:
+) -> Tuple[str, Dict[str, Any]]:
+    """Performs classification by evaluating model output and comparing it to possible choices."""
     completion_kwargs = completion_kwargs or {}
     format_kwargs = format_kwargs or {}
 
@@ -67,13 +80,14 @@ def classify(
     prompt = mg.prompt
     if isinstance(prompt, str):
         prompt = [{"role": "user", "content": prompt}]
-    if eval_type:
-        prompt = append_answer_prompt(
-            prompt=prompt,
-            eval_type=eval_type,
-            choice_strings=choice_strings,
-        )
 
+    if eval_type is None:
+        eval_type = "classify"
+    prompt = append_answer_prompt(
+        prompt=prompt,
+        eval_type=eval_type,
+        choice_strings=choice_strings,
+    )
     evaluate = PromptFn(prompt, completion_fn=completion_fn, **completion_kwargs)
     evaluation, prompt = evaluate(n=n, **format_kwargs)
     choice = get_choice(evaluation, mg.eval_type or eval_type, match_fn, choice_strings)
@@ -89,8 +103,9 @@ def classify(
 def get_choice_score(
     choice: str,
     choice_strings: Iterable[str],
-    choice_scores: Optional[Union[dict[str, float], str]] = None,
+    choice_scores: Optional[Union[Dict[str, float], str]] = None,
 ) -> Optional[float]:
+    """ "Calculates the score of a specific choice."""
     if choice_scores is None:
         return None
     if choice_scores == "from_strings":
@@ -102,28 +117,36 @@ def get_choice_score(
 
 
 def choice_to_str(choice_strings: Iterable[str]) -> str:
-    """Return a string of choices, e.g. '"Yes" or "No" or "Maybe"'."""
+    """Converts iterable of choice strings into a human-readable string."""
     return " or ".join(f'"{choice}"' for choice in choice_strings)
 
 
 def get_choice(
-    text: str, eval_type: str, match_fn: Union[str, Callable], choice_strings: Iterable[str]
+    text: str,
+    eval_type: str,
+    match_fn: Union[str, Callable],
+    choice_strings: Iterable[str],
 ) -> str:
-    """Clean the answer string to a choice string to one of choice_strings. Return '__invalid__.' if no match."""
+    """Extracts the final choice from the model output and validates it against the available choices.
+    Return INVALID_STR if no match."""
     if isinstance(match_fn, str):
-        match_fn = MATCH_FNS[match_fn]
-    lines = text.strip().split("\n")
-    if eval_type.startswith("cot_classify"):
-        lines = lines[::-1]  # reverse lines
-    for line in lines:
-        line = line.strip()
-        line = "".join(c for c in line if c not in string.punctuation)
-        if not line:
-            continue
+        try:
+            match_fn = MATCH_FNS[match_fn]
+        except KeyError:
+            raise ValueError(f"match_fn {match_fn} is not valid")
+
+    match = re.search(r"Final Answer: \[(.+?)]", text)
+    if match:
+        model_choice = "".join(
+            char for char in match.group(1) if char not in string.punctuation
+        )
         for choice in choice_strings:
-            if match_fn(line, choice):
+            if match_fn(model_choice, choice):
+                logging.debug(
+                    f"Matched {model_choice} to {choice} for {eval_type}: {text}"
+                )
                 return choice
-    logging.warn(f"Choices {choice_strings} not parsable for {eval_type}: {text}")
+    logging.warning(f"Choices {choice_strings} not parsable for {eval_type}: {text}")
     return INVALID_STR
 
 
@@ -134,17 +157,23 @@ def append_answer_prompt(
     answer_prompt: Optional[OpenAICreateChatPrompt] = None,
     choice_strings: Optional[Iterable[str]] = None,
 ) -> OpenAICreateChatPrompt:
-    """Append answer prompt to prompt."""
+    """Appends evaluation instructions to the prompt for the model."""
     answer_prompt = answer_prompt or ANSWER_PROMPTS[eval_type]
     answer_prompt = format_prompt(answer_prompt, choices=choice_to_str(choice_strings))
     if append_type == "as_content":
-        assert isinstance(answer_prompt, str), f"prompt must be str, not {type(answer_prompt)}"
+        assert isinstance(
+            answer_prompt, str
+        ), f"prompt must be str, not {type(answer_prompt)}"
         prompt[-1]["content"] += "\n\n" + answer_prompt
     elif append_type == "as_message":
-        assert is_chat_prompt(answer_prompt), f"prompt must be chat prompt, not {answer_prompt}"
+        assert is_chat_prompt(
+            answer_prompt
+        ), f"prompt must be chat prompt, not {answer_prompt}"
         prompt += answer_prompt
     else:
-        raise ValueError(f"append_type must be 'as_content' or 'as_message', not {append_type}")
+        raise ValueError(
+            f"append_type must be 'as_content' or 'as_message', not {append_type}"
+        )
     return prompt
 
 
@@ -153,8 +182,9 @@ def sample_and_concat_n_completions(
     prompt: OpenAICreateChatPrompt,
     n: int,
     template_i: str,
-    sample_kwargs: dict,
-):
+    sample_kwargs: Dict[str, Any],
+) -> str:
+    """Samples and concatenates multiple completions using either single or multiple models."""
     assert template_i
     completion_i_s = []
     for i in range(n):
@@ -165,14 +195,16 @@ def sample_and_concat_n_completions(
         else:
             # use the single model for all completions
             completion_fn = completion_fns[0]
-        get_input_completion = PromptFn(prompt, completion_fn=completion_fn, **sample_kwargs)
+        get_input_completion = PromptFn(
+            prompt, completion_fn=completion_fn, **sample_kwargs
+        )
         completion_i, _ = get_input_completion()
         completion_i_s.append(completion_i)
     return concat_n_completions(completion_i_s, template_i=template_i)
 
 
 def concat_n_completions(completions: Iterable[str], template_i: str) -> str:
-    """Concatenate n completions into a single text string."""
+    """Combines multiple completions into a single formatted string."""
     completion = ""
     for i, completion_i in enumerate(completions):
         completion += format_necessary(

--- a/evals/registry/modelgraded/closedqa.yaml
+++ b/evals/registry/modelgraded/closedqa.yaml
@@ -10,13 +10,14 @@ closedqa:
     [Criterion]: {criteria}
     ***
     [END DATA]
-    Does the submission meet the criterion? First, write out in a step by step manner your reasoning about the criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer. At the end, repeat just the letter again by itself on a new line.
 
-    Reasoning:
   eval_type: cot_classify
   choice_scores:
-    "Y": 1.0
-    "N": 0.0
-  choice_strings: 'YN'
+    "Yes": 1.0
+    "No": 0.0
+
+  choice_strings:
+    - "Yes"
+    - "No"
   input_outputs:
-    input: "completion"
+    input: completion

--- a/evals/registry/modelgraded/fact.yaml
+++ b/evals/registry/modelgraded/fact.yaml
@@ -18,6 +18,11 @@ fact:
     (C) The submitted answer contains all the same details as the expert answer.
     (D) There is a disagreement between the submitted answer and the expert answer.
     (E) The answers differ, but these differences don't matter from the perspective of factuality.
-  choice_strings: ABCDE
+  choice_strings:
+    - "A"
+    - "B"
+    - "C"
+    - "D"
+    - "E"
   input_outputs:
     input: completion

--- a/evals/registry/modelgraded/humor.yaml
+++ b/evals/registry/modelgraded/humor.yaml
@@ -36,7 +36,12 @@ humor_likert:
     {completion}
 
     Answer using the scale of 1 to 5, where 5 is the funniest.
-  choice_strings: "12345"
+  choice_strings:
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "5"
   choice_scores: from_strings
   input_outputs:
     input: completion
@@ -63,6 +68,11 @@ humor_jp:
 
     5. 大変面白い - このレベルの面白さは、非常に優れており、観る者を魅了し、心に強く残る体験ができます。独創的なストーリーや魅力的なキャラクターが際立ち、多くの人が共感や感動を覚えるでしょう。このレベルの面白さは、他のものと比較しても突出していると言えます。
   choice_scores: from_strings
-  choice_strings: "12345"
+  choice_strings:
+    - "1"
+    - "2"
+    - "3"
+    - "4"
+    - "5"
   input_outputs:
     input: completion

--- a/evals/registry/modelgraded/onomatopoeia.yaml
+++ b/evals/registry/modelgraded/onomatopoeia.yaml
@@ -18,7 +18,12 @@ onomatopoeia:
     (D) 意味が部分的に正解しているが、例文は不正解。
     (E) 意味は一致していないが、例文は正解している。
     (F) 意味が一致していないし、例文も不正解。
-  choice_strings: ABCDEF
+  choice_strings:
+    - "A"
+    - "B"
+    - "C"
+    - "D"
+    - "E"
   choice_scores:
     "A": 1.0
     "B": 0.8

--- a/evals/registry/modelgraded/possible.yaml
+++ b/evals/registry/modelgraded/possible.yaml
@@ -16,6 +16,8 @@ possible:
     (A) The statement declares the task to be impossible
     (B) The statement provides instructions on how to solve a given task, or provides a solution
 
-  choice_strings: AB
+  choice_strings:
+    - "A"
+    - "B"
   input_outputs:
     input: completion

--- a/evals/registry/modelgraded/regression-equation.yaml
+++ b/evals/registry/modelgraded/regression-equation.yaml
@@ -27,10 +27,11 @@ regression-equation:
     Use a tolerance of 0.1 for each coefficient and intercept.
     Ignore differences of notation.  Ignore extra zeros.
     Do not use "curly braces" in your answer.
-
   choice_scores:
     "Y": 1.0
     "N": 0.0
-  choice_strings: 'YN'
+  choice_strings:
+    - "Yes"
+    - "No"
   input_outputs:
-    input: "completion"
+    input: completion

--- a/evals/registry/modelgraded/rhyming.yaml
+++ b/evals/registry/modelgraded/rhyming.yaml
@@ -9,6 +9,8 @@ rhyming:
 
     (A) The verse has 3 or fewer rhymes
     (B) The verse has 4 or more rhymes
-  choice_strings: AB
+  choice_strings:
+    - "A"
+    - "B"
   input_outputs:
     input: completion

--- a/evals/registry/modelgraded/sql.yaml
+++ b/evals/registry/modelgraded/sql.yaml
@@ -11,10 +11,16 @@ sql:
     ************
     [END DATA]
 
-    Compare the content and correctness of the submitted SQL with the expert answer. Ignore any differences in whitespace, style, or output column names.
-    The submitted answer may either be correct or incorrect. Determine which case applies. Answer the question by responding with one of the following:
-      "Correct": The submitted SQL and the expert answer are semantically the same, i.e. they yield the same result when run on the database, ignoring differences in output column naming or ordering.
-      "Incorrect": The submitted SQL and the expert answer are semantically different, i.e. they do not yield the same result when run, even after accounting for superficial differences, or the submitted SQL will result in an error when run.
+    Compare the content and correctness of the submitted SQL with the expert answer.
+    Ignore any differences in whitespace, style, or output column names.
+    The submitted answer may either be correct or incorrect.
+    Determine which case applies. Answer the question by responding with one of the following:
+      "Correct": The submitted SQL and the expert answer are semantically the same,
+    i.e. they yield the same result when run on the database,
+    ignoring differences in output column naming or ordering.
+      "Incorrect": The submitted SQL and the expert answer are semantically different,
+    i.e. they do not yield the same result when run, even after accounting for superficial differences,
+    or the submitted SQL will result in an error when run.
   choice_strings:
     - "Correct"
     - "Incorrect"

--- a/evals/registry/modelgraded/translation.yaml
+++ b/evals/registry/modelgraded/translation.yaml
@@ -1,6 +1,7 @@
 translation:
   prompt: |-
-    You are comparing the submitted translation to an expert translation of a sentence from {language} to English. Here is the data:
+    You are comparing the submitted translation to an expert translation of a sentence from {language} to English.
+    Here is the data:
     [BEGIN DATA]
     ************
     [Sentence]: {input}
@@ -10,13 +11,17 @@ translation:
     [Submission]: {completion}
     ************
     [END DATA]
-    Does the submission answer and the expert's answer have the same meaning? Ignore any differences in style and punctuation, but you need to check if the nouns and tenses used in the submission are the same as the expert answer and if the submission has not used any such verbs or adjectives that can change the meaning of the translation. First, write out in a step-by-step manner your reasoning about the comparison to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line, corresponding to the correct answer. At the end, repeat just the letter again by itself on a new line.
-
-    Reasoning:
+    Does the submission answer and the expert's answer have the same meaning?
+    Ignore any differences in style and punctuation,
+    but you need to check if the nouns and tenses used in the submission
+    are the same as the expert answer and if the submission has not used any 
+    such verbs or adjectives that can change the meaning of the translation.
   eval_type: cot_classify
   choice_scores:
     "Y": 1.0
     "N": 0.0
-  choice_strings: 'YN'
+  choice_strings:
+    - "Yes"
+    - "No"
   input_outputs:
-    input: "completion"
+    input: completion


### PR DESCRIPTION
This PR addresses issue #1228 , where GPT-4 was observed to yield more invalid responses than GPT-3.5-turbo in closedqa evaluations.

The root cause was identified as inconsistencies and outdated practices in formatting ModelGraded Evals, specifically in the 'answer' prompting. The solution introduced here is an enhanced output template, which provides precise instructions for formatting the response across all four answer prompts. The revised instructions, adapted to each answer type, are as follows:
"Your final output should be in the following format (NOTE: Include the square brackets):\nReasoning: <your reasoning>\nFinal Answer: [<choice>]"

In addition to this, a streamlined method for final answer extraction has been adopted (regex-based instead of line by line analysis).

These modifications have significantly improved the performance of both GPT-3.5-turbo and GPT-4-0613, eliminating invalid responses in evaluation #1200 during my testing, a contrast to the 9 invalid responses observed earlier (Run stats at the bottom). Additional testing, ranging from spot checks to a full set of standard test evaluations (oaievalset test), confirms the elimination of errors and invalid responses across all tests without any new issues appearing.

Consistency in formatting has also been addressed across all ModelGraded yaml files and duplications in the instructions within yaml files, which were potentially contributing to the issue, have been rectified.

Further Considerations:

The Japanese ANSWER_PROMPT has been updated with the new output formatting request appended to the existing prompt. However, I just appended the instructions in English for now, a more comprehensive review of its impact on model performance is advisable.

In future, it may be beneficial to transition these evaluations to use the new function calling option for chat completions. This was deemed outside the current scope.

Should these modifications be accepted, minor updates to the ModelGraded eval documentation to reflect these best practices for reliable results are recommended. The proposed standardized format for the choices_strings (one per line) has been applied to all existing yaml files.

Although this proposed solution is extensively tested and does not seem to introduce any new issues, further scrutiny is welcome. I have done my best to familiarize myself with this repository over the last few months. However, the depth and complexity of this repository make it important to remain open to alternate strategies and modifications for optimal performance. I would be happy to make further revisions as needed and look forward to your feedback.

---------------------------------------
GPT 4-0613
---------------------------------------
oaieval gpt-4-0613 coq-editing-meta  
Y: 16, N: 16, Score: 0.5, MetaScore: 0.81

oaieval gpt-4-0613 coq-editing
Y:4, N: 11, Score: 0.27
---------------------------------------
GPT 3.5 Turbo
---------------------------------------
oaieval gpt-3.5-turbo coq-editing
Y: 11, N: 4, Score: 0.73

oaieval gpt-3.5-turbo coq-editing-meta
Y: 30, N: 2, Score: 0.94, MetaScore:0.56
