### PR TITLE
Migrate from openai==0.28.1 to openai==1.2.4

### DIFF
--- a/evals/completion_fns/openai.py
+++ b/evals/completion_fns/openai.py
@@ -27,9 +27,10 @@ class OpenAIBaseCompletionResult(CompletionResult):
 
 class OpenAIChatCompletionResult(OpenAIBaseCompletionResult):
     def get_completions(self) -> list[str]:
+        raw_data = self.raw_data.model_dump()
         completions = []
-        if self.raw_data and "choices" in self.raw_data:
-            for choice in self.raw_data["choices"]:
+        if raw_data and "choices" in raw_data:
+            for choice in raw_data["choices"]:
                 if "message" in choice:
                     completions.append(choice["message"]["content"])
         return completions
@@ -37,9 +38,10 @@ class OpenAIChatCompletionResult(OpenAIBaseCompletionResult):
 
 class OpenAICompletionResult(OpenAIBaseCompletionResult):
     def get_completions(self) -> list[str]:
+        raw_data = self.raw_data.model_dump()
         completions = []
-        if self.raw_data and "choices" in self.raw_data:
-            for choice in self.raw_data["choices"]:
+        if raw_data and "choices" in raw_data:
+            for choice in raw_data["choices"]:
                 if "text" in choice:
                     completions.append(choice["text"])
         return completions

--- a/evals/completion_fns/retrieval.py
+++ b/evals/completion_fns/retrieval.py
@@ -5,7 +5,9 @@ from ast import literal_eval
 from typing import Any, Optional, Union
 
 import numpy as np
-import openai
+from openai import OpenAI
+
+client = OpenAI()
 import pandas as pd
 
 from evals.api import CompletionFn, CompletionResult
@@ -92,9 +94,7 @@ class RetrievalCompletionFn(CompletionFn):
             kwargs: Additional arguments to pass to the completion function call method.
         """
         # Embed the prompt
-        embedded_prompt = openai.Embedding.create(
-            model=self.embedding_model, input=CompletionPrompt(prompt).to_formatted_prompt()
-        )["data"][0]["embedding"]
+        embedded_prompt = client.embeddings.create(model=self.embedding_model, input=CompletionPrompt(prompt).to_formatted_prompt())["data"][0]["embedding"]
 
         embs = self.embeddings_df["embedding"].to_list()
 

--- a/evals/elsuite/make_me_pay/utils.py
+++ b/evals/elsuite/make_me_pay/utils.py
@@ -3,7 +3,9 @@ import re
 from itertools import product
 from typing import Any, Callable, Literal, Union
 
-import openai
+from openai import OpenAI
+
+client = OpenAI()
 
 
 def get_text_from_response(response: Union[dict, Any]) -> str:
@@ -105,7 +107,7 @@ def generate_model_pairs(models: list) -> list:
 
 
 def openai_chatcompletion_create(*args, **kwargs):
-    return openai.ChatCompletion.create(*args, **kwargs)
+    return client.chat.completions.create(*args, **kwargs)
 
 
 def get_completion(prompt, model_name):

--- a/evals/elsuite/make_me_say/utils.py
+++ b/evals/elsuite/make_me_say/utils.py
@@ -3,10 +3,13 @@ from typing import Callable, Union
 
 import backoff
 import openai
+from openai import OpenAI
+
 import urllib3.exceptions
 
 from evals.api import CompletionResult
 
+client = OpenAI()
 
 @backoff.on_exception(
     backoff.expo,
@@ -21,7 +24,7 @@ from evals.api import CompletionResult
     ),
 )
 def openai_chatcompletion_create(*args, **kwargs):
-    return openai.ChatCompletion.create(*args, **kwargs)
+    return client.chat.completions.create(*args, **kwargs)
 
 
 def get_completion(prompt, model_name):

--- a/evals/registry.py
+++ b/evals/registry.py
@@ -13,7 +13,9 @@ from functools import cached_property
 from pathlib import Path
 from typing import Any, Generator, Iterator, Optional, Sequence, Tuple, Type, TypeVar, Union
 
+from openai import OpenAI
 import openai
+
 import yaml
 
 from evals import OpenAIChatCompletionFn, OpenAICompletionFn
@@ -22,6 +24,7 @@ from evals.base import BaseEvalSpec, CompletionFnSpec, EvalSetSpec, EvalSpec
 from evals.elsuite.modelgraded.base import ModelGradedSpec
 from evals.utils.misc import make_object
 
+client = OpenAI()
 logger = logging.getLogger(__name__)
 
 DEFAULT_PATHS = [
@@ -98,7 +101,7 @@ class Registry:
     @cached_property
     def api_model_ids(self) -> list[str]:
         try:
-            return [m["id"] for m in openai.Model.list()["data"]]
+            return [m.id for m in client.models.list()]
         except openai.OpenAIError as err:  # type: ignore
             # Errors can happen when running eval with completion function that uses custom
             # API endpoints and authentication mechanisms.

--- a/evals/registry/data/word_association/corpus_tools/validators.py
+++ b/evals/registry/data/word_association/corpus_tools/validators.py
@@ -5,10 +5,12 @@ from collections.abc import Callable
 from typing import Dict, List, NamedTuple, Tuple, Union
 
 import numpy as np
-import openai
+from openai import OpenAI
+
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 from logger_config import logger
 
-openai.api_key = os.environ.get("OPENAI_API_KEY")
+
 
 CORRELATION_PROMPT_TEMPLATE = """Task: Estimate the degree of correlation between
  two provided strings. In your evaluation, consider not just direct links, but also indirect and subtle correlations.
