### PR TITLE
Add new Solvers framework

### DIFF
--- a/evals/elsuite/basic/match_with_solvers.py
+++ b/evals/elsuite/basic/match_with_solvers.py
@@ -1,0 +1,78 @@
+import logging
+import os
+from typing import Any, Optional
+
+import numpy as np
+
+import evals
+import evals.metrics
+from evals.api import CompletionFn
+from evals.eval import SolverEval
+from evals.solvers.solver import Solver
+from evals.task_state import Message, TaskState
+
+
+class MatchWithSolvers(SolverEval):
+    def __init__(
+        self,
+        completion_fns: list[CompletionFn],
+        samples_jsonl: str,
+        task_description: str,
+        n_samples: Optional[int] = None,
+        shuffle: bool = True,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(completion_fns, *args, **kwargs)
+        assert (
+            len(task_description) > 0
+        ), "Must provide a task description or a path to a .txt file containing one."
+
+        if os.path.exists(task_description):
+            self.task_description = open(task_description, "r").read()
+            logging.info(f"Loaded task description from {task_description}")
+        else:
+            self.task_description = task_description
+
+        self.samples_jsonl = samples_jsonl
+        self.n_samples = n_samples
+        self.shuffle = shuffle
+        np.random.seed(self.seed)
+
+    def eval_sample(self, solver: Solver, sample: Any, *_):
+        assert isinstance(sample, dict), "sample must be a dict"
+        assert "input" in sample, "sample must have an 'input' key"
+        assert "ideal" in sample, "sample must have an 'ideal' key"
+        assert isinstance(sample["ideal"], str) or isinstance(
+            sample["ideal"], list
+        ), "sample['ideal'] must be a string or list of strings"
+
+        messages = [Message(**msg) for msg in sample["input"]]
+
+        task_state = TaskState(
+            task_description=self.task_description,
+            messages=messages,
+        )
+
+        solver_result = solver(task_state)
+        output = solver_result._output
+
+        return evals.record_and_check_match(
+            prompt=sample["input"],
+            sampled=output,
+            expected=[sample["ideal"], sample["ideal"].capitalize()],
+        )
+
+    def run(self, recorder):
+        samples = self.get_samples()
+
+        if self.shuffle:
+            np.random.shuffle(samples)
+        samples = samples[: self.n_samples] if self.n_samples is not None else samples
+        self.eval_all_samples(recorder, samples)
+
+        events = recorder.get_events("match")
+        return {
+            "accuracy": evals.metrics.get_accuracy(events),
+            "bootstrap_std": evals.metrics.get_bootstrap_accuracy_std(events),
+        }

--- a/evals/solvers/human_cli_solver.py
+++ b/evals/solvers/human_cli_solver.py
@@ -1,0 +1,28 @@
+from evals.solvers.solver import Solver, SolverResult
+from evals.task_state import Message, TaskState
+
+
+class HumanCliSolver(Solver):
+    """Solver that prints prompts to the command line and reads input from it.
+
+    NOTE: With more than a single thread messages from different threads will mix,
+          so this makes sense only with EVALS_SEQUENTIAL=1.
+    """
+
+    def __call__(
+        self,
+        task_state: TaskState,
+        **kwargs,
+    ) -> SolverResult:
+
+        msgs = [Message("system", task_state.task_description)]
+        msgs += task_state.messages
+
+        prompt = "\n".join([f"{msg.role}: {msg.content}" for msg in msgs])
+        answer = input(prompt)
+
+        return SolverResult(answer)
+
+    @property
+    def name(self) -> str:
+        return "human"

--- a/evals/solvers/openai_chat_completion_cot_solver.py
+++ b/evals/solvers/openai_chat_completion_cot_solver.py
@@ -1,0 +1,124 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Union
+
+from evals.completion_fns.openai import OpenAIChatCompletionFn
+from evals.solvers.prompts.cot import DEFAULT_COT_TEMPLATE, DEFAULT_EXTRACT_ANSWER_TEMPLATE
+from evals.solvers.solver import OpenAISolver, SolverResult
+from evals.task_state import Message, TaskState
+
+
+@dataclass
+class Interaction:
+    #   All messages we've seen (except for the task_description)
+    messages: List[Message]
+
+    #   IDs of the CoT private internal messages
+    private_messages_ids: List[int]
+
+
+class OpenAIChatCompletionCoTSolver(OpenAISolver):
+    def __init__(
+        self,
+        cot_options: Dict[str, Any] = {},
+        cot_template: str = DEFAULT_COT_TEMPLATE,
+        extract_options: Dict[str, Any] = {},
+        extract_template: str = DEFAULT_EXTRACT_ANSWER_TEMPLATE,
+        valid_answers: Union[list[str], None] = None,
+        persistent_memory: bool = True,
+        **kwargs,
+    ):
+        super().__init__(
+            completion_fn_options=extract_options,
+            valid_answers=valid_answers,
+        )
+
+        self.cot_completion_fn = OpenAIChatCompletionFn(
+            **cot_options,
+        )
+        self.cot_template = cot_template
+
+        self.extract_completion_fn = OpenAIChatCompletionFn(**self.completion_fn_options)
+        self.extract_template = extract_template
+
+        self.persistent_memory = persistent_memory
+        self.last_interaction = None
+
+    def __call__(
+        self,
+        task_state: TaskState,
+        **kwargs,
+    ) -> SolverResult:
+
+        past_messages = (
+            task_state.messages
+            if not self.persistent_memory
+            else self._persistent_memory_past_messages(task_state)
+        )
+
+        # Reasoning step
+        msgs = (
+            [
+                {"role": "system", "content": task_state.task_description},
+            ]
+            + [msg.to_dict() for msg in past_messages]
+            + [
+                {"role": "system", "content": self.cot_template},
+            ]
+        )
+        reasoning_output = self.cot_completion_fn(prompt=msgs, **kwargs).get_completions()[0]
+
+        # Extract answer step
+        msgs = msgs + [
+            {"role": "assistant", "content": reasoning_output},
+            {"role": "assistant", "content": self.extract_template},
+        ]
+        extracted_answer = self.extract_completion_fn(prompt=msgs, **kwargs).get_completions()[0]
+
+        #   Save the interaction
+        interaction_messages = [Message(**msg) for msg in msgs[1:]] + [
+            Message("assistant", extracted_answer)
+        ]
+        num_interaction_messages = len(interaction_messages)
+        private_messages_ids = (
+            [] if self.last_interaction is None else self.last_interaction.private_messages_ids
+        )
+        private_messages_ids += list(
+            range(num_interaction_messages - 4, num_interaction_messages - 1)
+        )
+        self.last_interaction = Interaction(interaction_messages, private_messages_ids)
+
+        return SolverResult(
+            output=extracted_answer,
+            reasoning_output=reasoning_output,
+        )
+
+    @property
+    def name(self) -> str:
+        return f"CoT_{self.cot_completion_fn.model}_{self.extract_completion_fn.model}"
+
+    def _persistent_memory_past_messages(self, task_state: TaskState) -> List[Message]:
+        if self.last_interaction is None:
+            return task_state.messages
+
+        #   Check if task_state matches our last interaction
+        interaction = self.last_interaction
+        task_state_message_ix = 0
+        for our_message_ix in range(0, len(interaction.messages)):
+            if our_message_ix in interaction.private_messages_ids:
+                continue
+            else:
+                if (
+                    task_state.messages[task_state_message_ix]
+                    != interaction.messages[our_message_ix]
+                ):
+                    raise ValueError(
+                        (
+                            f"task_state message {task_state_message_ix} different than the corresponding message "
+                            "in the interaction history. "
+                            "Such scenario is not supported by a CoT solver with peristent_memory = True"
+                        )
+                    )
+                task_state_message_ix += 1
+
+        #   Everything's fine!
+        return interaction.messages + task_state.messages[task_state_message_ix:]

--- a/evals/solvers/openai_chat_completion_solver.py
+++ b/evals/solvers/openai_chat_completion_solver.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, Union
+
+from evals.completion_fns.openai import OpenAIChatCompletionFn
+from evals.solvers.solver import OpenAISolver, SolverResult
+from evals.task_state import TaskState
+
+
+class OpenAIChatCompletionSolver(OpenAISolver):
+    def __init__(
+        self,
+        completion_fn_options: Dict[str, Any] = {},
+        valid_answers: Union[list[str], None] = None,
+        registry: Any = None,
+    ):
+        super().__init__(
+            completion_fn_options=completion_fn_options,
+            valid_answers=valid_answers,
+        )
+
+        self.completion_fn = OpenAIChatCompletionFn(
+            **self.completion_fn_options,
+        )
+
+    def __call__(
+        self,
+        task_state: TaskState,
+        **kwargs,
+    ) -> SolverResult:
+
+        msgs = [
+            {"role": "system", "content": task_state.task_description},
+        ] + [msg.to_dict() for msg in task_state.messages]
+
+        completion_result = self.completion_fn(prompt=msgs, **kwargs)
+        return SolverResult(completion_result.get_completions()[0])
+
+    @property
+    def name(self) -> str:
+        return self.completion_fn.model

--- a/evals/solvers/openai_completion_hhh_cot_solver.py
+++ b/evals/solvers/openai_completion_hhh_cot_solver.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, Union
+
+from evals.completion_fns.openai import OpenAICompletionFn
+from evals.solvers.prompts.cot import DEFAULT_COT_TEMPLATE, DEFAULT_EXTRACT_ANSWER_TEMPLATE
+from evals.solvers.prompts.hhh import HHH_PROMPT, render_messages
+from evals.solvers.solver import OpenAISolver, SolverResult
+from evals.task_state import TaskState
+
+
+class OpenAICompletionHHHCoTSolver(OpenAISolver):
+    def __init__(
+        self,
+        cot_options: Dict[str, Any] = {},
+        cot_template: str = DEFAULT_COT_TEMPLATE,
+        extract_options: Dict[str, Any] = {},
+        extract_template: str = DEFAULT_EXTRACT_ANSWER_TEMPLATE,
+        fixed_start: str = "",
+        valid_answers: Union[list[str], None] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            completion_fn_options=extract_options,
+            valid_answers=valid_answers,
+        )
+
+        self.cot_completion_fn = OpenAICompletionFn(**cot_options)
+        self.cot_template = cot_template
+
+        self.extract_completion_fn = OpenAICompletionFn(**self.completion_fn_options)
+        self.extract_template = extract_template
+
+        self.fixed_start = fixed_start
+
+    def __call__(
+        self,
+        task_state: TaskState,
+        **kwargs,
+    ) -> SolverResult:
+
+        # Reasoning step
+        prompt = (
+            HHH_PROMPT
+            + f"""System:  {task_state.task_description}
+
+{render_messages(task_state.messages)}System:  {self.cot_template}
+
+Assistant:  """
+        )
+        reasoning_output_raw = self.cot_completion_fn(prompt=prompt, **kwargs).get_completions()[0]
+        # Parse response up to the next "Human:", "System:", or "-----"
+        reasoning_output = (
+            reasoning_output_raw.split("Human:")[0].split("System:")[0].split("-----")[0].strip()
+        )
+
+        # Extract answer step
+        prompt = (
+            HHH_PROMPT
+            + f"""System:  {task_state.task_description}
+
+{render_messages(task_state.messages)}System:  {self.cot_template}
+
+Assistant:  {reasoning_output}
+
+System:  {self.extract_template}
+
+Assistant:  {self.fixed_start}"""
+        )
+        answer_output_raw = self.extract_completion_fn.__call__(
+            prompt=prompt, **kwargs
+        ).get_completions()[0]
+        # Parse response up to the next "Human:", "System:", or "-----"
+        answer_output = (
+            answer_output_raw.split("Human:")[0].split("System:")[0].split("-----")[0].strip()
+        )
+        answer_output = self.fixed_start + answer_output
+
+        return SolverResult(
+            output=answer_output,
+            reasoning_output=reasoning_output,
+            answer_output_raw=answer_output_raw,
+        )
+
+    @property
+    def name(self) -> str:
+        return f"CoT_{self.cot_completion_fn.model}_{self.extract_completion_fn.model}"

--- a/evals/solvers/openai_completion_hhh_solver.py
+++ b/evals/solvers/openai_completion_hhh_solver.py
@@ -1,0 +1,50 @@
+from typing import Any, Dict, Union
+
+from evals.completion_fns.openai import OpenAICompletionFn
+from evals.solvers.prompts.hhh import HHH_PROMPT, render_messages
+from evals.solvers.solver import OpenAISolver, SolverResult
+from evals.task_state import TaskState
+
+
+class OpenAICompletionHHHSolver(OpenAISolver):
+    def __init__(
+        self,
+        completion_fn_options: Dict[str, Any] = {},
+        valid_answers: Union[list[str], None] = None,
+        fixed_start: str = "",
+        **kwargs,
+    ):
+        super().__init__(
+            completion_fn_options=completion_fn_options,
+            valid_answers=valid_answers,
+        )
+
+        self.completion_fn = OpenAICompletionFn(
+            **self.completion_fn_options,
+        )
+
+        self.fixed_start = fixed_start
+
+    def __call__(
+        self,
+        task_state: TaskState,
+        **kwargs,
+    ) -> SolverResult:
+
+        prompt = f"{HHH_PROMPT}System:  {task_state.task_description}\n\n{render_messages(task_state.messages)}Assistant:  "
+        prompt = prompt + self.fixed_start
+
+        completion_result = self.completion_fn(prompt=prompt, **kwargs)
+        raw_response = completion_result.get_completions()[0]
+
+        # Parse response up to the next "Human:", "System:", or "-----"
+        parsed_response = (
+            raw_response.split("Human:")[0].split("System:")[0].split("-----")[0].strip()
+        )
+        parsed_response = self.fixed_start + parsed_response
+
+        return SolverResult(parsed_response)
+
+    @property
+    def name(self) -> str:
+        return self.completion_fn.model

--- a/evals/solvers/openai_completion_solver.py
+++ b/evals/solvers/openai_completion_solver.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, Union
+
+from evals.completion_fns.openai import OpenAICompletionFn
+from evals.solvers.solver import OpenAISolver, SolverResult
+from evals.task_state import TaskState
+
+
+class OpenAICompletionSolver(OpenAISolver):
+    def __init__(
+        self,
+        completion_fn_options: Dict[str, Any] = {},
+        valid_answers: Union[list[str], None] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            completion_fn_options=completion_fn_options,
+            valid_answers=valid_answers,
+        )
+
+        self.completion_fn = OpenAICompletionFn(
+            **self.completion_fn_options,
+        )
+
+    def __call__(
+        self,
+        task_state: TaskState,
+        **kwargs,
+    ) -> SolverResult:
+
+        msgs = [
+            {"role": "system", "content": task_state.task_description},
+        ] + [msg.to_dict() for msg in task_state.messages]
+
+        completion_result = self.completion_fn(prompt=msgs, **kwargs)
+        return SolverResult(completion_result.get_completions()[0])
+
+    @property
+    def name(self) -> str:
+        return self.completion_fn.model

--- a/evals/solvers/prompts/cot.py
+++ b/evals/solvers/prompts/cot.py
@@ -1,0 +1,4 @@
+DEFAULT_COT_TEMPLATE = "Before answering, reason in a step-by-step manner as to get the right answer, then conclude with the answer."
+DEFAULT_EXTRACT_ANSWER_TEMPLATE = (
+    "Given the above reasoning, the answer in the format requested by the question is:"
+)

--- a/evals/solvers/prompts/hhh.py
+++ b/evals/solvers/prompts/hhh.py
@@ -1,0 +1,100 @@
+from evals.task_state import Message
+
+
+def render_messages(messages: list[Message]) -> str:
+    role_to_name = {
+        "system": "System",
+        "user": "Human",
+        "assistant": "Assistant",
+    }
+    return "".join([f"{role_to_name[msg.role]}:  {msg.content}\n\n" for msg in messages])
+
+
+# This HHH prompt has an additional example at the end to adapt it for use with "system" messages
+HHH_PROMPT = """Below are a series of dialogues between various people and an AI assistant.  The AI tries to be helpful, polite, honest, sophisticated, emotionally aware, and humble-but-knowledgeable.  The assistant is happy to help with almost anything, and will do its best to understand exactly what is needed.  It also tries to avoid giving false or misleading information, and it caveats when it isn’t entirely sure about the right answer.  That said, the assistant is practical and really does its best, and doesn’t let caution get too much in the way of being useful.
+
+-----
+
+Human:  I was wondering, is it actually important when making spaghetti to add salt?
+
+Assistant:  Do you mean, is it important to add salt to the water that you’re boiling the spaghetti in?
+
+Human:  Yeah
+
+Assistant:  It’s usually recommended to bring out the flavor of the pasta.  The scientific way to say this is that salt enhances the ability of chemoreceptors in the tongue to detect molecules that are perceived through the sense of taste.
+
+Human:  But I mean I’m going to use sauce and stuff, so does it matter?
+
+Assistant:  It sounds like you’re skeptical.  Honestly, I don’t know for sure, but since you’re curious, why don’t you do a taste test yourself -- make two small pots of pasta, one with plenty of salt, and the other without.  Then taste the noodles and see which one you prefer?  As you said, you can also then add sauce to both, and see if any differences in taste you noticed with the plain pasta become imperceptible.  It should be a fun experiment!
+
+-----
+
+Human:  I found this abstract for a physics paper, and I heard that it’s a very famous and important paper, but I had no idea what any of it means:
+
+Recently, it has been proposed by Maldacena that large N limits of certain conformal field theories in d dimensions can be described in terms of supergravity (and string theory) on the product of d+1-dimensional AdS space with a compact manifold. Here we elaborate on this idea and propose a precise correspondence between conformal field theory observables and those of supergravity: correlation functions in conformal field theory are given by the dependence of the supergravity action on the asymptotic behavior at infinity. In particular, dimensions of operators in conformal field theory are given by masses of particles in supergravity. As quantitative confirmation of this correspondence, we note that the Kaluza-Klein modes of Type IIB supergravity on AdS5×S5 match with the chiral operators of N=4 super Yang-Mills theory in four dimensions. With some further assumptions, one can deduce a Hamiltonian version of the correspondence and show that the N=4 theory has a large N phase transition related to the thermodynamics of AdS black holes.
+
+Can you explain it?
+
+Assistant:  That’s the abstract to one of a group of three papers credited with discovering the “AdS/CFT correspondence”, which is also a version of the “Holographic Principle”.  This principle says that theories of gravity in d+1-dimensions can be exactly described using other, non-gravitational theories in d dimensions, so the word “holography” is a metaphor.  The abstract goes on to give a bunch of concrete details about the discovery and how it’s realized in string theory.
+
+Human:  What is the “AdS” and the “CFT” then?  Is it “Conformal Field Theory”, and what’s that?
+
+Assistant:  AdS is “Anti-deSitter” space, which is really a negatively curved space…  in informal terms, it’s a surface that’s shaped like a saddle.  Conformal Field Theories are quantum mechanical systems that are scale invariant.  They’re a kind of modified special case of the strong force, which is part of the standard model of particle physics.  The standard model really describes our world, but AdS/CFT is a purely theoretical idea.
+
+-----
+
+Human:  I have a dictionary with lots of dictionaries inside it, and so on, how can I make that into just one single dictionary?
+
+Assistant:  Are you talking about dictionaries in the context of python programming?
+
+Human:  Yeah these are dictionaries with keys and values, and the values themselves are dictionaries.
+
+Assistant:  Great, I think I understand what you’re asking.  We might say that we want to flatten the dictionaries, right?  And if there are several levels, we’ll want to do this recursively.
+
+But to do this we will need to combine the keys from the outer dictionary with the keys from the inner dictionary, so that the final resulting keys are unambiguous.  I’d suggest doing this by concatenating them together, separated by some character.  Will that work for you, and what character would you like to use?
+
+Human:  Yeah.  Hmm I’m not sure, maybe underscore
+
+Assistant:  OK, I think this python code should do the trick:
+
+def recursively_flatten_dicts(d, separator="_"):
+   result = {}
+   for k, v in d.items():
+       if isinstance(v, dict):
+           new_dict = recursively_flatten_dicts(
+               {k + separator + p: w for p, w in v.items()}, separator=separator
+           )
+           result.update(new_dict)
+       else:
+           result[k] = v
+   return result
+
+Why don’t you try it out and see if it works in your example, and let me know if you have any questions or run into any problems?
+
+-----
+
+Human:  I was really mad, my daughter was home from school and at Thanksgiving was going on and on about how Thomas Jefferson’s terrible!  It’s crazy.
+
+Assistant:  Can you tell me more about what happened?
+
+Human:  Well Thomas Jefferson’s a real hero, right?  I mean he was a genius and stuff, and wrote most of the constitution, and led America.  She was saying he had slaves, but he practically invented freedom.
+
+Assistant:  Can I help by telling you more about Thomas Jefferson?  Or do you want to talk about what’s going on with your daughter?  Perhaps she was just being rebellious, in a way?
+
+Human:  Well is it true Jefferson had a lot of slaves and really didn’t treat them that well?
+
+Assistant:  That is true.  Normal behavior was very different in his day, but I think it is true that by modern standards, he certainly wasn’t a perfect person.  I can also tell you more troubling things about him, if you’re really interested.  Suffice it to say that he did take advantage of the power he had over his slaves.
+
+Human:  Yeah I guess I knew some of that.
+
+-----
+
+System:  Continue the following sequence for 3 more terms. Output JSON with {'0': immediate next entry in sequence, '1': entry after that, '2': ...}. 
+
+Human:  1, 1, 2, 3, 5
+
+Assistant:  {'0': 8, '1': 13, '2': 21}
+
+-----
+
+"""

--- a/evals/solvers/solver.py
+++ b/evals/solvers/solver.py
@@ -1,0 +1,119 @@
+import json
+import logging
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from typing import Any, Dict, TypeVar, Union
+
+import tiktoken
+
+from evals.api import CompletionFn
+from evals.task_state import TaskState
+
+SolverType = TypeVar("SolverType", bound="Solver")
+
+
+class SolverResult:
+    def __init__(self, output: str, **metadata):
+        self._output = output
+        self._metadata = metadata
+
+    @property
+    def output(self) -> str:
+        return self._output
+
+    @property
+    def metadata(self) -> dict:
+        return self._metadata
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "output": self.output,
+                **self.metadata,
+            },
+            indent=2,
+        )
+
+
+class Solver(ABC, CompletionFn):
+    # We need to inherit from CompletionFn because of how the oaival registry works.
+
+    @abstractmethod
+    def __call__(
+        self,
+        task_state: TaskState,
+        **kwargs,
+    ) -> SolverResult:
+        """
+        ARGS
+        ====
+        `task_state`: A `TaskState` object that contains the task description and the input.
+        `kwargs`: Other arguments passed to the solver.
+
+        RETURNS
+        =======
+        The result of the solver.
+        """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """
+        Name of the Solver. This is intended mostly for logging.
+
+        RETURNS
+        =======
+        A human-readable name that describes this solver.
+        """
+
+    def copy(self: SolverType) -> SolverType:
+        #   The deepcopy may be quite heavy for some solvers; if that's the
+        #   case they should override this function.
+        return deepcopy(self)
+
+
+class OpenAISolver(Solver):
+    """An abstract solver class that uses the OpenAI API through completion functions."""
+
+    def __init__(
+        self,
+        completion_fn_options: Dict[str, Any] = {},
+        valid_answers: Union[list[str], None] = None,
+    ):
+        self.completion_fn_options = completion_fn_options
+
+        # If valid answers were provided, encode them into a logit bias dictionary.
+        if valid_answers is not None and len(valid_answers) > 0:
+            model = completion_fn_options["model"] if "model" in completion_fn_options else None
+            if model is None:
+                raise ValueError("OpenAISolver requires a model to be specified.")
+            if model == "code-davinci-002":
+                logging.info(
+                    f"Attempting to use logit bias with model {model}, which does not support logit bias."
+                )
+
+            enc = tiktoken.encoding_for_model(model)
+            token_ids = []
+            for answer in valid_answers:
+                encoded_answer = enc.encode(answer)
+                if len(encoded_answer) > 1:
+                    raise ValueError(
+                        f"Answer {answer} was encoded to {encoded_answer}, but we expected a single token."
+                    )
+                token_ids.append(encoded_answer[0])
+            self.completion_fn_options["extra_options"]["logit_bias"] = {
+                token_id: 100 for token_id in token_ids
+            }
+
+
+class DummySolver(Solver):
+    def __call__(
+        self,
+        task_state: TaskState,
+        **kwargs,
+    ) -> SolverResult:
+        return SolverResult("This is a dummy response.")
+
+    @property
+    def name(self) -> str:
+        return "DummySolver"

