### PR TITLE
Add powershell-encoding-basics eval

### DIFF
--- a/evals/registry/data/powershell_encoding_basics/samples.jsonl
+++ b/evals/registry/data/powershell_encoding_basics/samples.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a61efd0272b6e309bb4797d95caf99dc35f99d859e51d0f6de0ccdc52400094
-size 829
+oid sha256:341a8353951cc11781834f02f8e82b3d9eea92c91b100d09b6e2d9e3122086ca
+size 3856

--- a/evals/registry/data/powershell_encoding_basics/samples.jsonl
+++ b/evals/registry/data/powershell_encoding_basics/samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a61efd0272b6e309bb4797d95caf99dc35f99d859e51d0f6de0ccdc52400094
+size 829

--- a/evals/registry/evals/powershell-encoding-basics.yaml
+++ b/evals/registry/evals/powershell-encoding-basics.yaml
@@ -1,0 +1,9 @@
+powershell-encoding-basics:
+  id: powershell-encoding-basics.dev.v0
+  description: "PowerShell encoding + tooling basics (BOM, Format-Hex version differences)."
+  metrics: [accuracy]
+
+powershell-encoding-basics.dev.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: powershell_encoding_basics/samples.jsonl


### PR DESCRIPTION
I confirm this PR follows the Evals contribution guidelines (min 15 samples; run with GPT-3.5-Turbo; JSON data stored via Git LFS). :contentReference[oaicite:1]{index=1}

## Eval details 📑

### Eval name
powershell-encoding-basics

### Eval description
PowerShell encoding + tooling basics across Windows PowerShell 5.1 vs PowerShell 7+ (UTF-8 BOM behavior, default encodings, and Format-Hex `-Count` support).

### What makes this a useful eval?
This eval targets a real-world and version-dependent failure mode: diagnosing and preventing encoding-related bugs when moving between Windows PowerShell 5.1 and PowerShell 7+ (BOM vs no-BOM), plus tooling/version differences (e.g., `Format-Hex -Count`). These are tasks a human can do from docs + experience, but models often mix up version-specific defaults and behaviors.

- Thematically consistent: all samples focus on PowerShell encoding defaults and version differences.
- Strong signal: answers are intentionally short and unambiguous (Yes/No, version number, encoding name, byte sequence).
- Sample count: **21**
- JSON data stored with **Git LFS**
- Ran locally with `gpt-3.5-turbo`: **accuracy = 0.8095238095 (17/21)** (below 90%)

Command used:
```powershell
$env:EVALS_THREADS = "1"
.\.venv\Scripts\oaieval gpt-3.5-turbo powershell-encoding-basics `
  --record_path .\tmp\evallogs\powershell-encoding-basics.gpt-3.5-turbo.jsonl
