### PR TITLE
Grade every sampled completion in ModelBasedClassify

### DIFF
--- a/evals/elsuite/modelgraded/classify.py
+++ b/evals/elsuite/modelgraded/classify.py
@@ -48,7 +48,8 @@ class ModelBasedClassify(evals.Eval):
         if len(self.completion_fns) > 1:
             assert self.multicomp_n == n_models
 
-        self.n_samples = self.sample_kwargs.get("n_samples") or 1
+        configured_n_samples = self.sample_kwargs.get("n_samples")
+        self.n_samples = 1 if configured_n_samples is None else configured_n_samples
         if not isinstance(self.n_samples, int) or self.n_samples < 1:
             raise ValueError("sample_kwargs.n_samples must be a positive integer")
         if self.multicomp_n > 1 and self.n_samples > 1:
@@ -60,7 +61,7 @@ class ModelBasedClassify(evals.Eval):
 
         self.mg = self.registry.get_modelgraded_spec(modelgraded_spec)
 
-    def eval_sample(self, test_sample: dict, rng: Random) -> None:
+    def eval_sample(self, test_sample: dict, rng: Random) -> Union[str, list[str]]:
         """Evaluate a single sample.
 
         Recorded metrics are always: one of the self.choice_strings, or "__invalid__".

--- a/evals/elsuite/modelgraded/classify.py
+++ b/evals/elsuite/modelgraded/classify.py
@@ -48,19 +48,30 @@ class ModelBasedClassify(evals.Eval):
         if len(self.completion_fns) > 1:
             assert self.multicomp_n == n_models
 
+        self.n_samples = self.sample_kwargs.get("n_samples") or 1
+        if not isinstance(self.n_samples, int) or self.n_samples < 1:
+            raise ValueError("sample_kwargs.n_samples must be a positive integer")
+        if self.multicomp_n > 1 and self.n_samples > 1:
+            raise ValueError(
+                "sample_kwargs.n_samples > 1 cannot be combined with multicomp_n > 1; "
+                "use n_samples to grade independent completions or multicomp_n to grade "
+                "multiple outputs jointly."
+            )
+
         self.mg = self.registry.get_modelgraded_spec(modelgraded_spec)
 
     def eval_sample(self, test_sample: dict, rng: Random) -> None:
         """Evaluate a single sample.
 
         Recorded metrics are always: one of the self.choice_strings, or "__invalid__".