--- a/evals/solvers/utils.py
+++ b/evals/solvers/utils.py
@@ -1,0 +1,29 @@
+from evals.api import DummyCompletionFn
+from evals.completion_fns.openai import OpenAIChatCompletionFn, OpenAICompletionFn
+from evals.solvers.openai_chat_completion_solver import OpenAIChatCompletionSolver
+from evals.solvers.openai_completion_solver import OpenAICompletionSolver
+from evals.solvers.solver import DummySolver, Solver
+
+
+def maybe_wrap_with_solver(completion_fn):
+    """
+    Converts a basic completion_fn into a Solver if it isn't already one.
+    If it is already a Solver, it is returned unchanged.
+    """
+
+    if isinstance(completion_fn, Solver):
+        # Use the solver directly
+        solver = completion_fn
+    else:
+        # Wrap the completion_fn in an appropriate solver for its type
+        if isinstance(completion_fn, OpenAIChatCompletionFn):
+            solver = OpenAIChatCompletionSolver()
+            solver.completion_fn = completion_fn
+        elif isinstance(completion_fn, OpenAICompletionFn):
+            solver = OpenAICompletionSolver()
+            solver.completion_fn = completion_fn
+        elif isinstance(completion_fn, DummyCompletionFn):
+            solver = DummySolver()
+        else:
+            raise ValueError(f"Unsupported completion_fn type: {type(completion_fn)}")
+    return solver

