### PR TITLE
Make semantic encoder dependency optional

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyyaml
         pip install pytest
-        pip install -e .[torch]
+        pip install -e .[semantic-similarity,torch]
 
     - name: Run unit tests
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "sacrebleu",
     "seaborn",
     "snowflake-connector-python[pandas]",
-    "spacy-universal-sentence-encoder",
     "statsmodels",
     "termcolor",
     "tiktoken",
@@ -55,6 +54,7 @@ repository = "https://github.com/openai/evals"
 [project.optional-dependencies]
 formatters = ["black", "isort", "autoflake", "ruff"]
 
+semantic-similarity = ["spacy-universal-sentence-encoder"]
 torch = ["torch"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Move `spacy-universal-sentence-encoder` out of the core dependency set and into a dedicated `semantic-similarity` extra.

- default installs no longer pull in TensorFlow through `spacy-universal-sentence-encoder`
- semantic-similarity evals can install the dependency explicitly with `pip install -e '.[semantic-similarity]'`
- CI continues installing the extra so the existing steganography and text-compression coverage remains available

## Why

`spacy-universal-sentence-encoder` is only imported by the semantic reconstruction metrics used in the steganography and text-compression evals, but its TensorFlow dependency is currently imposed on every Evals installation. On Python versions/platforms where the TensorFlow constraint cannot be satisfied, even unrelated Evals workflows fail to install.

This follows the same pattern already used by this repository for the optional `torch` dependency: keep specialized heavy dependencies out of the core install while installing the relevant extras in CI.

## Validation

The branch is based on current `main` and changes only packaging plus the CI install command. Runtime code and semantic-similarity behavior are unchanged.

Closes #1567.