### PR TITLE
Dynamic Argument Integration for Registered Completion Functions

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -32,6 +32,7 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("eval", type=str, help="Name of an eval. See registry.")
     parser.add_argument("--extra_eval_params", type=str, default="")
+    parser.add_argument("--completion_args", type=str, default="")
     parser.add_argument("--max_samples", type=int, default=None)
     parser.add_argument("--cache", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--visible", action=argparse.BooleanOptionalAction, default=None)
@@ -128,8 +129,12 @@ def run(args: OaiEvalArguments, registry: Optional[Registry] = None) -> str:
         eval_spec is not None
     ), f"Eval {args.eval} not found. Available: {list(sorted(registry._evals.keys()))}"
 
+    # If the user provided an argument to --completion_args, parse it into a dict here, to be passed to the completion_fn creation **kwargs
+    completion_args = args.completion_args.split(",")
+    additonal_completion_args = {k: v for k, v in (kv.split("=") for kv in completion_args if kv)}
+
     completion_fns = args.completion_fn.split(",")
-    completion_fn_instances = [registry.make_completion_fn(url) for url in completion_fns]
+    completion_fn_instances = [registry.make_completion_fn(url, **additonal_completion_args) for url in completion_fns]
 
     run_config = {
         "completion_fns": completion_fns,

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -32,7 +32,7 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("eval", type=str, help="Name of an eval. See registry.")
     parser.add_argument("--extra_eval_params", type=str, default="")
-    parser.add_argument("--completion_args", type=str, default="")
+    parser.add_argument("--completion_args", type=str, default="", help="Specify additional parameters to modify the behavior of the completion_fn during its creation. Parameters should be passed as a comma-separated list of key-value pairs (e.g., 'key1=value1,key2=value2'). This option allows for the dynamic modification of completion_fn settings, including the ability to override default arguments where necessary.")
     parser.add_argument("--max_samples", type=int, default=None)
     parser.add_argument("--cache", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--visible", action=argparse.BooleanOptionalAction, default=None)

--- a/evals/registry.py
+++ b/evals/registry.py
@@ -102,22 +102,21 @@ class Registry:
             logger.warning(f"Could not fetch API model IDs from OpenAI API: {err}")
             return []
 
-    def make_completion_fn(self, name: str) -> CompletionFn:
+    def make_completion_fn(self, name: str, **kwargs) -> CompletionFn:
         """
         Create a CompletionFn. The name can be one of the following formats:
         1. openai-model-id (e.g. "gpt-3.5-turbo")
         2. completion-fn-id (from the registry)
         """
-
         if name == "dummy":
             return DummyCompletionFn()
 
         n_ctx = n_ctx_from_model_name(name)
 
         if is_chat_model(name):
-            return OpenAIChatCompletionFn(model=name, n_ctx=n_ctx)
+            return OpenAIChatCompletionFn(model=name, n_ctx=n_ctx, **kwargs)
         elif name in self.api_model_ids:
-            return OpenAICompletionFn(model=name, n_ctx=n_ctx)
+            return OpenAICompletionFn(model=name, n_ctx=n_ctx, **kwargs)
 
         # No match, so try to find a completion-fn-id in the registry
         spec = self.get_completion_fn(name)
@@ -125,6 +124,7 @@ class Registry:
             raise ValueError(f"Could not find CompletionFn in the registry with ID {name}")
         if spec.args is None:
             spec.args = {}
+        spec.args.update(kwargs)
 
         spec.args["registry"] = self
         instance = make_object(spec.cls)(**spec.args or {})

--- a/evals/registry/completion_fns/cot.yaml
+++ b/evals/registry/completion_fns/cot.yaml
@@ -8,7 +8,19 @@ cot/gpt-3.5-turbo:
   args:
     cot_completion_fn: gpt-3.5-turbo
 
+cot/gpt-4:
+  class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
+  args:
+    cot_completion_fn: gpt-4
+
 cot/flan-t5-xl:
   class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
   args:
     cot_completion_fn: langchain/llm/flan-t5-xl
+
+
+cot:
+  class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
+  args:
+    # Default to gpt-3.5-turbo, but can be overridden by the user using --completion_args "cot_completion_fn=<completion_fn>"
+    cot_completion_fn: gpt-3.5-turbo

--- a/evals/registry/completion_fns/cot.yaml
+++ b/evals/registry/completion_fns/cot.yaml
@@ -8,19 +8,13 @@ cot/gpt-3.5-turbo:
   args:
     cot_completion_fn: gpt-3.5-turbo
 
-cot/gpt-4:
-  class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
-  args:
-    cot_completion_fn: gpt-4
-
 cot/flan-t5-xl:
   class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
   args:
     cot_completion_fn: langchain/llm/flan-t5-xl
 
-
 cot:
   class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
   args:
-    # Default to gpt-3.5-turbo, but can be overridden by the user using --completion_args "cot_completion_fn=<completion_fn>"
+    # Default to gpt-3.5-turbo, but can be overridden in CLI --completion_args "cot_completion_fn=<completion_fn>"
     cot_completion_fn: gpt-3.5-turbo


### PR DESCRIPTION
## Feature Overview
This PR introduces an enhancement that adds dynamic argument capabilities to completion functions. By leveraging the newly added `--completion_args` argument, it's now possible to pass `**kwargs` to registered `CompletionFns` `__init__`. This is mostly meant for use with [yaml registered completion-fns](https://github.com/openai/evals/blob/main/docs/completion-fns.md#registering-completion-functions). 

## Problem Statement
In the existing setup, the necessity for new registration arises with each `completion_fn` that necessitates even a singular unique arg value. This can result in significant redundancy, particularly evident in configurations like `cot.yaml` (See Examples Section).

### Changes
1. **Added `--completion_args` to `oaieval.py` CLI**
   - The new argument is parsed into a dictionary and passed to the completion function creation process, allowing for the dynamic registration of 'CompletionFn' without significant alterations to the class structure.
   - `--completion_args` is inspired by and follows similar implementation logic to `--extra-eval-params`

2. **Minor Modification to `registry.py`**
   - Adapted `make_completion_fn` method to accommodate additional parameters (`**kwargs`) which are then funneled to various completion function creations, enhancing the dynamic construction capabilities at no identified cost. The update also comes with the added advantage of being able to override default completion arguments (for registered fns) seamlessly, fostering more flexibility in function calls without inducing errors due to keyword duplications.
   
3. **Enhancements to `cot.yaml`**
   - Refined to support a more generic 'cot', permitting the use of multiple completion functions through the new CLI argument, while ensuring backward compatibility. 
 
### Examples and Implications
A concise example can be drawn from the current `cot.yaml` registered completion function workflow, which registers multiple 'CompletionFn' instances, despite the only varying element being the `cot_completion_fn` arg. This enhancement allows for a streamlined approach, where a generic `cot` can replace the existing instances (I am not suggesting to actually remove these for backwards compatability reasons), facilitated by the '--completion_args' CLI argument.  This adjustment proves especially beneficial when considering versioned models (e.g.  `gpt-3.5-turbo-0613`).

```
cot/text-davinci-003:
  class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
  args:
    cot_completion_fn: text-davinci-003

cot/gpt-3.5-turbo:
  class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
  args:
    cot_completion_fn: gpt-3.5-turbo

cot/flan-t5-xl:
  class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
  args:
    cot_completion_fn: langchain/llm/flan-t5-xl
```
Could be replaced with:
```
cot:
  class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
```
If you want to provide a default value, that is still possible as well:
```
cot:
  class: evals.completion_fns.cot:ChainOfThoughtCompletionFn
    args:
      cot_completion_fn: gpt-3.5-turbo
```
Even with this reduction, we can run still run them all using `--completion-args`.
```
oaieval cot <eval-name> --completion_args "cot_completion_fn=<completion_fn>" 
```
`cot/text-davinci-003`, `gpt-3.5-turbo`, and `cot/flan-t5-xl` can be run this way instead:
```
oaieval cot <eval-name> --completion_args "cot_completion_fn=text-davinci-003"
oaieval cot <eval-name> --completion_args "cot_completion_fn=gpt-3.5-turbo"
oaieval cot <eval-name> --completion_args "cot_completion_fn=langchain/llm/flan-t5-xl"
```
Additionally, instead of registering new and/or versioned models:
```
oaieval cot <eval-name> --completion_args"cot_completion_fn=gpt-4"
oaieval cot <eval-name> --completion_args"cot_completion_fn=gpt-3.5-turbo-0613"
```

### Future Prospects
While the current (experimental) implementation serves as a straightforward example, the potential applications of this feature are vast, paving the way for a substantial set of keyword argument handled logic in future `completion_fn` developments.

By providing an easy interface to provide kwargs, future developers should in theory be able to utilize more advanced `completion_fn` run argument configurations without being limited to hardcoding args in their yaml config.

Thank you for considering this PR. I look forward to your feedback and the opportunity to further enhance this functionality.