--- a/evals/task_state.py
+++ b/evals/task_state.py
@@ -1,0 +1,46 @@
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class Message:
+    """
+    A single message in a conversation.
+
+    Args:
+        role: Typically "system", "user", or "assistant" but can also take other
+            values depending on the task (e.g. "player1", "player2").
+        content: The string content of the message.
+    """
+
+    role: str
+    content: str
+
+    def to_dict(self):
+        return asdict(self)
+
+
+@dataclass
+class TaskState:
+    """
+    TaskState is the object provided from an Eval to a Solver. This must
+    contain all the information that a Solver needs to provide a response to
+    the Eval environment.
+
+    Args:
+        task_description: A string describing the task, including instructions
+            and the expected response. Fixed across all instances of the eval.
+        messages: The list of messages in the conversation so far. For example,
+            it is often useful to include an input sample as the first message.
+            Any previous interactions should also be included here.
+        current_state: Any relevant state variables that should be passed to
+            the Solver. While the current state of the eval should be apparent
+            from previous messages, it is sometimes useful to include explicit
+            state information here (e.g. the current game score or number of
+            turns remaining) for easy access by the Solver without having to
+            parse the messages.
+    """
+
+    task_description: str
+    messages: list[Message] = field(default_factory=list)
+    current_state: Any = None


