### PR TITLE
Fix a bug in examples/mmlu.ipynb when using gpt-4o or gpt-4o-mini

### DIFF
--- a/evals/registry.py
+++ b/evals/registry.py
@@ -84,7 +84,7 @@ def is_chat_model(model_name: str) -> bool:
     if model_name in {"gpt-4-base"} or model_name.startswith("gpt-3.5-turbo-instruct"):
         return False
 
-    CHAT_MODEL_NAMES = {"gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "gpt-4-32k"}
+    CHAT_MODEL_NAMES = {"gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "gpt-4-32k", "gpt-4o", "gpt-4o-mini"}
 
     if model_name in CHAT_MODEL_NAMES:
         return True


### PR DESCRIPTION
# Fix a bug in examples/mmlu.ipynb
## Description: 
if we use `gpt-4o` or `gpt-4o-mini` to replace gpt-3.5-turbo for evaluation in https://github.com/openai/evals/blob/234bcde34b5951233681455faeb92baaaef97573/examples/mmlu.ipynb#L126
It will raise error as below:
```
[2024-08-25 16:11:24,231] [registry.py:271] Loading registry from /workspace/evals/evals/registry/evals
[2024-08-25 16:11:24,874] [registry.py:271] Loading registry from /home/gitpod/.evals/evals
[2024-08-25 16:11:25,190] [oaieval.py:215] Run started: 240825161125LT57KOL6
[2024-08-25 16:11:25,386] [data.py:94] Fetching /workspace/evals/examples/../evals/registry/data/mmlu/anatomy/few_shot.jsonl
[2024-08-25 16:11:25,386] [data.py:94] Fetching /workspace/evals/examples/../evals/registry/data/mmlu/anatomy/samples.jsonl
[2024-08-25 16:11:25,388] [eval.py:36] Evaluating 135 samples
[2024-08-25 16:11:25,394] [eval.py:144] Running in threaded mode with 10 threads!
  0%|                                                   | 0/135 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/home/gitpod/.pyenv/versions/3.12.4/bin/oaieval", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/workspace/evals/evals/cli/oaieval.py", line 304, in main
    run(args)
  File "/workspace/evals/evals/cli/oaieval.py", line 226, in run
    result = eval.run(recorder)
             ^^^^^^^^^^^^^^^^^^
  File "/workspace/evals/evals/elsuite/basic/match.py", line 60, in run
    self.eval_all_samples(recorder, samples)
  File "/workspace/evals/evals/eval.py", line 146, in eval_all_samples
    idx_and_result = list(tqdm(iter, total=len(work_items), disable=not show_progress))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.pyenv_mirror/user/current/lib/python3.12/site-packages/tqdm/std.py", line 1181, in __iter__
    for obj in iterable:
  File "/home/gitpod/.pyenv/versions/3.12.4/lib/python3.12/multiprocessing/pool.py", line 873, in next
...
           ^^^^^^^^^^^^^^
  File "/workspace/.pyenv_mirror/user/current/lib/python3.12/site-packages/openai/_base_client.py", line 1041, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.NotFoundError: Error code: 404 - {'error': {'message': 'This is a chat model and not supported in the v1/completions endpoint. Did you mean to use v1/chat/completions?', 'type': 'invalid_request_error', 'param': 'model', 'code': None}}
```
It may cause confuse for beginers if they want to test gpt-4o or gpt-4o-mini.
We can solve it by change https://github.com/openai/evals/blob/234bcde34b5951233681455faeb92baaaef97573/evals/registry.py#L87
into
```
 CHAT_MODEL_NAMES = {"gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "gpt-4-32k", "gpt-4o", "gpt-4o-mini"} 
```

## Criteria for a good eval ✅

Below are some of the criteria we look for in a good eval. In general, we are seeking cases where the model does not do a good job despite being capable of generating a good response (note that there are some things large language models cannot do, so those would not make good evals).

Your eval should be:

- [x] Thematically consistent: The eval should be thematically consistent. We'd like to see a number of prompts all demonstrating some particular failure mode. For example, we can create an eval on cases where the model fails to reason about the physical world.
- [x] Contains failures where a human can do the task, but either GPT-4 or GPT-3.5-Turbo could not.
- [x] Includes good signal around what is the right behavior. This means either a correct answer for `Basic` evals or the `Fact` Model-graded eval, or an exhaustive rubric for evaluating answers for the `Criteria` Model-graded eval.
- [x] **Include at least 15 high-quality examples.**

If there is anything else that makes your eval worth including, please document it below.

### Unique eval value

> Insert what makes your eval high quality that was not mentioned above. (Not required)

## Eval structure 🏗️

Your eval should

- [x] Check that your data is in `evals/registry/data/{name}`
- [x] Check that your YAML is registered at `evals/registry/evals/{name}.yaml`
- [x] Ensure you have the right to use the data you submit via this eval

(For now, we will only be approving evals that use one of the existing eval classes. You may still write custom eval classes for your own cases, and we may consider merging them in the future.)

## Final checklist 👀

### Submission agreement

By contributing to Evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an Eval. OpenAI reserves the right to use this data in future service improvements to our product. Contributions to OpenAI Evals will be subject to our usual Usage Policies (<https://platform.openai.com/docs/usage-policies>).

- [x] I agree that my submission will be made available under an MIT license and complies with OpenAI's usage policies.

### Email address validation

If your submission is accepted, we will be granting GPT-4 access to a limited number of contributors. Access will be given to the email address associated with the commits on the merged pull request.

- [x] I acknowledge that GPT-4 access will only be granted, if applicable, to the email address used for my merged pull request.

### Limited availability acknowledgment

We know that you might be excited to contribute to OpenAI's mission, help improve our models, and gain access to GPT-4. However, due to the requirements mentioned above and the high volume of submissions, we will not be able to accept all submissions and thus not grant everyone who opens a PR GPT-4 access. We know this is disappointing, but we hope to set the right expectation before you open this PR.

- [x] I understand that opening a PR, even if it meets the requirements above, does not guarantee the PR will be merged nor GPT-4 access be granted.

### Submit eval

- [x] I have filled out all required fields of this form
- [x] I have used **Git LFS** for the Eval JSON data
- [x] (Ignore if not submitting code) I have run `pip install pre-commit; pre-commit install` and have verified that `mypy`, `black`, `isort`, `autoflake` and `ruff` are running when I commit and push

Failure to fill out all required fields will result in the PR being closed.

### Eval JSON data

Since we are using Git LFS, we are asking eval submitters to add in as many Eval Samples (at least 5) from their contribution here:

<details>
  <summary>View evals in JSON</summary>

  ### Eval
  ```jsonl
  INSERT_EVAL_HERE
  ```
</details>
