### PR TITLE
[For Issue #1284] Allow match_fn to be set in modelgraded eval .yaml file using kwarg

### DIFF
--- a/evals/elsuite/modelgraded/classify.py
+++ b/evals/elsuite/modelgraded/classify.py
@@ -21,6 +21,7 @@ class ModelBasedClassify(evals.Eval):
         eval_kwargs: Optional[dict[str, Any]] = None,
         multicomp_n: Union[int, str] = 1,
         eval_type: Optional[str] = None,
+        match_fn: Optional[str] = None,
         metaeval: bool = False,
         **kwargs,
     ):
@@ -37,6 +38,7 @@ class ModelBasedClassify(evals.Eval):
         self.metaeval = metaeval
         self.modelgraded_spec_args = modelgraded_spec_args or {}
         self.eval_type = eval_type
+        self.match_fn = match_fn
         if multicomp_n == "from_models":
             assert n_models > 1
             self.multicomp_n = n_models
@@ -85,6 +87,7 @@ class ModelBasedClassify(evals.Eval):
             completion_kwargs=self.eval_kwargs,
             eval_type=self.eval_type,
             n=self.multicomp_n,
+            match_fn=self.match_fn,
             format_kwargs={**completions, **test_sample, **self.modelgraded_spec_args},
         )
         metrics.update(dict(choice=choice, score=info["score"]))

--- a/evals/elsuite/modelgraded/classify_utils.py
+++ b/evals/elsuite/modelgraded/classify_utils.py
@@ -55,10 +55,11 @@ def classify(
     format_kwargs: Optional[dict[str, Any]] = None,
     eval_type: Optional[str] = None,
     n: Optional[int] = None,
-    match_fn: str = "starts_or_endswith",
+    match_fn: Optional[str] = None,
 ) -> str:
     completion_kwargs = completion_kwargs or {}
     format_kwargs = format_kwargs or {}
+    match_fn = match_fn or "starts_or_endswith"
 
     # get choice strings
     choice_strings = get_choice_strings(mg.choice_strings, n=n)


### PR DESCRIPTION
This PR resolves the problem mentioned in issue #1284.

Changes made:
- Added `match_fn` kwarg to `ModelBasedClassify`
- Added `match_fn` kwarg when calling `classify()`
- Modified implementation for setting of default `match_fn` value in `classify()`