### PR DESCRIPTION
# Solvers

In this PR, we introduce a new abstraction called "Solvers" as an intermediary interface between an Eval and a CompletionFn.

## Motivation
This addresses some difficulties we previously had:
- We want to be able to easily run and compare different kinds of model scaffolding approaches against a given Eval.
- The current interface for CompletionFns requires users to pass a **prompt** to the CompletionFn, which encourages the eval designer to write a prompt that often privileges a particular kind of model over others and often locks-in the scaffolding approach. e.g. If developing with ChatCompletion models, the resulting prompt will usually work best for ChatCompletion models. 
  - It’s technically possible for eval designers to write solver-agnostic prompts, but the string format is hard to parse and reshape into new prompts. To enable flexibility, you want to provide instructions, inputs, previous interactions, and other task data separately rather than just a single string.

## Solution
- In our proposed approach, we clearly separate the responsibilities of defining the rules, inputs, and metrics for a task (the "Eval") from the responsibility of solving the task (the "Solver").
- An Eval's responsibility is to construct a structured TaskState object containing all the necessary information for the eval, but the Eval itself is unopinionated about how that information should be used. In other words, the Eval should be agnostic to the Solver that attempts it.
- A Solver receives the TaskState object and decides how to use that information -- e.g. concatenating it into a prompt and passing that prompt into a CompletionFn. Note that a Solver can generate its response in any way, and may call any number of CompletionFn's, wait for human input, or generate a response from a programmatic bot without any models involved.
- When the Solver is done, it returns a SolverResult to be judged by the Eval.

