### PR TITLE
Fix specifying API arguments from the CLI

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -138,6 +138,9 @@ def run(args: OaiEvalArguments, registry: Optional[Registry] = None) -> str:
     # If the user provided an argument to --completion_args, parse it into a dict here, to be passed to the completion_fn creation **kwargs
     completion_args = args.completion_args.split(",")
     additonal_completion_args = {k: v for k, v in (kv.split("=") for kv in completion_args if kv)}
+    # if the user provides temperature, transform that into a number:
+    if "temperature" in additonal_completion_args:
+        additonal_completion_args["temperature"] = float(additonal_completion_args["temperature"])
 
     completion_fns = args.completion_fn.split(",")
     completion_fn_instances = [

--- a/evals/registry.py
+++ b/evals/registry.py
@@ -121,9 +121,9 @@ class Registry:
         n_ctx = n_ctx_from_model_name(name)
 
         if is_chat_model(name):
-            return OpenAIChatCompletionFn(model=name, n_ctx=n_ctx, **kwargs)
+            return OpenAIChatCompletionFn(model=name, n_ctx=n_ctx, extra_options=kwargs)
         elif name in self.api_model_ids:
-            return OpenAICompletionFn(model=name, n_ctx=n_ctx, **kwargs)
+            return OpenAICompletionFn(model=name, n_ctx=n_ctx, extra_options=kwargs)
 
         # No match, so try to find a completion-fn-id in the registry
         spec = self.get_completion_fn(name)


### PR DESCRIPTION
Fix #1504 

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [X] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [X] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [X] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [X] I have filled out all required fields of this form
- [X] I have used **Git LFS** for the Eval JSON data
- [X] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `mypy`, `black`, `isort`, `autoflake` and `ruff` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.