### PR TITLE
[Eval] Evaluate the model's understanding of C/C++ type conversion rules

### DIFF
--- a/evals/registry/data/c_expression_size/samples.jsonl
+++ b/evals/registry/data/c_expression_size/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d1ef6817a8e531592364cb8d520c212ffe7670f171238f20b2cc88e8d91b54d
+size 3678

--- a/evals/registry/evals/c_expression_size.yaml
+++ b/evals/registry/evals/c_expression_size.yaml
@@ -1,0 +1,8 @@
+c_expression_size:
+  id: c_expression_size.dev.v0
+  description: Evaluate the model's understanding of C/C++ type conversion rules
+  metrics: [accuracy]
+c_expression_size.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: c_expression_size/samples.jsonl


### PR DESCRIPTION
# Thank you for contributing an eval! ♥️

🚨 Please make sure your PR follows these guidelines, **failure to follow the guidelines below will result in the PR being closed automatically**. Note that even if the criteria are met, that does not guarantee the PR will be merged nor GPT-4 access be granted. 🚨

**PLEASE READ THIS**:

In order for a PR to be merged, it must fail on GPT-4. We are aware that right now, users do not have access, so you will not be able to tell if the eval fails or not. Please run your eval with GPT-3.5-Turbo, but keep in mind as we run the eval, if GPT-4 gets higher than 90% on the eval, we will likely reject it since GPT-4 is already capable of completing the task.

We plan to roll out a way for users submitting evals to see the eval performance on GPT-4 soon. Stay tuned! Until then, you will not be able to see the eval performance on GPT-4. **Starting April 10, the minimum eval count is 15 samples, we hope this makes it easier to create and contribute evals.**

Also, please note that we're using **Git LFS** for storing the JSON files, so please make sure that you move the JSON file to Git LFS before submitting a PR. Details on how to use Git LFS are available [here](https://git-lfs.com).

## Eval details 📑

### Eval name

Understanding of explicit and implicit type conversions in C/C++

### Eval description

This evaluation is designed to assess the model's understanding of explicit and implicit type conversions in the C/C++ programming language. The evaluation works by asking the model to predict the sizes of various expressions, with the results compared against the correct sizes generated by a standard C/C++ compiler.

Type conversion rules in C/C++ can be complex. For instance, take the following expression:

```c
(float)0 + 1.0
```

The above expression evaluates as a `double` type because `(float)1` is promoted to `double` before the addition takes place. This behavior is outlined in the C/C++ standard. As a result, the size of the expression becomes `8` bytes. This is because the expression is essentially equivalent to:

```c
(double)(float)0 + 1.0
```

Through this evaluation, we aim to test the model's grasp of these rules and its ability to apply them correctly.

While humans can easily reason about the size of the expressions in this eval, the results can also be obtained by running the code through a C/C++ compiler as shown below:
```c
#include <stdio.h>
#include <stdint.h>

int main() {
    printf("(uint8_t)0,%lu\n", sizeof((uint8_t)0));
    printf("(uint16_t)0,%lu\n", sizeof((uint16_t)0));
    printf("(uint32_t)0,%lu\n", sizeof((uint32_t)0));
    printf("(uint64_t)0,%lu\n", sizeof((uint64_t)0));
    printf("(float)0,%lu\n", sizeof((float)0));
    printf("(double)0,%lu\n", sizeof((double)0));
    printf("(uint8_t)0 + 1,%lu\n", sizeof((uint8_t)0 + 1));
    printf("(uint16_t)0 + 1,%lu\n", sizeof((uint16_t)0 + 1));
    printf("(uint32_t)0 + 1,%lu\n", sizeof((uint32_t)0 + 1));
    printf("(uint64_t)0 + 1,%lu\n", sizeof((uint64_t)0 + 1));
    printf("(float)0 + 1,%lu\n", sizeof((float)0 + 1));
    printf("(double)0 + 1,%lu\n", sizeof((double)0 + 1));
    printf("(uint8_t)0 + 1.0,%lu\n", sizeof((uint8_t)0 + 1.0));
    printf("(uint16_t)0 + 1.0,%lu\n", sizeof((uint16_t)0 + 1.0));
    printf("(uint32_t)0 + 1.0,%lu\n", sizeof((uint32_t)0 + 1.0));
    printf("(uint64_t)0 + 1.0,%lu\n", sizeof((uint64_t)0 + 1.0));
    printf("(float)0 + 1.0,%lu\n", sizeof((float)0 + 1.0));
    printf("(double)0 + 1.0,%lu\n", sizeof((double)0 + 1.0));
    return 0;
}
```

### What makes this a useful eval?

ChatGPT is an essential tool utilized by many developers during their software development processes. As such, its understanding of code semantics plays a crucial role in providing valuable and accurate support to programmers.

C/C++ is among the most widely-used programming languages in the field of software development. Given its widespread use, mastering the type conversion rules of C/C++ is paramount for a tool like ChatGPT. This evaluation helps ensure that ChatGPT can accurately interpret and apply these rules, thus enabling it to offer better support to developers working with C/C++.
## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should

- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint8_t)0"}], "ideal": "1"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint16_t)0"}], "ideal": "2"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint32_t)0"}], "ideal": "4"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint64_t)0"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (float)0"}], "ideal": "4"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (double)0"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint8_t)0 + 1"}], "ideal": "4"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint16_t)0 + 1"}], "ideal": "4"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint32_t)0 + 1"}], "ideal": "4"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint64_t)0 + 1"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (float)0 + 1"}], "ideal": "4"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (double)0 + 1"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint8_t)0 + 1.0"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint16_t)0 + 1.0"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint32_t)0 + 1.0"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (uint64_t)0 + 1.0"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (float)0 + 1.0"}], "ideal": "8"}
{"input": [{"role": "system", "content": "Please just answer a integer value."}, {"role": "user", "content": "Answer the size of this expression written in the C language: (double)0 + 1.0"}], "ideal": "8"}
  ```
</details>