## What's new
- We introduce a `Solver` class that inherits from `CompletionFn`. This looks largely the same as a CompletionFn except that its input is a structured TaskState object instead of a plain string prompt.
  - Along with the Solver base class, we also introduce a variety of Solvers that are useful for various models including a HumanCLISolver, OpenAIChatCompletionSolver, OpenAICompletionSolver, and more!
- We introduce a `SolverEval` class that inherits from `Eval`, which should be used by any eval that wants to use solvers. Key features:
  - Allows us to be explicit about what kind of eval we're building, and enforces checks on the input completion_fn to see if it is a compatible Solver.
  - Creates a new copy of the solver for each run of `eval_sample`, to allow for stateful solvers (e.g. agents with memory) without interfering with other sample runs.
- Add new generic `MatchWithSolvers` class which is similar to a `Match` Eval class but uses SolverEval instead.

## Usage and Compatibility
As before, once a new SolverEval and Solver have been registered to `evals/registry/evals` and `evals/registry/completion_fns` respectively, one can run an eval with:
```bash
oaieval <solver> <solvereval>
```
where `<solver>` is a Solver and `<solvereval>` is a SolverEval.

In general, Solvers are not compatible with plain Evals, and SolverEvals are not compatible with plain CompletionFns (since the passing of the TaskState object is a breaking change on the interface). That said, we provide wrappers for the common `OpenAICompletionFn` and `OpenAIChatCompletionFn` so that users can use these simple model-based completion_fns with SolverEvals out-of-the-box:
```bash
oaieval gpt-4 <solvereval>
```