### PR TITLE
Add run_id to final_report from LocalRecorder

### DIFF
--- a/evals/record.py
+++ b/evals/record.py
@@ -364,7 +364,7 @@ class LocalRecorder(RecorderBase):
 
     def record_final_report(self, final_report: Any):
         with bf.BlobFile(self.event_file_path, "ab") as f:
-            f.write((jsondumps({"final_report": final_report}) + "\n").encode("utf-8"))
+            f.write((jsondumps({"final_report": final_report, "run_id": self.run_spec.run_id}) + "\n").encode("utf-8"))
 
         logging.info(f"Final report: {final_report}. Logged to {self.event_file_path}")
 


### PR DESCRIPTION
(Not an eval)

The `final_report` log line currently doesn't include the `run_id`, which means that if we want to work out which run it belongs to, we have to look at the `run_id` of other log lines in the same file. This makes it a bit harder to work with the logs, and as far as I can tell there's no downside to including the `run_id`.