### PR TITLE
Unified create_retrying for all solvers

### DIFF
--- a/evals/completion_fns/openai.py
+++ b/evals/completion_fns/openai.py
@@ -116,7 +116,7 @@ class OpenAICompletionFn(CompletionFn):
         openai_create_prompt: OpenAICreatePrompt = prompt.to_formatted_prompt()
 
         result = openai_completion_create_retrying(
-            client=OpenAI(api_key=self.api_key, base_url=self.api_base),
+            OpenAI(api_key=self.api_key, base_url=self.api_base),
             model=self.model,
             prompt=openai_create_prompt,
             **{**kwargs, **self.extra_options},
@@ -161,7 +161,7 @@ class OpenAIChatCompletionFn(CompletionFnSpec):
         openai_create_prompt: OpenAICreateChatPrompt = prompt.to_formatted_prompt()
 
         result = openai_chat_completion_create_retrying(
-            client=OpenAI(api_key=self.api_key, base_url=self.api_base),
+            OpenAI(api_key=self.api_key, base_url=self.api_base),
             model=self.model,
             messages=openai_create_prompt,
             **{**kwargs, **self.extra_options},

--- a/evals/utils/api_utils.py
+++ b/evals/utils/api_utils.py
@@ -1,73 +1,22 @@
-"""
-This file defines various helper functions for interacting with the OpenAI API.
-"""
-import concurrent
 import logging
 import os
 
 import backoff
-import openai
-from openai import OpenAI
 
 EVALS_THREAD_TIMEOUT = float(os.environ.get("EVALS_THREAD_TIMEOUT", "40"))
 logging.getLogger("httpx").setLevel(logging.WARNING)  # suppress "OK" logs from openai API calls
 
 
-@backoff.on_exception(
+@backoff.on_predicate(
     wait_gen=backoff.expo,
-    exception=(
-        openai.RateLimitError,
-        openai.APIConnectionError,
-        openai.APITimeoutError,
-        openai.InternalServerError,
-    ),
     max_value=60,
     factor=1.5,
 )
-def openai_completion_create_retrying(client: OpenAI, *args, **kwargs):
+def create_retrying(func: callable, retry_exceptions: tuple[Exception], *args, **kwargs):
     """
-    Helper function for creating a completion.
-    `args` and `kwargs` match what is accepted by `openai.Completion.create`.
+    Retries given function if one of given exceptions is raised
     """
-    result = client.completions.create(*args, **kwargs)
-    if "error" in result:
-        logging.warning(result)
-        raise openai.error.APIError(result["error"])
-    return result
-
-
-def request_with_timeout(func, *args, timeout=EVALS_THREAD_TIMEOUT, **kwargs):
-    """
-    Worker thread for making a single request within allotted time.
-    """
-    while True:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(func, *args, **kwargs)
-            try:
-                result = future.result(timeout=timeout)
-                return result
-            except concurrent.futures.TimeoutError:
-                continue
-
-
-@backoff.on_exception(
-    wait_gen=backoff.expo,
-    exception=(
-        openai.RateLimitError,
-        openai.APIConnectionError,
-        openai.APITimeoutError,
-        openai.InternalServerError,
-    ),
-    max_value=60,
-    factor=1.5,
-)
-def openai_chat_completion_create_retrying(client: OpenAI, *args, **kwargs):
-    """
-    Helper function for creating a chat completion.
-    `args` and `kwargs` match what is accepted by `openai.ChatCompletion.create`.
-    """
-    result = request_with_timeout(client.chat.completions.create, *args, **kwargs)
-    if "error" in result:
-        logging.warning(result)
-        raise openai.error.APIError(result["error"])
-    return result
+    try:
+        return func(*args, **kwargs)
+    except retry_exceptions:
+        return False


### PR DESCRIPTION
We're now implementing solvers for new APIs we're calling (Anthropic, Gemini, ...). Each solver was implementing the same logic for backing off and retrying when the API query limit was hit. This PR created a generic create_retrying function, which retries when specific exceptions are raised. These exceptions are passed as arguments.

This uses the changes from #1482 