### PR TITLE
Bug fix: gpt-4-base runs with ChatCompletion

### DIFF
--- a/evals/registry.py
+++ b/evals/registry.py
@@ -51,6 +51,7 @@ def n_ctx_from_model_name(model_name: str) -> Optional[int]:
         "gpt-3.5-turbo": 4096,
         "gpt-4": 8192,
         "gpt-4-32k": 32768,
+        "gpt-4-base": 8192,
     }
 
     # first, look for an exact match
@@ -67,6 +68,9 @@ def n_ctx_from_model_name(model_name: str) -> Optional[int]:
 
 
 def is_chat_model(model_name: str) -> bool:
+    if model_name in {"gpt-4-base"}:
+        return False
+
     CHAT_MODEL_NAMES = {"gpt-3.5-turbo", "gpt-4", "gpt-4-32k"}
     if model_name in CHAT_MODEL_NAMES:
         return True


### PR DESCRIPTION
If you run an eval with `gpt-4-base` you get the following error:
```
openai.error.InvalidRequestError: This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?
```

Example: run `oaieval gpt-4-base,gpt-4 multiturn` on [commit](https://github.com/openai/evals/commit/413402ecc5115a21710acbd4b844c3668052c874)

---

With this fix, you can run evals with `gpt-4-base` without the error. 

Example: run `oaieval gpt-4-base,gpt-4` [commit](https://github.com/openai/evals/commit/e1230bdd82e15a4eeaea5f7ae726924bab72631d)