### PR TITLE
Nits

### DIFF
--- a/evals/completion_fns/retrieval.py
+++ b/evals/completion_fns/retrieval.py
@@ -23,12 +23,11 @@ def load_embeddings(embeddings_and_text_path: str):
 
 
 def find_top_k_closest_embeddings(embedded_prompt: list[float], embs: list[list[float]], k: int):
-    # Normalize the embeddings
-    norm_embedded_prompt = embedded_prompt / np.linalg.norm(embedded_prompt)
-    norm_embs = embs / np.linalg.norm(embs, axis=1)[:, np.newaxis]
+    # Calculate the product of the norms of the prompt and the embeddings
+    norm_product = np.linalg.norm(embedded_prompt) * np.linalg.norm(embs)
 
     # Calculate cosine similarity
-    cosine_similarities = np.dot(norm_embs, norm_embedded_prompt)
+    cosine_similarities = np.dot(embs, embedded_prompt) / norm_product
 
     # Get the indices of the top k closest embeddings
     top_k_indices = np.argsort(cosine_similarities)[-k:]

--- a/evals/elsuite/translate.py
+++ b/evals/elsuite/translate.py
@@ -42,6 +42,8 @@ class Translate(evals.Eval):
                 prompt += s["sample"]
             prompt += sample["input"][-1:]
 
+        assert expected is not None, "Translate requires `ideal`"
+
         if isinstance(expected, tuple):
             expected = list(expected)
         elif not isinstance(expected, list):
@@ -53,18 +55,15 @@ class Translate(evals.Eval):
         )
         sampled = result.get_completions()[0]
 
-        score = None
-        if expected is not None:
-            score = self.bleu.sentence_score(sampled, expected).score
-            evals.record.record_metrics(sacrebleu_sentence_score=score)
+        score = self.bleu.sentence_score(sampled, expected).score
+        evals.record.record_metrics(sacrebleu_sentence_score=score)
 
-            match = score > 30
+        match = score > 30
 
-            if score is not None:
-                evals.record.record_match(
-                    match, expected=expected, sampled=sampled, sacrebleu_sentence_score=score
-                )
-            return match
+        evals.record.record_match(
+            match, expected=expected, sampled=sampled, sacrebleu_sentence_score=score
+        )
+        return match
 
     def run(self, recorder):
         samples = self.get_samples()


### PR DESCRIPTION

While I was reading some of OpenAI code and documents, I noticed little typos/bugs. In my view, only the first of the three listed merits further scrutiny, as it appears the code may not align with the author's original intention. This is not an actual pull request.


## 1. eval_sample(self, sample: Any, *_)
Commit: [Code flow nit in translate eval](https://github.com/openai/evals/commit/53095d9b9ede2abf7ad626d399530200e4089491)

### Case when `expected` is `None`
In the case when `expected` is `None`, the code (line 45):
```Python
if isinstance(expected, tuple):
    expected = list(expected)
elif not isinstance(expected, list):
    expected = [expected]
```
Will have `expected` to hold `[None]` (a list with a single value `None`)

The code later checks if `expected is not None` (line 57) which will always be true, which I don't think was the intended behavior.

### Case when `score` is `None`
When the score is evaluated by (line 58):
```Python
score = self.bleu.sentence_score(sampled, expected).score
```
If `score` is `None`, the line `match = score > 30` (line 61) will produce the exception `TypeError: '>' not supported between instances of 'NoneType' and 'int'` and the following check `score is not None` (line 63) will never be reached. 

## 2. find_top_k_closest_embeddings
Commit [Factor the normalization in cosine similarity fn](https://github.com/openai/evals/commit/fceedb13369c458b1d833654cf17f91c810996b2)
Really a nit here, this is not a performance issue in practical terms. The normalization of the two input vectors can be combined.

## 3. Typo in the post [Introducing Triton: Open-source GPU programming for neural networks](https://openai.com/research/triton)

The section "Fused softmax with the Torch JIT.", provides the following code:
```Python
@torch.jit.script
def softmax(x):
    x_max = x.max(dim=1)[0]
    z = x - x_max[:, None]
    numerator = torch.exp(x)
    denominator = numerator.sum(dim=1)
    return numerator / denominator[:, None]
```

I believe `numerator = torch.exp(x)` should be `numerator = torch.exp(z)` (i.e. `z` not `x`)


## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [X] I have filled out all required fields of this form
- [X] I have used **Git LFS** for the Eval JSON data
- [ ] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `black`, `isort`, and `autoflake` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

