### PR TITLE
Make the torch dep optional

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyyaml
         pip install pytest
-        pip install -e .
+        pip install -e .[torch]
 
     - name: Run unit tests
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "statsmodels",
     "termcolor",
     "tiktoken",
-    "torch",
     "tqdm",
     "types-PyYAML",
     "types-tqdm",
@@ -54,12 +53,9 @@ dependencies = [
 repository = "https://github.com/openai/evals"
 
 [project.optional-dependencies]
-formatters = [
-    "black",
-    "isort",
-    "autoflake",
-    "ruff"
-]
+formatters = ["black", "isort", "autoflake", "ruff"]
+
+torch = ["torch"]
 
 [project.scripts]
 oaieval = "evals.cli.oaieval:main"


### PR DESCRIPTION
`torch` was added in https://github.com/openai/evals/pull/1496, but it's very heavy and only required for one eval. Let's move it to an optional-dependency