### PR TITLE
Initialize the registry OpenAI client lazily

### DIFF
--- a/evals/registry.py
+++ b/evals/registry.py
@@ -23,8 +23,6 @@ from evals.base import BaseEvalSpec, CompletionFnSpec, EvalSetSpec, EvalSpec
 from evals.elsuite.modelgraded.base import ModelGradedSpec
 from evals.utils.misc import make_object
 
-client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
-
 logger = logging.getLogger(__name__)
 
 DEFAULT_PATHS = [
@@ -110,6 +108,7 @@ class Registry:
     @cached_property
     def api_model_ids(self) -> list[str]:
         try:
+            client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
             return [m.id for m in client.models.list().data]
         except openai.OpenAIError as err:
             # Errors can happen when running eval with completion function that uses custom

--- a/evals/registry_test.py
+++ b/evals/registry_test.py
@@ -1,4 +1,7 @@
-from evals.registry import is_chat_model, n_ctx_from_model_name
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from evals.registry import Registry, is_chat_model, n_ctx_from_model_name
 
 
 def test_n_ctx_from_model_name():
@@ -30,3 +33,23 @@ def test_is_chat_model():
     assert not is_chat_model("text-davinci-003")
     assert not is_chat_model("gpt4-base")
     assert not is_chat_model("code-davinci-002")
+
+
+def test_api_model_ids_initializes_openai_client_lazily():
+    registry = Registry(registry_paths=[])
+    fake_client = MagicMock()
+    fake_client.models.list.return_value = SimpleNamespace(
+        data=[SimpleNamespace(id="model-a"), SimpleNamespace(id="model-b")]
+    )
+
+    with patch("evals.registry.OpenAI", return_value=fake_client) as openai_client:
+        openai_client.assert_not_called()
+
+        assert registry.api_model_ids == ["model-a", "model-b"]
+        openai_client.assert_called_once()
+        fake_client.models.list.assert_called_once()
+
+        # api_model_ids is cached; repeated routing checks do not repeat model discovery.
+        assert registry.api_model_ids == ["model-a", "model-b"]
+        openai_client.assert_called_once()
+        fake_client.models.list.assert_called_once()


### PR DESCRIPTION
## Summary

Avoid constructing an OpenAI API client as a side effect of importing `evals.registry`.

- remove the module-level `OpenAI(...)` construction
- initialize the client only when `Registry.api_model_ids` is first accessed
- preserve the existing cached model-ID lookup
- preserve the existing OpenAI-error fallback for custom completion-function workflows
- add regression coverage proving client initialization and model discovery are lazy and cached

## Why

The registry is imported by CLI and local framework code that may never need OpenAI model discovery. Constructing an API client at import time couples those code paths to API configuration unnecessarily and can prevent operations such as CLI/parser setup or custom completion-function use before the registry has any reason to contact OpenAI.

`api_model_ids` is the only registry path that actually needs the client, so client creation belongs inside that cached property. This also keeps repeated model-routing checks efficient: the property still performs discovery once per `Registry` instance.

## Tests

Updated `evals/registry_test.py` with regression coverage verifying that:

- constructing a `Registry` does not initialize `OpenAI`
- first access to `api_model_ids` initializes the client and returns discovered model IDs
- repeated access uses the cached result without another client construction or model-list call

Closes #1723.