### PR TITLE
Extending to Azure OpenAI implementation

### DIFF
--- a/evals/completion_fns/openai.py
+++ b/evals/completion_fns/openai.py
@@ -4,6 +4,7 @@ from openai import OpenAI
 
 from evals.api import CompletionFn, CompletionResult
 from evals.base import CompletionFnSpec
+from evals.openai_client.openai_client_provider import OpenAIClientProvider
 from evals.prompt.base import (
     ChatCompletionPrompt,
     CompletionPrompt,
@@ -82,7 +83,7 @@ class OpenAICompletionFn(CompletionFn):
         openai_create_prompt: OpenAICreatePrompt = prompt.to_formatted_prompt()
 
         result = openai_completion_create_retrying(
-            OpenAI(api_key=self.api_key, base_url=self.api_base),
+            OpenAIClientProvider(api_key=self.api_key).get_client(),
             model=self.model,
             prompt=openai_create_prompt,
             **{**kwargs, **self.extra_options},
@@ -127,7 +128,7 @@ class OpenAIChatCompletionFn(CompletionFnSpec):
         openai_create_prompt: OpenAICreateChatPrompt = prompt.to_formatted_prompt()
 
         result = openai_chat_completion_create_retrying(
-            OpenAI(api_key=self.api_key, base_url=self.api_base),
+            OpenAIClientProvider(api_key=self.api_key).get_client(),
             model=self.model,
             messages=openai_create_prompt,
             **{**kwargs, **self.extra_options},

--- a/evals/openai_client/openai_client_provider.py
+++ b/evals/openai_client/openai_client_provider.py
@@ -1,0 +1,27 @@
+import os
+from abc import ABC
+
+from openai import OpenAI
+from openai.lib.azure import AzureOpenAI
+
+
+class OpenAIClientProvider(ABC):
+    def __init__(self, api_key, **kwargs):
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self.azure_endpoint = kwargs.pop("azure_endpoint", None) or os.environ.get(
+            "OPENAI_AZURE_ENDPOINT"
+        )
+        self.api_version = kwargs.pop("opena_api_version", None) or os.environ.get(
+            "OPENAI_API_VERSION"
+        )
+
+        self.kwargs = kwargs
+
+    def get_client(self):
+        if not self.azure_endpoint:
+            return OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+        return AzureOpenAI(
+            api_key=os.environ.get("OPENAI_API_KEY"),
+            azure_endpoint=os.environ.get("OPENAI_AZURE_ENDPOINT"),
+            api_version=os.environ.get("OPENAI_API_VERSION"),
+        )

--- a/evals/registry.py
+++ b/evals/registry.py
@@ -15,15 +15,20 @@ from typing import Any, Generator, Iterator, Optional, Sequence, Tuple, Type, Ty
 
 import openai
 import yaml
-from openai import OpenAI
+
 
 from evals import OpenAIChatCompletionFn, OpenAICompletionFn
 from evals.api import CompletionFn, DummyCompletionFn
 from evals.base import BaseEvalSpec, CompletionFnSpec, EvalSetSpec, EvalSpec
 from evals.elsuite.modelgraded.base import ModelGradedSpec
+from evals.openai_client.openai_client_provider import OpenAIClientProvider
 from evals.utils.misc import make_object
 
-client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+client = OpenAIClientProvider(
+    api_key=os.environ.get("OPENAI_API_KEY"),
+    azure_endpoint=os.environ.get("OPENAI_AZURE_ENDPOINT"),
+    api_version=os.environ.get("OPENAI_API_VERSION"),
+).get_client()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR allows to use Azure OpenAI implementation. Since the API structure in openAI and Azure openAI is same the client can be initialised by looking at environment variable presence of AZURE_OPENAI_ENDPOINT. If we rely on CompletionFn endpoint then the code will still be more or less copy paste of existing OpenAI completionfn's