### PR TITLE
Exclude invalid model-grader outputs from scoring

### DIFF
--- a/evals/elsuite/modelgraded/classify_utils.py
+++ b/evals/elsuite/modelgraded/classify_utils.py
@@ -96,9 +96,8 @@ def get_choice_score(
         return None
     if choice_scores == "from_strings":
         choice_scores = {c: float(c) for c in choice_strings}
-    # assumption: each INVALID_STR contributes the lowest score
     if choice == INVALID_STR:
-        return min(choice_scores.values())
+        return None
     return choice_scores[choice]
 
 

--- a/tests/unit/evals/test_modelgraded_classify_utils.py
+++ b/tests/unit/evals/test_modelgraded_classify_utils.py
@@ -1,0 +1,13 @@
+from evals.elsuite.modelgraded.classify_utils import INVALID_STR, get_choice_score
+
+
+def test_invalid_choice_has_no_numeric_score() -> None:
+    assert get_choice_score(INVALID_STR, ["A", "B"], {"A": 1.0, "B": 0.0}) is None
+
+
+def test_invalid_choice_has_no_score_for_from_strings() -> None:
+    assert get_choice_score(INVALID_STR, ["1", "2"], "from_strings") is None
+
+
+def test_valid_choice_keeps_configured_score() -> None:
+    assert get_choice_score("A", ["A", "B"], {"A": 1.0, "B": 0.0}) == 1.0


### PR DESCRIPTION
## Summary

Stop treating an unparseable model-grader response as the minimum rubric score.

- `get_choice_score()` now returns `None` for `__invalid__`
- invalid choices continue to be recorded and counted as `counts/__invalid__`
- the existing score aggregation already excludes `None` values, so malformed judge output no longer lowers the evaluated model's numerical score
- valid choice scoring is unchanged

## Why

An invalid judge response represents grader failure, not evidence that the evaluated model deserves the worst available score. The previous behavior silently converted parse failures into minimum scores and could bias benchmark results when judge formatting failures were correlated with particular samples.

This keeps the fix deliberately narrow: no retry policy or new judge-output protocol is introduced. It uses the framework's existing invalid-choice accounting and existing `None`-score exclusion path.

## Tests

Added regression coverage for:

- invalid choices with explicit score mappings
- invalid choices with `choice_scores: from_strings`
- unchanged scoring for valid choices

Closes #1712.