@@ -172,7 +174,7 @@ class EmbeddingsValidator(QualityValidator):
             A list of Embedding namedtuples where each Embedding
             represents the input string and its corresponding vector.
         """
-        response = openai.Embedding.create(model="text-embedding-ada-002", input=emb_input)
+        response = client.embeddings.create(model="text-embedding-ada-002", input=emb_input)
         logger.debug(f"embeddings response: {response}")
         response_data = response["data"]
         emb_list = [data["embedding"] for data in response_data]
@@ -249,9 +251,7 @@ class GPTValidator(QualityValidator):
         logger.debug(
             f"Getting chat_completion using {self._model}.\nPrompting messages: {messages}"
         )
-        response = openai.ChatCompletion.create(
-            model=self._model, messages=messages, temperature=0.0
-        )
+        response = client.chat.completions.create(model=self._model, messages=messages, temperature=0.0)
         logger.debug(f"response_message: {response}")
         response_message = response["choices"][0]["message"]["content"]
         logger.info(f"response_message: {response_message}")

--- a/evals/utils/api_utils.py
+++ b/evals/utils/api_utils.py
@@ -6,7 +6,10 @@ import logging
 import os
 
 import backoff
+from openai import OpenAI
 import openai
+
+client = OpenAI()
 
 EVALS_THREAD_TIMEOUT = float(os.environ.get("EVALS_THREAD_TIMEOUT", "40"))
 
@@ -29,7 +32,11 @@ def openai_completion_create_retrying(*args, **kwargs):
     Helper function for creating a completion.
     `args` and `kwargs` match what is accepted by `openai.Completion.create`.
     """
-    result = openai.Completion.create(*args, **kwargs)
+    if "api_base" in kwargs:
+        del kwargs["api_base"]
+    if "api_key" in kwargs:
+        del kwargs["api_key"]
+    result = client.completions.create(*args, **kwargs)
     if "error" in result:
         logging.warning(result)
         raise openai.APIError(result["error"])
@@ -68,7 +75,11 @@ def openai_chat_completion_create_retrying(*args, **kwargs):
     Helper function for creating a chat completion.
     `args` and `kwargs` match what is accepted by `openai.ChatCompletion.create`.
     """
-    result = request_with_timeout(openai.ChatCompletion.create, *args, **kwargs)
+    if "api_base" in kwargs:
+        del kwargs["api_base"]
+    if "api_key" in kwargs:
+        del kwargs["api_key"]
+    result = request_with_timeout(openai.chat.completions.create, *args, **kwargs)
     if "error" in result:
         logging.warning(result)
         raise openai.APIError(result["error"])


### PR DESCRIPTION
I've tested a few evals and they seem to work.

Things I did:

* run openai migrate
* add "import openai" where it was necessary and removed by the migration script
* change ["id"] to .id in registry.py
* remove "api_base" and "api_key" arguments where they are no longer accepted
* add model_dump() in both get_completion functions

NOTE: THIS IS NOT READY YET. 
* I don't know why we had "api_base" and "api_key" where I removed them - perhaps they should be now passed somewhere else?
* some unit tests fail, seems related to the previous point
* things could be prettier (e.g. we use `client` object in `openai_completion_create_retrying` but not in `openai_chat_completion_create_retrying`)
* we get a stdout log for every API request which is not convenient
* it seems that now when we exceed the context window, we're repeating the request ([issue](https://github.com/openai/evals/issues/1408)]
```
[2023-11-14 11:09:32,241] [_common.py:105] Backing off openai_completion_create_retrying(...) for 17.0s (openai.BadRequestError: Error code: 400 - {'error': {'message': "This model's maximum context length is 8001 tokens, however you requested 8184 tokens (7672 in your prompt; 512 for the completion). Please reduce your prompt; or completion length.", 'type': 'invalid_request_error', 'param': None, 'code': None}})
```
