### PR TITLE
Updating readme to link to OpenAI hosted evals experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenAI Evals
 
+> You can now configure and run Evals directly in the OpenAI Dashboard. [Get started →](https://platform.openai.com/docs/guides/evals)
+
 Evals provide a framework for evaluating large language models (LLMs) or systems built using LLMs. We offer an existing registry of evals to test different dimensions of OpenAI models and the ability to write your own custom evals for use cases you care about. You can also use your data to build private evals which represent the common LLMs patterns in your workflow without exposing any of that data publicly.
 
 If you are building with LLMs, creating high quality evals is one of the most impactful things you can do. Without evals, it can be very difficult and time intensive to understand how different model versions might affect your use case. In the words of [OpenAI's President Greg Brockman](https://twitter.com/gdb/status/1733553161884127435):


### PR DESCRIPTION
To offer greater flexibility, proposing we add a link to OpenAI's [hosted evals experience](https://platform.openai.com/docs/guides/evals) launched at DevDay this year