### PR TITLE
Update README.md - Remove reference to early GPT4 access

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ To get set up with evals, follow the [setup instructions below](README.md#Setup)
 
 If you think you have an interesting eval, please open a PR with your contribution. OpenAI staff actively review these evals when considering improvements to upcoming models.
 
-____________________
-🚨 For a limited time, we will be granting GPT-4 access to those who contribute high quality evals. Please follow the instructions mentioned above and note that spam or low quality submissions will be ignored❗️
-
-Access will be granted to the email address associated with an accepted Eval. Due to high volume, we are unable to grant access to any email other than the one used for the pull request.
-____________________
-
 ## Setup
 
 To run evals, you will need to set up and specify your OpenAI API key. You can generate one at <https://platform.openai.com/account/api-keys>. After you obtain an API key, specify it using the `OPENAI_API_KEY` environment variable. **Please be aware of the [costs](https://openai.com/pricing) associated with using the API when running evals.**


### PR DESCRIPTION
Since we have now released GPT4 to everyone, these lines are outdated.