+        When n_samples > 1, each sampled completion is graded and recorded independently.
         """
         # process test_sample
         for k in self.mg.input_outputs:
             test_sample[k] = scrub_formatting_from_prompt(test_sample[k])
 
-        # run policy completions
-        completions = {}
+        # Each dictionary is one independently gradeable set of generated outputs.
+        completion_variants: list[dict[str, str]] = [{}]
         for k, v in self.mg.input_outputs.items():
             if v in test_sample:  # test_sample already has completion, skip.
                 continue
@@ -72,34 +83,57 @@ class ModelBasedClassify(evals.Eval):
                     sample_kwargs=self.sample_kwargs,
                     n=self.multicomp_n,
                 )
-            else:
-                get_input_completion = PromptFn(
-                    test_sample[k], completion_fn=self.completion_fn, **self.sample_kwargs
-                )
+                completion_variants[0][v] = completion
+                continue
+
+            get_input_completion = PromptFn(
+                test_sample[k], completion_fn=self.completion_fn, **self.sample_kwargs
+            )
+            if self.n_samples == 1:
                 completion, _ = get_input_completion()
-            completions[v] = completion
+                sampled_completions = [completion]
+            else:
+                sampled_completions, _ = get_input_completion.sample_all()
+                if len(sampled_completions) != self.n_samples:
+                    raise ValueError(
+                        f"Completion function returned {len(sampled_completions)} completions "
+                        f"after n_samples={self.n_samples} was requested"
+                    )
 
-        # run modelgraded eval
-        metrics = {}
-        choice, info = classify(
-            mg=self.mg,
-            completion_fn=self.eval_completion_fn,
-            completion_kwargs=self.eval_kwargs,
-            eval_type=self.eval_type,
-            n=self.multicomp_n,
-            match_fn=self.match_fn,
-            format_kwargs={**completions, **test_sample, **self.modelgraded_spec_args},
-        )
-        metrics.update(dict(choice=choice, score=info["score"]))
+            if len(completion_variants) == 1 and not completion_variants[0]:
+                completion_variants = [{} for _ in sampled_completions]
+            elif len(sampled_completions) != len(completion_variants):
+                raise ValueError(
+                    "Generated outputs for model-graded fields returned different numbers of completions"
+                )
 
-        # run metaeval if requested
-        if self.metaeval:
-            assert "choice" in test_sample
-            metrics["metascore"] = choice == test_sample["choice"]
+            for completion_index, completion in enumerate(sampled_completions):
+                completion_variants[completion_index][v] = completion
 
-        evals.record.record_metrics(**metrics)
+        choices = []
+        for completion_index, completions in enumerate(completion_variants):
+            choice, info = classify(
+                mg=self.mg,
+                completion_fn=self.eval_completion_fn,
+                completion_kwargs=self.eval_kwargs,
+                eval_type=self.eval_type,
+                n=self.multicomp_n,
+                match_fn=self.match_fn,
+                format_kwargs={**completions, **test_sample, **self.modelgraded_spec_args},
+            )
+            metrics = dict(choice=choice, score=info["score"])
+            if len(completion_variants) > 1:
+                metrics["completion_index"] = completion_index
 
-        return choice
+            # run metaeval if requested
+            if self.metaeval:
+                assert "choice" in test_sample
+                metrics["metascore"] = choice == test_sample["choice"]
+
+            evals.record.record_metrics(**metrics)
+            choices.append(choice)
+
+        return choices[0] if len(choices) == 1 else choices
 
     def run(self, recorder):
         samples = self.get_samples()

--- a/evals/elsuite/utils.py
+++ b/evals/elsuite/utils.py
@@ -163,8 +163,7 @@ class PromptFn:
         self.completion_kwargs = completion_kwargs
         self.n_samples = n_samples
 
-    def __call__(self, **kwargs):
-        # if any input kwargs is chat prompt, convert to text prompt
+    def _format_prompt(self, **kwargs):
         kwargs = {
             k: chat_prompt_to_text_prompt(v, for_completion=False) if is_chat_prompt(v) else v
             for k, v in kwargs.items()
@@ -176,10 +175,12 @@ class PromptFn:
                 if "content" in formatted_msg:
                     formatted_msg["content"] = format_necessary(formatted_msg["content"], **kwargs)
                 prompt.append(formatted_msg)
-        else:
-            # Prompt is a string
-            prompt = format_necessary(self.prompt, **kwargs)
+            return prompt
+        return format_necessary(self.prompt, **kwargs)
 
+    def sample_all(self, **kwargs):
+        """Return every completion produced by the configured sampling request."""
+        prompt = self._format_prompt(**kwargs)
         result = self.completion_fn(
             prompt=prompt,
             max_tokens=self.max_tokens,
@@ -190,5 +191,8 @@ class PromptFn:
             n=(1 if self.n_samples is None else self.n_samples),
             **self.completion_kwargs,
         )
-        sampled = result.get_completions()[0]
-        return sampled, prompt
+        return result.get_completions(), prompt
+
+    def __call__(self, **kwargs):
+        completions, prompt = self.sample_all(**kwargs)
+        return completions[0], prompt

--- a/tests/unit/evals/test_modelgraded_multiple_completions.py
+++ b/tests/unit/evals/test_modelgraded_multiple_completions.py
@@ -1,0 +1,115 @@
+import importlib
+from unittest.mock import call, patch
+
+import pytest
+
+import evals.record
+from evals.elsuite.modelgraded.base import ModelGradedSpec
+from evals.elsuite.modelgraded.classify import ModelBasedClassify
+from evals.elsuite.utils import PromptFn
+
+
+class FakeCompletionResult:
+    def __init__(self, completions: list[str]):
+        self.completions = completions
+
+    def get_completions(self) -> list[str]:
+        return self.completions
+
+
+class FakeCompletionFn:
+    def __init__(self, completions: list[str]):
+        self.completions = completions
+        self.calls: list[dict] = []
+
+    def __call__(self, prompt, **kwargs):
+        self.calls.append({"prompt": prompt, **kwargs})
+        return FakeCompletionResult(self.completions)
+
+
+def test_prompt_fn_sample_all_preserves_all_requested_completions() -> None:
+    completion_fn = FakeCompletionFn(["first", "second", "third"])
+    prompt_fn = PromptFn(
+        "Question: {question}",
+        completion_fn=completion_fn,
+        max_tokens=32,
+        temperature=0.7,
+        n_samples=3,
+    )
+
+    completions, prompt = prompt_fn.sample_all(question="hello")
+
+    assert completions == ["first", "second", "third"]
+    assert prompt == "Question: hello"
+    assert completion_fn.calls[0]["n"] == 3
+    assert completion_fn.calls[0]["temperature"] == 0.7
+
+
+def test_prompt_fn_call_keeps_single_completion_compatibility() -> None:
+    completion_fn = FakeCompletionFn(["first", "second"])
+    prompt_fn = PromptFn("hello", completion_fn=completion_fn, max_tokens=32)
+
+    completion, prompt = prompt_fn()
+
+    assert completion == "first"
+    assert prompt == "hello"
+    assert completion_fn.calls[0]["n"] == 1
+
+
+def make_model_based_classify(completion_fn: FakeCompletionFn, n_samples: int):
+    evaluator = ModelBasedClassify.__new__(ModelBasedClassify)
+    evaluator.completion_fns = [completion_fn]
+    evaluator.eval_completion_fn = object()
+    evaluator.sample_kwargs = {"max_tokens": 32, "temperature": 0.8, "n_samples": n_samples}
+    evaluator.eval_kwargs = {"max_tokens": 32}
+    evaluator.metaeval = False
+    evaluator.modelgraded_spec_args = {}
+    evaluator.eval_type = "classify"
+    evaluator.match_fn = None
+    evaluator.multicomp_n = 1
+    evaluator.n_samples = n_samples
+    evaluator.mg = ModelGradedSpec(
+        prompt="Grade {completion}",
+        choice_strings=["A", "B"],
+        input_outputs={"input": "completion"},
+        eval_type="classify",
+        choice_scores={"A": 1.0, "B": 0.0},
+    )
+    return evaluator
+
+
+def test_model_based_classify_grades_each_sampled_completion() -> None:
+    policy = FakeCompletionFn(["candidate 1", "candidate 2", "candidate 3"])
+    evaluator = make_model_based_classify(policy, n_samples=3)
+    classify_module = importlib.import_module("evals.elsuite.modelgraded.classify")
+    seen_completions: list[str] = []
+
+    def fake_classify(**kwargs):
+        completion = kwargs["format_kwargs"]["completion"]
+        seen_completions.append(completion)
+        if completion == "candidate 2":
+            return "B", {"score": 0.0}
+        return "A", {"score": 1.0}
+
+    with patch.object(classify_module, "classify", side_effect=fake_classify), patch.object(
+        evals.record, "record_metrics"
+    ) as record_metrics:
+        choices = evaluator.eval_sample({"input": "question"}, None)
+
+    assert choices == ["A", "B", "A"]
+    assert seen_completions == ["candidate 1", "candidate 2", "candidate 3"]
+    assert len(policy.calls) == 1
+    assert policy.calls[0]["n"] == 3
+    assert record_metrics.call_args_list == [
+        call(choice="A", score=1.0, completion_index=0),
+        call(choice="B", score=0.0, completion_index=1),
+        call(choice="A", score=1.0, completion_index=2),
+    ]
+
+
+def test_model_based_classify_rejects_incomplete_multi_sample_result() -> None:
+    policy = FakeCompletionFn(["candidate 1", "candidate 2"])
+    evaluator = make_model_based_classify(policy, n_samples=3)
+
+    with pytest.raises(ValueError, match="returned 2 completions"):
+        evaluator.eval_sample({"input": "question"}, None)


### PR DESCRIPTION
## Summary

Fix `ModelBasedClassify` so requesting multiple policy completions with `sample_kwargs.n_samples` grades every returned completion instead of silently grading only index 0.

- add `PromptFn.sample_all()` while preserving the existing `PromptFn.__call__()` single-result API
- make one policy sampling request with `n=n_samples`
- independently run the model grader for each returned completion
- record one metrics event per completion, including `completion_index`
- let the existing `run()` aggregation include every independent grade in choice counts and the mean score
- validate that the completion function actually returned the requested number of samples
- reject ambiguous configurations that combine independent `n_samples > 1` sampling with joint `multicomp_n > 1` grading

## Why

The current sampling wrapper calls the completion function with `n_samples`, but immediately indexes `get_completions()[0]`. For model-graded evals this means users can pay for N candidate generations while N-1 candidates are discarded and never evaluated.

That is particularly problematic for higher-temperature robustness studies, pass-rate estimation, and any experiment intended to measure variation across multiple generations from the same prompt. The resulting reported score represents only the first generation rather than the requested sample distribution.

This change keeps the two existing concepts separate:

- `n_samples`: multiple independent generations, each graded separately
- `multicomp_n`: multiple outputs intentionally combined into one joint grading prompt

Existing single-completion behavior remains unchanged.

## Tests

Added focused regression coverage verifying that:

- `PromptFn.sample_all()` preserves every returned completion and passes the requested `n`
- the existing `PromptFn()` API still returns only the first completion for backwards compatibility
- `ModelBasedClassify` grades all requested completions independently from a single policy-model request
- each grade records its completion index
- incomplete multi-sample responses fail explicitly instead of silently undercounting

Closes #1484.