### PR TITLE
Release 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evals"
-version = "2.0.0.post1"
+version = "3.0.0.post1"
 requires-python = ">=3.9"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
Release 3.0.0 of evals. This is a major version bump because https://github.com/openai/evals/pull/1514 was a breaking change to how we handle zstd files