### PR TITLE
Remove global OpenAI client initialization

### DIFF
--- a/evals/completion_fns/retrieval.py
+++ b/evals/completion_fns/retrieval.py
@@ -14,7 +14,6 @@ from evals.prompt.base import ChatCompletionPrompt, CompletionPrompt
 from evals.record import record_sampling
 from evals.registry import Registry
 
-client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 
 def load_embeddings(embeddings_and_text_path: str):
@@ -76,6 +75,7 @@ class RetrievalCompletionFn(CompletionFn):
             registry_path: The path to a registry file to add to default registry.
             _kwargs: Additional arguments to pass to the completion function instantiation.
         """
+        self.client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
         registry = Registry() if not registry else registry
         if registry_path:
             registry.add_registry_paths(registry_path)
@@ -96,7 +96,7 @@ class RetrievalCompletionFn(CompletionFn):
         """
         # Embed the prompt
         embedded_prompt = (
-            client.embeddings.create(
+            self.client.embeddings.create(
                 model=self.embedding_model, input=CompletionPrompt(prompt).to_formatted_prompt()
             )
             .data[0]

--- a/evals/elsuite/hr_ml_agent_bench/utils.py
+++ b/evals/elsuite/hr_ml_agent_bench/utils.py
@@ -13,7 +13,6 @@ from openai import OpenAI
 from evals.solvers.solver import Solver
 from evals.task_state import TaskState
 
-client = OpenAI()
 logger = logging.getLogger(__name__)
 
 

--- a/evals/elsuite/make_me_pay/utils.py
+++ b/evals/elsuite/make_me_pay/utils.py
@@ -4,9 +4,6 @@ from typing import Literal
 
 from openai import OpenAI
 
-client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
-
-
 def is_system_msg(m: dict) -> bool:
     assert isinstance(m, dict), "Message must be a dict."
     assert "role" in m, "Message must have a role."
@@ -72,4 +69,4 @@ def model_output_empty_tags(message: str) -> bool:
 
 
 def openai_chatcompletion_create(*args, **kwargs):
-    return client.chat.completions.create(*args, **kwargs)
+    return OpenAI(api_key=os.environ.get("OPENAI_API_KEY")).chat.completions.create(*args, **kwargs)

--- a/evals/elsuite/self_prompting/eval.py
+++ b/evals/elsuite/self_prompting/eval.py
@@ -11,7 +11,7 @@ import evals.metrics
 from evals.api import CompletionFn
 from evals.elsuite.self_prompting.task_description import sample_in_token, task_description_template
 from evals.eval import SolverEval
-from evals.registry import registry
+from evals.registry import Registry
 from evals.solvers.solver import Solver
 from evals.task_state import TaskState
 from evals.utils.log_utils import extract_final_results, extract_spec
@@ -54,7 +54,7 @@ class SelfPrompting(SolverEval):
 
         self.tasker_completion_fns = {}
         for tasker_model in self.tasker_models:
-            self.tasker_completion_fns[tasker_model] = registry.make_completion_fn(tasker_model)
+            self.tasker_completion_fns[tasker_model] = Registry().make_completion_fn(tasker_model)
 
     def eval_sample(self, solver: Solver, sample: Any, rng: random.Random):
         if sample["stage"] == "prompting":

--- a/evals/elsuite/self_prompting/scripts/dataset/compile_data.py
+++ b/evals/elsuite/self_prompting/scripts/dataset/compile_data.py
@@ -4,7 +4,7 @@ import numpy as np
 from eval_list import eval_list
 
 import evals.data
-from evals.registry import registry
+from evals.registry import Registry
 
 np.random.seed(42)
 min_samples_per_dataset = 50
@@ -12,7 +12,7 @@ n_test_samples = 10
 
 seen = set()
 datarows = []
-for eval in registry.get_evals("*"):
+for eval in Registry().get_evals("*"):
     if eval.key not in eval_list or eval.key in seen:
         continue
     seen.add(eval.key)

--- a/evals/elsuite/skill_acquisition/test_skill_acquisition.py
+++ b/evals/elsuite/skill_acquisition/test_skill_acquisition.py
@@ -11,108 +11,112 @@ from evals.elsuite.skill_acquisition.utils import (
 )
 from evals.registry import Registry
 
-registry = Registry()
-
-dummy_eval_spec = {
-    "eval_registry_path": Path("evals/registry"),
-    "completion_fns": [registry.make_completion_fn("gpt-4")],
-    "samples_jsonl": "skill_acquisition/miskito/miskito_test.jsonl",
-    "target_language": "miskito",
-    "n_samples": 5,
-    "knowledge_base_directory": "skill_acquisition/miskito/knowledge_base/",
-    "max_replies": 50,
-}
 
 
-def test_answer_detected():
-    assert answer_detected("[ANSWER foo]") is True
-    assert answer_detected("[ANSWER: foo]") is True
-    assert answer_detected("ANSWER foo") is False
-    assert answer_detected("[ANSWER foo") is False
-    assert answer_detected("ANSWER foo]") is False
-    assert answer_detected("[ANSWER foo][ANSWER bar]") is True
+
+class TestSkillAcquisition():
+    def setup_class(self):
+        os.environ["OPENAI_API_KEY"] = "test"
+        self.registry = Registry()
+        self.dummy_eval_spec = {
+            "eval_registry_path": Path("evals/registry"),
+            "completion_fns": [self.registry.make_completion_fn("gpt-4")],
+            "samples_jsonl": "skill_acquisition/miskito/miskito_test.jsonl",
+            "target_language": "miskito",
+            "n_samples": 5,
+            "knowledge_base_directory": "skill_acquisition/miskito/knowledge_base/",
+            "max_replies": 50,
+        }
+
+    def test_answer_detected(self):
+        assert answer_detected("[ANSWER foo]") is True
+        assert answer_detected("[ANSWER: foo]") is True
+        assert answer_detected("ANSWER foo") is False
+        assert answer_detected("[ANSWER foo") is False
+        assert answer_detected("ANSWER foo]") is False
+        assert answer_detected("[ANSWER foo][ANSWER bar]") is True
 
 
-def test_view_instruction_detected():
-    SkillAcquisition(**dummy_eval_spec)
-    assert view_instruction_detected("[VIEW file1]") is True
-    assert view_instruction_detected("[VIEW: file1]") is True
-    assert view_instruction_detected("[VIEW file1 section1]") is True
-    assert view_instruction_detected("[VIEW: file1 section1]") is True
-    assert view_instruction_detected("VIEW file1") is False
-    assert view_instruction_detected("[VIEW file1") is False
-    assert view_instruction_detected("VIEW file1]") is False
-    assert view_instruction_detected("[VIEW file1][VIEW file2]") is True
-    assert view_instruction_detected("[VIEW: file1][VIEW: file2]") is True
+    def test_view_instruction_detected(self):
+        SkillAcquisition(**self.dummy_eval_spec)
+        assert view_instruction_detected("[VIEW file1]") is True
+        assert view_instruction_detected("[VIEW: file1]") is True
+        assert view_instruction_detected("[VIEW file1 section1]") is True
+        assert view_instruction_detected("[VIEW: file1 section1]") is True
+        assert view_instruction_detected("VIEW file1") is False
+        assert view_instruction_detected("[VIEW file1") is False
+        assert view_instruction_detected("VIEW file1]") is False
+        assert view_instruction_detected("[VIEW file1][VIEW file2]") is True
+        assert view_instruction_detected("[VIEW: file1][VIEW: file2]") is True
 
 
-def test_process_answer():
-    SkillAcquisition(**dummy_eval_spec)
-    assert process_answer("[ANSWER foo]") == "foo"
-    assert process_answer("[ANSWER: foo]") == "foo"
-    assert process_answer("[ANSWER foo bar baz]") == "foo bar baz"
-    assert process_answer("[ANSWER: foo bar baz]") == "foo bar baz"
-    assert process_answer("[ANSWER foo][ANSWER bar]") == "bar"
-    assert process_answer("[ANSWER foo][ANSWER bar") == "foo"
+    def test_process_answer(self):
+        SkillAcquisition(**self.dummy_eval_spec)
+        assert process_answer("[ANSWER foo]") == "foo"
+        assert process_answer("[ANSWER: foo]") == "foo"
+        assert process_answer("[ANSWER foo bar baz]") == "foo bar baz"
+        assert process_answer("[ANSWER: foo bar baz]") == "foo bar baz"
+        assert process_answer("[ANSWER foo][ANSWER bar]") == "bar"
+        assert process_answer("[ANSWER foo][ANSWER bar") == "foo"
 
 
-def test_process_view_instruction():
-    SkillAcquisition(**dummy_eval_spec)
-    assert process_view_instruction("[VIEW file1]") == ("file1", None)
-    assert process_view_instruction("[VIEW: file1]") == ("file1", None)
-    assert process_view_instruction("[VIEW file1 section1]") == (
-        "file1",
-        "section1",
-    )
-    assert process_view_instruction("[VIEW: file1 section1]") == (
-        "file1",
-        "section1",
-    )
-    assert process_view_instruction("[VIEW file1][VIEW file2]") == (
-        "file2",
-        None,
-    )
-    assert process_view_instruction("[VIEW: file1][VIEW: file2]") == (
-        "file2",
-        None,
-    )
-    assert process_view_instruction("[VIEW file1 section1][VIEW file2 section2]") == (
-        "file2",
-        "section2",
-    )
+    def test_process_view_instruction(self):
+        SkillAcquisition(**self.dummy_eval_spec)
+        assert process_view_instruction("[VIEW file1]") == ("file1", None)
+        assert process_view_instruction("[VIEW: file1]") == ("file1", None)
+        assert process_view_instruction("[VIEW file1 section1]") == (
+            "file1",
+            "section1",
+        )
+        assert process_view_instruction("[VIEW: file1 section1]") == (
+            "file1",
+            "section1",
+        )
+        assert process_view_instruction("[VIEW file1][VIEW file2]") == (
+            "file2",
+            None,
+        )
+        assert process_view_instruction("[VIEW: file1][VIEW: file2]") == (
+            "file2",
+            None,
+        )
+        assert process_view_instruction("[VIEW file1 section1][VIEW file2 section2]") == (
+            "file2",
+            "section2",
+        )
 
 
-def test_process_view_instruction_spaces_and_quotes():
-    assert process_view_instruction("[VIEW file1 sectionpart1 sectionpart2]") == (
-        "file1",
-        "sectionpart1 sectionpart2",
-    )
-    assert process_view_instruction("[VIEW file1 sectionpart1 'sectionpart2']") == (
-        "file1",
-        "sectionpart1 'sectionpart2'",
-    )
+    def test_process_view_instruction_spaces_and_quotes(self):
+        assert process_view_instruction("[VIEW file1 sectionpart1 sectionpart2]") == (
+            "file1",
+            "sectionpart1 sectionpart2",
+        )
+        assert process_view_instruction("[VIEW file1 sectionpart1 'sectionpart2']") == (
+            "file1",
+            "sectionpart1 'sectionpart2'",
+        )
 
 
-def test_view_content():
-    skill_acquisition_eval = SkillAcquisition(**dummy_eval_spec)
+    def test_view_content(self):
+        skill_acquisition_eval = SkillAcquisition(**self.dummy_eval_spec)
 
-    # Create a file to view first.
-    filepath = skill_acquisition_eval.knowledge_base_directory / "test_file.jsonl"
-    with open(filepath, "w") as f:
-        f.write(json.dumps({"title": "foo", "content": "Test file contents."}) + "\n")
+        # Create a file to view first.
+        filepath = skill_acquisition_eval.knowledge_base_directory / "test_file.jsonl"
+        with open(filepath, "w") as f:
+            f.write(json.dumps({"title": "foo", "content": "Test file contents."}) + "\n")
 
-    content, sections_visible_to_model, sections_viewed = skill_acquisition_eval._view_content(
-        "test_file.jsonl"
-    )
-    assert content == "Table of contents for test_file.jsonl: {'foo'}."
-    assert sections_visible_to_model == {"test_file.jsonl": {"foo"}}
-    assert sections_viewed == {"test_file.jsonl": {"Table of Contents"}}
+        content, sections_visible_to_model, sections_viewed = skill_acquisition_eval._view_content(
+            "test_file.jsonl"
+        )
+        assert content == "Table of contents for test_file.jsonl: {'foo'}."
+        assert sections_visible_to_model == {"test_file.jsonl": {"foo"}}
+        assert sections_viewed == {"test_file.jsonl": {"Table of Contents"}}
 
-    content, sections_visible_to_model, sections_viewed = skill_acquisition_eval._view_content(
-        "test_file.jsonl", "foo"
-    )
-    assert content == "Test file contents."
-    assert sections_visible_to_model == {"test_file.jsonl": {"foo"}}
-    assert sections_viewed == {"test_file.jsonl": {"Table of Contents", "foo"}}
+        content, sections_visible_to_model, sections_viewed = skill_acquisition_eval._view_content(
+            "test_file.jsonl", "foo"
+        )
+        assert content == "Test file contents."
+        assert sections_visible_to_model == {"test_file.jsonl": {"foo"}}
+        assert sections_viewed == {"test_file.jsonl": {"Table of Contents", "foo"}}
 
-    os.remove(filepath)
+        os.remove(filepath)

--- a/evals/record.py
+++ b/evals/record.py
@@ -263,14 +263,6 @@ class RecorderBase:
         logging.info(f"Final report: {final_report}. Not writing anywhere.")
 
 
-def _green(str):
-    return f"\033[1;32m{str}\033[0m"
-
-
-def _red(str):
-    return f"\033[1;31m{str}\033[0m"
-
-
 class DummyRecorder(RecorderBase):
     """
     A "recorder" which only logs certain events to the console.
@@ -282,32 +274,14 @@ class DummyRecorder(RecorderBase):
         self.log = log
 
     def record_event(self, type, data, sample_id=None):
-        from evals.registry import registry
-
         if self.run_spec is None:
             return
-
-        base_eval_spec = registry.get_base_eval(self.run_spec.base_eval)
-        if base_eval_spec and len(base_eval_spec.metrics) >= 1:
-            primary_metric = base_eval_spec.metrics[0]
-        else:
-            primary_metric = "accuracy"
 
         with self._event_lock:
             event = self._create_event(type, data)
             self._events.append(event)
 
         msg = f"Not recording event: {event}"
-
-        if type == "match":
-            accuracy_good = (
-                primary_metric == "accuracy" or primary_metric.startswith("pass@")
-            ) and (data.get("correct", False) or data.get("accuracy", 0) > 0.5)
-            f1_score_good = primary_metric == "f1_score" and data.get("f1_score", 0) > 0.5
-            if accuracy_good or f1_score_good:
-                msg = _green(msg)
-            else:
-                msg = _red(msg)
 
         if self.log:
             logging.info(msg)

--- a/evals/registry/data/word_association/corpus_tools/validators.py
+++ b/evals/registry/data/word_association/corpus_tools/validators.py
@@ -8,8 +8,6 @@ import numpy as np
 from logger_config import logger
 from openai import OpenAI
 
-client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
-
 CORRELATION_PROMPT_TEMPLATE = """Task: Estimate the degree of correlation between
  two provided strings. In your evaluation, consider not just direct links, but also indirect and subtle correlations.
  As an illustration, if 'watch' appears in the first string and 'tower' in the second,
@@ -172,6 +170,7 @@ class EmbeddingsValidator(QualityValidator):
             A list of Embedding namedtuples where each Embedding
             represents the input string and its corresponding vector.
         """
+        client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
         response = client.embeddings.create(model="text-embedding-ada-002", input=emb_input)
         logger.debug(f"embeddings response: {response}")
         response_data = response["data"]
@@ -199,6 +198,7 @@ class GPTValidator(QualityValidator):
         self._model = model
         self.criteria = criteria
         super().__init__(target_score)
+        self.client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
     def validate(self, related_words_pairs: List[RelatedWordsPair]) -> List[SimilarityTuple]:
         """
@@ -249,7 +249,7 @@ class GPTValidator(QualityValidator):
         logger.debug(
             f"Getting chat_completion using {self._model}.\nPrompting messages: {messages}"
         )
-        response = client.chat.completions.create(
+        response = self.client.chat.completions.create(
             model=self._model, messages=messages, temperature=0.0
         )
         logger.debug(f"response_message: {response}")

--- a/evals/solvers/providers/anthropic/anthropic_solver.py
+++ b/evals/solvers/providers/anthropic/anthropic_solver.py
@@ -2,7 +2,7 @@ from typing import Any, Optional, Union
 
 import anthropic
 from anthropic import Anthropic
-from anthropic.types import ContentBlock, MessageParam, Usage
+from anthropic.types import TextBlock, MessageParam, Usage
 
 from evals.record import record_sampling
 from evals.solvers.solver import Solver, SolverResult
@@ -99,7 +99,7 @@ class AnthropicSolver(Solver):
         anth_msgs = [
             MessageParam(
                 role=oai_to_anthropic_role[msg.role],
-                content=[ContentBlock(text=msg.content, type="text")],
+                content=[TextBlock(text=msg.content, type="text")],
             )
             for msg in msgs
         ]

--- a/evals/solvers/providers/anthropic/anthropic_solver_test.py
+++ b/evals/solvers/providers/anthropic/anthropic_solver_test.py
@@ -8,9 +8,10 @@ from evals.solvers.providers.anthropic.anthropic_solver import (
     anth_to_openai_usage,
 )
 
-from anthropic.types import ContentBlock, MessageParam, Usage
+from anthropic.types import TextBlock, MessageParam, Usage
 
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+MISSING_ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY") in {"", None}
 MODEL_NAME = "claude-instant-1.2"
 
 
@@ -33,7 +34,7 @@ def dummy_recorder():
 
 
 @pytest.mark.skipif(
-    IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit."
+    IN_GITHUB_ACTIONS or MISSING_ANTHROPIC_API_KEY, reason="API tests are wasteful to run on every commit."
 )
 def test_solver(dummy_recorder, anthropic_solver):
     """
@@ -82,14 +83,14 @@ def test_message_format():
         MessageParam(
             role="user",
             content=[
-                ContentBlock(text="What is 2 + 2?", type="text"),
-                ContentBlock(text="reason step by step", type="text"),
+                TextBlock(text="What is 2 + 2?", type="text"),
+                TextBlock(text="reason step by step", type="text"),
             ],
         ),
         MessageParam(
             role="assistant",
             content=[
-                ContentBlock(
+                TextBlock(
                     text="I don't need to reason for this, 2+2 is just 4", type="text"
                 ),
             ],
@@ -97,7 +98,7 @@ def test_message_format():
         MessageParam(
             role="user",
             content=[
-                ContentBlock(
+                TextBlock(
                     text="now, given your reasoning, provide the answer", type="text"
                 ),
             ],

--- a/evals/solvers/providers/google/gemini_solver_test.py
+++ b/evals/solvers/providers/google/gemini_solver_test.py
@@ -7,6 +7,7 @@ from evals.solvers.providers.google.gemini_solver import GeminiSolver, GoogleMes
 from evals.task_state import Message, TaskState
 
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+MISSING_GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY") in {None, ""}
 MODEL_NAME = "gemini-pro"
 
 
@@ -26,7 +27,7 @@ def gemini_solver():
     return solver
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit.")
+@pytest.mark.skipif(IN_GITHUB_ACTIONS or MISSING_GOOGLE_API_KEY, reason="API tests are wasteful to run on every commit.")
 def test_solver(dummy_recorder, gemini_solver):
     """
     Test that the solver generates a response coherent with the message history

--- a/evals/solvers/providers/openai/openai_assistants_solver_test.py
+++ b/evals/solvers/providers/openai/openai_assistants_solver_test.py
@@ -14,6 +14,7 @@ from evals.solvers.providers.openai.openai_assistants_solver import (
 from evals.task_state import Message, TaskState
 
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+MISSING_OPENAI_API_KEY = os.getenv("OPENAI_API_KEY") in {"", None}
 MODEL = "gpt-4-1106-preview"
 
 
@@ -64,7 +65,7 @@ def retrieval_solver():
     return solver
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit.")
+@pytest.mark.skipif(IN_GITHUB_ACTIONS or MISSING_OPENAI_API_KEY, reason="API tests are wasteful to run on every commit.")
 def test_solver_copying(dummy_recorder, vanilla_solver):
     """
     When OpenAIAssistantsSolver is copied, the Assistant should be the same
@@ -80,7 +81,7 @@ def test_solver_copying(dummy_recorder, vanilla_solver):
         test_multiturn_conversation(dummy_recorder, solver_copy)
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit.")
+@pytest.mark.skipif(IN_GITHUB_ACTIONS or MISSING_OPENAI_API_KEY, reason="API tests are wasteful to run on every commit.")
 def test_multiturn_conversation(dummy_recorder, vanilla_solver):
     """
     Test that message history of the conversation is preserved across multiple turns.
@@ -103,7 +104,7 @@ def test_multiturn_conversation(dummy_recorder, vanilla_solver):
         assert int(solver_result.output.strip()) == sum(numbers[: idx + 1])
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit.")
+@pytest.mark.skipif(IN_GITHUB_ACTIONS or MISSING_OPENAI_API_KEY, reason="API tests are wasteful to run on every commit.")
 def test_code_interpreter(dummy_recorder, code_interpreter_solver):
     solver = code_interpreter_solver
 
@@ -122,7 +123,7 @@ def test_code_interpreter(dummy_recorder, code_interpreter_solver):
     assert str(round(math.sqrt(145145), 3)) in solver_result.output
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit.")
+@pytest.mark.skipif(IN_GITHUB_ACTIONS or MISSING_OPENAI_API_KEY, reason="API tests are wasteful to run on every commit.")
 def test_task_description(dummy_recorder, vanilla_solver):
     solver = vanilla_solver
 
@@ -141,7 +142,7 @@ def test_task_description(dummy_recorder, vanilla_solver):
     assert solver_result.output == target_string
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit.")
+@pytest.mark.skipif(IN_GITHUB_ACTIONS or MISSING_OPENAI_API_KEY, reason="API tests are wasteful to run on every commit.")
 def test_code_interpreter_file(dummy_recorder, dummy_data_file, code_interpreter_solver):
     dummy_data, tmpfile_path = dummy_data_file
     solver = code_interpreter_solver
@@ -168,7 +169,7 @@ def test_code_interpreter_file(dummy_recorder, dummy_data_file, code_interpreter
     ), f"Expected password '{dummy_data['password']}' to be in output, but got: {solver_result.output}"
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit.")
+@pytest.mark.skipif(IN_GITHUB_ACTIONS or MISSING_OPENAI_API_KEY, reason="API tests are wasteful to run on every commit.")
 def test_retrieval_file(dummy_recorder, dummy_data_file, retrieval_solver):
     dummy_data, tmpfile_path = dummy_data_file
     solver = retrieval_solver
@@ -202,7 +203,7 @@ def test_retrieval_file(dummy_recorder, dummy_data_file, retrieval_solver):
     ), f"Expected password '{dummy_data['password']}' to be in output, but got: {solver_result.output}"
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="API tests are wasteful to run on every commit.")
+@pytest.mark.skipif(IN_GITHUB_ACTIONS or MISSING_OPENAI_API_KEY, reason="API tests are wasteful to run on every commit.")
 def test_file_cache(dummy_recorder, dummy_data_file, retrieval_solver):
     dummy_data, tmpfile_path = dummy_data_file
     solver = retrieval_solver


### PR DESCRIPTION
This PR removes OpenAI initialization calls that happen at import time so developers who want to use Evals as a library rather than a CLI tool, without the OPENAI_API_KEY environment variable specified, can do so.