### PR TITLE
Fix TypeError in add_token_usage_to_result when non-integer usage data is present

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -279,7 +279,7 @@ def add_token_usage_to_result(result: dict[str, Any], recorder: RecorderBase) ->
     if usage_events:
         # Sum up the usage of all samples (assumes the usage is the same for all samples)
         total_usage = {
-            key: sum(u[key] if u[key] is not None else 0 for u in usage_events)
+            key: sum(u[key] if isinstance(u[key], int) else 0 for u in usage_events)
             for key in usage_events[0]
         }
         total_usage_str = "\n".join(f"{key}: {value:,}" for key, value in total_usage.items())


### PR DESCRIPTION
Fixes a TypeError in add_token_usage_to_result by ensuring only integer values are summed from usage_events, preventing issues with non-integer data types.