### PR TITLE
Run tests on all commits to main

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   check_files:


### PR DESCRIPTION
Because people contribute to the repo via forks, we can't run tests depending on secrets in PRs. This change updates our action so the tests depending on secrets run on merge (giving us signal on if we need to revert the PR or not)