### PR TITLE
Choose completion function for evaluation of modelgraded evals

### DIFF
--- a/evals/elsuite/modelgraded/classify.py
+++ b/evals/elsuite/modelgraded/classify.py
@@ -21,13 +21,17 @@ class ModelBasedClassify(evals.Eval):
         eval_kwargs: Optional[dict[str, Any]] = None,
         multicomp_n: Union[int, str] = 1,
         eval_type: Optional[str] = None,
+        eval_completion_fn: Optional[str] = None,
         match_fn: Optional[str] = None,
         metaeval: bool = False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        # treat last completion_fn as eval_completion_fn
-        self.eval_completion_fn = self.completion_fns[-1]
+        if eval_completion_fn:
+            self.eval_completion_fn = self.registry.make_completion_fn(eval_completion_fn)
+        else:
+            # treat last completion_fn as eval_completion_fn
+            self.eval_completion_fn = self.completion_fns[-1]
         if len(self.completion_fns) > 1:
             self.completion_fns = self.completion_fns[:-1]
         n_models = len(self.completion_fns)


### PR DESCRIPTION
The [documentation](https://github.com/openai/evals/blob/main/docs/eval-templates.md#the-model-graded-eval-template) for modelgraded evals says:

> In general, the evaluation model and the model being evaluated don't have to be the same, though we will assume that they are here for ease of explanation.

However, the current code did not allow to do this. Indeed, [`classify.py:ModelBasedClassify`](../evals/elsuite/modelgraded/classify.py)  had the following line: https://github.com/openai/evals/blob/7400b0ee3934d64ff6efd9d4ec04be631625c014/evals/elsuite/modelgraded/classify.py#L30

I have now added an additional optional parameter to ModelBasedClassify which allows to pick a different model for the evaluation from the evaluated one. The model for the evaluation has to be specified from the `.yaml` file, for instance with:

```
<my_eval>:
  id: <my_eval>.test.v1
  metrics:
  - accuracy
<my_eval>.test.v1:
  args:
    eval_type: cot_classify
    modelgraded_spec: fact
    samples_jsonl: ../registry/data/<my_eval>/samples.jsonl
    eval_completion_fn: gpt-3.5-turbo
  class: evals.elsuite.modelgraded.classify:ModelBasedClassify
```

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `mypy`, `black`, `isort`, `autoflake` and `ruff` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.
