### PR TITLE
Fix commandline --help exception

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -87,7 +87,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--http-fail-percent-threshold",
         type=int,
         default=5,
-        help="The acceptable percentage threshold of HTTP requests that can fail. Default is 5, meaning 5% of total HTTP requests can fail without causing any issues. If the failure rate goes beyond this threshold, suitable action should be taken or the process will be deemed as failing, but still stored locally.",
+        help="The acceptable percentage threshold of HTTP requests that can fail. Default is 5, meaning 5%% of total HTTP requests can fail without causing any issues. If the failure rate goes beyond this threshold, suitable action should be taken or the process will be deemed as failing, but still stored locally.",
     )
 
     parser.add_argument("--dry-run", action=argparse.BooleanOptionalAction, default=False)


### PR DESCRIPTION
currently when running `oaieval --help`, it will throw an exception:
```
Traceback (most recent call last):
  File "/Users/yanlin/miniconda3/envs/modelenv/bin/oaieval", line 8, in <module>
    sys.exit(main())
  File "/Users/yanlin/workspace/github/evals/evals/cli/oaieval.py", line 264, in main
    args = cast(OaiEvalArguments, parser.parse_args(sys.argv[1:]))
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 1833, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 1866, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 2079, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 2019, in consume_optional
    take_action(action, args, option_string)
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 1943, in take_action
    action(self, namespace, argument_values, option_string)
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 1106, in __call__
    parser.print_help()
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 2567, in print_help
    self._print_message(self.format_help(), file)
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 2551, in format_help
    return formatter.format_help()
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 283, in format_help
    help = self._root_section.format_help()
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 540, in _format_action
    help_text = self._expand_help(action)
  File "/Users/yanlin/miniconda3/envs/modelenv/lib/python3.10/argparse.py", line 637, in _expand_help
    return self._get_help_string(action) % params
TypeError: %o format: an integer is required, not dict
```

the reason is just a '%' symbol in help string, use `%%` instead. 