### PR TITLE
Release 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "evals"
-version = "1.0.3.post1"
+version = "2.0.0.post1"
 requires-python = ">=3.9"
+readme = "README.md"
 dependencies = [
     "mypy",
     "openai>=1.0.0",
@@ -34,6 +35,9 @@ dependencies = [
     "seaborn",
     "statsmodels",
 ]
+
+[project.urls]
+repository = "https://github.com/openai/evals"
 
 [project.optional-dependencies]
 formatters = [


### PR DESCRIPTION
Releases 2.0.0 of evals. This is a major version bump because:
* openai-python is bumped to >1.0.0, which reflects a major breaking change to many uses of the repo
* We haven't released a version since April, so it seems fair to bump to 2.0.0 since there may be significant breaking changes to the code in the last 8 months

The release is successfully pushed to PyPi: https://pypi.org/project/evals/. Updating the repo to reflect the new version.

In future work, I'll set up a github action to publish versions to PyPi when the version string is bumped