### PR TITLE
Harden flask-playwright error handling

### DIFF
--- a/evals/elsuite/multistep_web_tasks/docker/flask-playwright/app.py
+++ b/evals/elsuite/multistep_web_tasks/docker/flask-playwright/app.py
@@ -59,9 +59,8 @@ def setup():
         client = page.context.new_cdp_session(page)  # talk to chrome devtools
         client.send("Accessibility.enable")  # to get AccessibilityTrees
     except Exception as e:
-        return jsonify(
-            {"status": "error", "message": f"failed to start session (already started?): {e}"}
-        )
+        logger.error("Failed to start Playwright session: %s", type(e).__name__)
+        return jsonify({"status": "error", "message": "failed to start session (already started?)"})
     return jsonify({"status": "success", "message": "session started"})
 
 
@@ -104,7 +103,7 @@ def exec_command():
         result = _execute_command(request.json)
     except ValueError as e:
         assert len(e.args) == 2, "ValueError should have a message and a return object"
-        logger.error(e.args[0])
+        logger.error("%s", e.args[0])
         return e.args[1]
     try:
         response = jsonify(
@@ -116,11 +115,12 @@ def exec_command():
             }
         )
     except TypeError as e:
+        logger.error("Failed to serialize command result: %s", type(e).__name__)
         response = jsonify(
             {
                 "status": "success",
-                "message": f"could not return results of executed commands {request.json['command']}",
-                "content": str(e),
+                "message": "could not return results of executed command",
+                "content": None,
                 "url": page.url,
             }
         )
@@ -149,7 +149,7 @@ def exec_commands():
         results = _execute_commands(request.json)
     except ValueError as e:
         assert len(e.args) == 2, "ValueError should have a message and a return object"
-        logger.error(e.args[0])
+        logger.error("%s", e.args[0])
         return e.args[1]
     try:
         response = jsonify(
@@ -161,11 +161,12 @@ def exec_commands():
             }
         )
     except TypeError as e:
+        logger.error("Failed to serialize command results: %s", type(e).__name__)
         response = jsonify(
             {
                 "status": "success",
-                "message": f"could not return results of executed commands {request.json['commands']}",
-                "content": str(e),
+                "message": "could not return results of executed commands",
+                "content": None,
                 "url": page.url,
             }
         )
@@ -184,12 +185,12 @@ def _execute_command(json_data: dict):
         result = eval(command)
         return result
     except Exception as e:
-        logger.info(f"Error executing command: {command}")
-        logger.error(e)
+        logger.info("Error executing command: %r", command)
+        logger.error("Command execution failed: %s", type(e).__name__)
         raise ValueError(
-            f"Error executing command {command}",
-            jsonify({"status": "error", "message": f"error executing command {command}: {e}"}),
-        )
+            "Error executing command",
+            jsonify({"status": "error", "message": "error executing command"}),
+        ) from None
 
 
 def _execute_commands(json_data: dict):

--- a/tests/unit/evals/test_flask_playwright_app.py
+++ b/tests/unit/evals/test_flask_playwright_app.py
@@ -1,0 +1,91 @@
+import importlib.util
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "evals"
+    / "elsuite"
+    / "multistep_web_tasks"
+    / "docker"
+    / "flask-playwright"
+    / "app.py"
+)
+SPEC = importlib.util.spec_from_file_location("flask_playwright_app", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+flask_playwright_app = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(flask_playwright_app)
+
+
+def test_execute_command_redacts_exception_details_and_escapes_log(caplog) -> None:
+    command = "1 / 0\nforged-log-entry"
+
+    with flask_playwright_app.app.app_context(), caplog.at_level(
+        logging.INFO, logger=flask_playwright_app.logger.name
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            flask_playwright_app._execute_command({"command": command})
+
+    assert exc_info.value.args[0] == "Error executing command"
+    assert exc_info.value.args[1].get_json() == {
+        "status": "error",
+        "message": "error executing command",
+    }
+    command_log = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("Error executing command:")
+    )
+    assert "\\nforged-log-entry" in command_log
+    assert "\nforged-log-entry" not in command_log
+
+
+def test_setup_does_not_return_exception_text(monkeypatch) -> None:
+    def fail_setup():
+        raise RuntimeError("sensitive setup detail")
+
+    monkeypatch.setattr(flask_playwright_app, "sync_playwright", fail_setup)
+    monkeypatch.setattr(flask_playwright_app, "playwright", None)
+    monkeypatch.setattr(flask_playwright_app, "browser", None)
+    monkeypatch.setattr(flask_playwright_app, "page", None)
+    monkeypatch.setattr(flask_playwright_app, "client", None)
+
+    response = flask_playwright_app.app.test_client().post(
+        "/setup",
+        json={"api-key": flask_playwright_app.FLASK_API_KEY},
+    )
+
+    payload = response.get_json()
+    assert payload == {
+        "status": "error",
+        "message": "failed to start session (already started?)",
+    }
+    assert "sensitive setup detail" not in response.get_data(as_text=True)
+
+
+def test_exec_command_does_not_return_serialization_exception(monkeypatch) -> None:
+    monkeypatch.setattr(
+        flask_playwright_app,
+        "page",
+        SimpleNamespace(url="https://example.com"),
+    )
+    monkeypatch.setattr(flask_playwright_app, "_execute_command", lambda _json: object())
+
+    response = flask_playwright_app.app.test_client().post(
+        "/exec_command",
+        json={
+            "api-key": flask_playwright_app.FLASK_API_KEY,
+            "command": "return-object",
+        },
+    )
+
+    assert response.get_json() == {
+        "status": "success",
+        "message": "could not return results of executed command",
+        "content": None,
+        "url": "https://example.com",
+    }


### PR DESCRIPTION
## Summary

Harden the multistep web-task Flask/Playwright helper so command failures do not inject raw input into logs or expose exception details through API responses.

- log commands with `%r` so embedded control characters such as newlines are escaped
- log only exception types rather than raw exception messages
- return generic error responses instead of `str(e)` or interpolated exception text
- keep successful command responses and existing API-key checks unchanged
- add regression coverage for command-log escaping, setup error redaction, and result-serialization errors

## Why

The current error path interpolates model-provided command text directly into a log message and returns exception strings to the caller. That creates two separate problems:

1. command text containing newlines can forge additional-looking log entries
2. exception text can disclose internal implementation details or stack-derived information through the Flask API

This patch keeps diagnostic information server-side at a safe level while preventing untrusted command/error text from crossing those boundaries.

## Tests

Added focused tests covering:

- newline-containing command input is represented safely in logs
- setup exceptions are not included in API responses
- JSON serialization exceptions are not returned to callers

Closes #1542.
Closes #1543.