### PR TITLE
Add case-insensitive and whitespace-normalized Match options

### DIFF
--- a/evals/api.py
+++ b/evals/api.py
@@ -58,6 +58,8 @@ def record_and_check_match(
     expected: Union[str, list[str], tuple[str]],
     separator: Callable[[str], bool] = None,
     options: Optional[list[str]] = None,
+    ignore_case: bool = False,
+    strip: bool = False,
 ):
     """
     Records and checks if a sampled response from a CompletionFn matches the expected result.
@@ -68,6 +70,8 @@ def record_and_check_match(
         expected: The expected response or list of responses.
         separator: Optional function to check if a character is a separator.
         options: Optional list of options to match against the sampled response.
+        ignore_case: Match case-insensitively while preserving recorded values.
+        strip: Strip leading and trailing whitespace before matching while preserving recorded values.
 
     Returns:
         The matched option or None if no match found.
@@ -79,14 +83,23 @@ def record_and_check_match(
     if options is None:
         options = expected
 
+    def normalize(value: str) -> str:
+        if strip:
+            value = value.strip()
+        if ignore_case:
+            value = value.casefold()
+        return value
+
+    sampled_for_match = normalize(sampled)
     picked = None
     for option in options:
-        if not sampled.startswith(option):
+        option_for_match = normalize(option)
+        if not sampled_for_match.startswith(option_for_match):
             continue
         if (
             separator is not None
-            and len(sampled) > len(option)
-            and not separator(sampled[len(option)])
+            and len(sampled_for_match) > len(option_for_match)
+            and not separator(sampled_for_match[len(option_for_match)])
         ):
             continue
         picked = option

--- a/evals/elsuite/basic/match.py
+++ b/evals/elsuite/basic/match.py
@@ -15,6 +15,8 @@ class Match(evals.Eval):
         max_tokens: int = 500,
         num_few_shot: int = 0,
         few_shot_jsonl: str = None,
+        ignore_case: bool = False,
+        strip: bool = False,
         **kwargs,
     ):
         super().__init__(completion_fns, *args, **kwargs)
@@ -22,6 +24,8 @@ class Match(evals.Eval):
         self.max_tokens = max_tokens
         self.samples_jsonl = samples_jsonl
         self.num_few_shot = num_few_shot
+        self.ignore_case = ignore_case
+        self.strip = strip
         if self.num_few_shot > 0:
             assert few_shot_jsonl is not None, "few shot requires few shot sample dataset"
             self.few_shot_jsonl = few_shot_jsonl
@@ -53,6 +57,8 @@ class Match(evals.Eval):
             prompt=prompt,
             sampled=sampled,
             expected=sample["ideal"],
+            ignore_case=self.ignore_case,
+            strip=self.strip,
         )
 
     def run(self, recorder):

--- a/tests/unit/evals/test_api.py
+++ b/tests/unit/evals/test_api.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+
+from evals.api import record_and_check_match
+
+
+def test_record_and_check_match_can_ignore_case() -> None:
+    with patch("evals.api.record_match") as record_match:
+        picked = record_and_check_match(
+            prompt="prompt",
+            sampled="No",
+            expected="no",
+            ignore_case=True,
+        )
+
+    assert picked == "no"
+    record_match.assert_called_once_with(
+        True,
+        expected=["no"],
+        picked="no",
+        sampled="No",
+        options=["no"],
+    )
+
+
+def test_record_and_check_match_can_strip_whitespace() -> None:
+    with patch("evals.api.record_match") as record_match:
+        picked = record_and_check_match(
+            prompt="prompt",
+            sampled="  Mumbai\n",
+            expected="Mumbai",
+            strip=True,
+        )
+
+    assert picked == "Mumbai"
+    record_match.assert_called_once_with(
+        True,
+        expected=["Mumbai"],
+        picked="Mumbai",
+        sampled="  Mumbai\n",
+        options=["Mumbai"],
+    )
+
+
+def test_record_and_check_match_defaults_remain_strict() -> None:
+    with patch("evals.api.record_match") as record_match:
+        case_mismatch = record_and_check_match(
+            prompt="prompt",
+            sampled="No",
+            expected="no",
+        )
+        whitespace_mismatch = record_and_check_match(
+            prompt="prompt",
+            sampled=" Mumbai",
+            expected="Mumbai",
+        )
+
+    assert case_mismatch is None
+    assert whitespace_mismatch is None
+    assert record_match.call_count == 2


### PR DESCRIPTION
## Summary

Add optional normalization controls to the `Match` eval template so exact-prefix matching can handle common formatting differences without weakening the default behavior.

- add `ignore_case: bool = False` to `Match`
- add `strip: bool = False` to `Match`
- pass those controls through `record_and_check_match()`
- preserve the original sampled text and original expected option in recorded events
- keep existing strict matching as the default

## Why

`Match` currently treats responses such as `No` vs `no` and ` Mumbai` vs `Mumbai` as failures even when the eval author wants to ignore capitalization or surrounding whitespace. Using broader templates such as `Includes` or `FuzzyMatch` changes the matching semantics and can introduce false positives.

The new options let an eval author opt into normalization in YAML while retaining the existing prefix-match behavior.

## Tests

Added focused regression coverage for:

- case-insensitive matching
- leading/trailing whitespace stripping
- unchanged strict default behavior
- preservation of original sampled values in recorded match events

Closes #1421.