### PR TITLE
Fix Pydantic warning on data_test run

### DIFF
--- a/evals/data.py
+++ b/evals/data.py
@@ -188,7 +188,7 @@ def _to_py_types(o: Any, exclude_keys: List[Text]) -> Any:
     if isinstance(o, pydantic.BaseModel):
         return {
             k: _to_py_types(v, exclude_keys=exclude_keys)
-            for k, v in json.loads(o.json()).items()
+            for k, v in json.loads(o.model_dump_json()).items()
             if k not in exclude_keys
         }
 


### PR DESCRIPTION
This PR fixes a warning from Pydantic when running the JSON dumps test in `data_test.py`:

```
evals/data_test.py::test_jsondumps
evals/data_test.py::test_jsondumps
evals/data_test.py::test_jsondumps
  /evals/evals/data.py:191: PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
    for k, v in json.loads(o.json()).items()

evals/data_test.py::test_jsondumps
evals/data_test.py::test_jsondumps
evals/data_test.py::test_jsondumps
  /evals/lib/python3.9/site-packages/pydantic/main.py:1005: PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
    warnings.warn('The `json` method is deprecated; use `model_dump_json` instead.', DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

