### PR TITLE
Allow for evals with no args

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -155,7 +155,11 @@ def run(args: OaiEvalArguments, registry: Optional[Registry] = None) -> str:
         return {k: to_number(v) for k, v in str_dict.items()}
 
     extra_eval_params = parse_extra_eval_params(args.extra_eval_params)
-    eval_spec.args.update(extra_eval_params)
+
+    if eval_spec.args is None:
+        eval_spec.args = extra_eval_params
+    else:
+        eval_spec.args.update(extra_eval_params)
 
     # If the user provided an argument to --completion_args, parse it into a dict here, to be passed to the completion_fn creation **kwargs
     completion_args = args.completion_args.split(",")


### PR DESCRIPTION
As raised in #1515, the `args` field of `EvalSpec` is optional. Therefore it is possible for evals with no args to exist. Here `args` is `None`. 

However, currently our [arg overriding code](https://github.com/openai/evals/blame/main/evals/cli/oaieval.py#L158) mistakingly does not support this API, since it assumes `args` is not `None`.

This PR addresses the issue with an if statement. Fixes #1515