### PR TITLE
fix: omit non-numeric usage fields from token usage report

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -279,7 +279,7 @@ def add_token_usage_to_result(result: dict[str, Any], recorder: RecorderBase) ->
     if usage_events:
         # Sum up the usage of all samples (assumes the usage is the same for all samples)
         total_usage = {
-            key: sum(int(u[key]) if u[key] is not None else 0 for u in usage_events)
+            key: sum(int(u[key]) if isinstance(u[key], (int, float)) else 0 for u in usage_events)
             for key in usage_events[0]
         }
         total_usage_str = "\n".join(f"{key}: {value:,}" for key, value in total_usage.items())

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -279,7 +279,7 @@ def add_token_usage_to_result(result: dict[str, Any], recorder: RecorderBase) ->
     if usage_events:
         # Sum up the usage of all samples (assumes the usage is the same for all samples)
         total_usage = {
-            key: sum(u[key] if u[key] is not None else 0 for u in usage_events)
+            key: sum(int(u[key]) if u[key] is not None else 0 for u in usage_events)
             for key in usage_events[0]
         }
         total_usage_str = "\n".join(f"{key}: {value:,}" for key, value in total_usage.items())

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -279,8 +279,9 @@ def add_token_usage_to_result(result: dict[str, Any], recorder: RecorderBase) ->
     if usage_events:
         # Sum up the usage of all samples (assumes the usage is the same for all samples)
         total_usage = {
-            key: sum(int(u[key]) if isinstance(u[key], (int, float)) else 0 for u in usage_events)
+            key: sum(int(u[key]) for u in usage_events if u.get(key) is not None)
             for key in usage_events[0]
+            if all(u.get(key) is None or isinstance(u.get(key), (int, float)) for u in usage_events)
         }
         total_usage_str = "\n".join(f"{key}: {value:,}" for key, value in total_usage.items())
         logger.info(f"Token usage from {len(usage_events)} sampling events:\n{total_usage_str}")

--- a/evals/cli/oaieval_test.py
+++ b/evals/cli/oaieval_test.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from evals.cli.oaieval import add_token_usage_to_result
+
+
+class DummyRecorder:
+    def __init__(self, events):
+        self.events = events
+
+    def get_events(self, type):
+        return self.events
+
+
+def test_add_token_usage_to_result_skips_non_numeric_usage_fields():
+    result = {}
+    recorder = DummyRecorder(
+        [
+            SimpleNamespace(
+                data={
+                    "usage": {
+                        "completion_tokens": 14,
+                        "prompt_tokens": 80,
+                        "total_tokens": 94,
+                        "completion_tokens_details": object(),
+                        "prompt_tokens_details": object(),
+                    }
+                }
+            )
+        ]
+    )
+
+    add_token_usage_to_result(result, recorder)
+
+    assert result == {
+        "usage_completion_tokens": 14,
+        "usage_prompt_tokens": 80,
+        "usage_total_tokens": 94,
+    }


### PR DESCRIPTION
## Problem

When running evals, the OpenAI API returns nested objects such as
`CompletionTokensDetails` and `PromptTokensDetails` alongside plain
integer fields in the usage response. The original code attempted to
sum all fields directly, causing:

```
TypeError: unsupported operand type(s) for +: 'int' and 'CompletionTokensDetails'
```

Fixes #1582

## Root cause

`dict(usage)` produces a mix of plain integers (`completion_tokens`,
`prompt_tokens`, `total_tokens`) and nested Pydantic models
(`completion_tokens_details`, `prompt_tokens_details`). The summation
loop hit these nested objects and failed because they are not numeric.

## Fix

Filter at the key level — only include keys where all events have
`None` or numeric values. Nested objects are excluded entirely from
the report rather than being reported as a misleading `0`.

```python
total_usage = {
    key: sum(int(u[key]) for u in usage_events if u.get(key) is not None)
    for key in usage_events[0]
    if all(u.get(key) is None or isinstance(u.get(key), (int, float)) for u in usage_events)
}
```

## Changes

- `evals/cli/oaieval.py` — filter non-numeric fields at the key level
- `evals/cli/oaieval_test.py` — regression test verifying that nested detail objects are skipped while real token counts are summed correctly

## Tests

- `venv/bin/python -m pytest evals/cli/oaieval_test.py` — passed
- Full `venv/bin/python -m pytest` could not complete locally; the venv is missing several project dependencies (`mock`, `torch`, `nltk`, `anthropic`, `google-generativeai`) due to conflicts with Python 3.9
- GitHub reports no CI checks configured on this PR branch