### PR TITLE
Use the API key for testing evals in CI

### DIFF
--- a/.github/workflows/test_eval.yaml
+++ b/.github/workflows/test_eval.yaml
@@ -43,6 +43,8 @@ jobs:
         echo "new_files=$(cat new_files)" >> $GITHUB_ENV
 
     - name: Run oaieval command for each new YAML file
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
         files="${{ env.new_files }}"
         if [ -n "$files" ]; then


### PR DESCRIPTION
Passes in the API key for testing new evals via CI checks (note: only works for PRs made from a branch within the repo)