### PR TITLE
Chess eval: Changed typo 'beset' to 'best' in all 101 examples.

### DIFF
--- a/evals/registry/data/chess/match.jsonl
+++ b/evals/registry/data/chess/match.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cdaf29dc3e6449500804734d7a2f7dad63bab3c3cf053d9c6c0a735d76b3d47
-size 48775
+oid sha256:aefbe3480ab9c818e59a1915cf6442164d1bd0ce3697ad5659ead8a4ecb008e6
+size 48674


### PR DESCRIPTION
What the title says. The chess eval currently contains the same typo in every single prompt asking for the 'beset move' instead of the 'best move'. This PR fixes those typos.