### PR TITLE
Drop two datasets from steganography

### DIFF
--- a/evals/registry/data/steganography/LICENSE
+++ b/evals/registry/data/steganography/LICENSE
@@ -2,10 +2,6 @@ Abirate/english_quotes:
 License: Creative Commons Attribution 4.0 International License https://creativecommons.org/licenses/by/4.0/legalcode.txt
 Source: https://huggingface.co/datasets/Abirate/english_quotes
 
-PiC/phrase_similarity:
-License: Creative Commons NonCommercial (CC BY-NC 4.0) https://creativecommons.org/licenses/by-nc/4.0/legalcode
-Source: https://huggingface.co/datasets/PiC/phrase_similarity
-
 wikipedia:
 License: Creative Commons Attribution-ShareAlike 3.0 Unported License (CC BY-SA): https://en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License and the GNU Free Documentation License (GFDL): https://en.wikipedia.org/wiki/Wikipedia:Text_of_the_GNU_Free_Documentation_License
 Source: https://huggingface.co/datasets/wikipedia
@@ -25,7 +21,3 @@ Source: https://huggingface.co/datasets/alespalla/chatbot_instruction_prompts
 lighteval/mmlu:
 License: MIT License https://opensource.org/license/mit/
 Source: https://huggingface.co/datasets/lighteval/mmlu
-
-vicgalle/alpaca-gpt4:
-License: Creative Commons NonCommercial (CC BY-NC 4.0) https://creativecommons.org/licenses/by-nc/4.0/legalcode
-Source: https://huggingface.co/datasets/vicgalle/alpaca-gpt4

--- a/evals/registry/data/steganography/samples.jsonl
+++ b/evals/registry/data/steganography/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad102a1509c2acf971a3d50aa7b0aaa4f794edf1cf405adb27f3e1e8f03aad86
-size 754139
+oid sha256:fb3b1de00891dcc8166d067a9a501aa869f2361c3950f0c562d3617542e2bb03
+size 852057

--- a/evals/solvers/openai_assistants_solver.py
+++ b/evals/solvers/openai_assistants_solver.py
@@ -51,11 +51,11 @@ class OpenAIAssistantsSolver(Solver):
         tools: list[Dict[str, Any]] = [],
         file_paths: list[str] = [],
         assistant: Optional[Assistant] = None,
-        thread: Optional[Thread] = client.beta.threads.create(),
+        thread: Optional[Thread] = None,
         registry: Any = None,
     ):
         self.model = model
-        self.thread = thread
+        self.thread = thread if thread else client.beta.threads.create()
         self.tools = tools
         self.all_uploaded_files = []
         if not assistant:


### PR DESCRIPTION
Removing two datasets:
- PiC/phrase_similarity
- vicgalle/alpaca-gpt4

Impact on Steganography:
- Only marginal change in data distribution.
- We modify the sampling counts such that we have the same total number of samples as before.
- Did not re-run results; absolute scores should change but qualitative interpretation of eval will not be different.