### PR TITLE
Make Snowflake connector an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pip install evals
 
 You can find the full instructions to run existing evals in [`run-evals.md`](docs/run-evals.md) and our existing eval templates in [`eval-templates.md`](docs/eval-templates.md). For more advanced use cases like prompt chains or tool-using agents, you can use our [Completion Function Protocol](docs/completion-fns.md).
 
-We provide the option for you to log your eval results to a Snowflake database, if you have one or wish to set one up. For this option, you will further have to specify the `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_DATABASE`, `SNOWFLAKE_USERNAME`, and `SNOWFLAKE_PASSWORD` environment variables.
+We provide the option for you to log your eval results to a Snowflake database, if you have one or wish to set one up. Install the Snowflake support with `pip install 'evals[snowflake]'`, then specify the `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_DATABASE`, `SNOWFLAKE_USERNAME`, and `SNOWFLAKE_PASSWORD` environment variables.
 
 ## Writing evals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "pyyaml",
     "sacrebleu",
     "seaborn",
-    "snowflake-connector-python[pandas]",
     "spacy-universal-sentence-encoder",
     "statsmodels",
     "termcolor",
@@ -54,6 +53,8 @@ repository = "https://github.com/openai/evals"
 
 [project.optional-dependencies]
 formatters = ["black", "isort", "autoflake", "ruff"]
+
+snowflake = ["snowflake-connector-python[pandas]"]
 
 torch = ["torch"]
 


### PR DESCRIPTION
## Summary

Move `snowflake-connector-python[pandas]` out of the core dependency set and into a dedicated `snowflake` extra.

- core installs no longer pull in the Snowflake connector
- Snowflake users can install support with `pip install 'evals[snowflake]'`
- README installation guidance now documents the extra

## Why

Snowflake logging is optional and the connector is imported lazily only when a Snowflake connection is used. Keeping the connector in the default dependency set adds unnecessary installation weight for users who only run local or non-Snowflake evals.

## Testing

Packaging-only change. The existing lazy import path in `evals/utils/snowflake.py` remains unchanged.

Closes #1714.