### PR TITLE
Avoid mutating chat prompts during formatting scrub

### DIFF
--- a/evals/elsuite/utils.py
+++ b/evals/elsuite/utils.py
@@ -89,15 +89,18 @@ def f1_score(prediction: str, answers: list[str]) -> float:
 
 
 def scrub_formatting_from_prompt(prompt):
-    scrubbed_prompt = copy.copy(prompt)
-
     if is_chat_prompt(prompt):
-        for i, msg in enumerate(scrubbed_prompt):
-            if "content" in msg:
-                scrubbed_prompt[i]["content"] = msg["content"].replace("{", "{{").replace("}", "}}")
-    else:
-        scrubbed_prompt = scrubbed_prompt.replace("{", "{{").replace("}", "}}")
-    return scrubbed_prompt
+        scrubbed_prompt = []
+        for msg in prompt:
+            scrubbed_msg = copy.copy(msg)
+            if "content" in scrubbed_msg:
+                scrubbed_msg["content"] = scrubbed_msg["content"].replace("{", "{{").replace(
+                    "}", "}}"
+                )
+            scrubbed_prompt.append(scrubbed_msg)
+        return scrubbed_prompt
+
+    return prompt.replace("{", "{{").replace("}", "}}")
 
 
 def format_necessary(template: str, allow_missing: bool = False, **kwargs: dict[str, str]) -> str:

--- a/evals/elsuite/utils_test.py
+++ b/evals/elsuite/utils_test.py
@@ -1,6 +1,8 @@
+from copy import deepcopy
+
 from pytest import mark
 
-from evals.elsuite.utils import fuzzy_match, normalize
+from evals.elsuite.utils import fuzzy_match, normalize, scrub_formatting_from_prompt
 
 
 @mark.parametrize(
@@ -32,3 +34,36 @@ def test_normalize(s: str, expected: str):
 def test_fuzzy_match(s1: str, s2: str, expected: bool):
     assert fuzzy_match(s1, s2) == expected
     assert fuzzy_match(s2, s1) == expected
+
+
+def test_scrub_formatting_from_chat_prompt_does_not_mutate_input():
+    prompt = [
+        {"role": "system", "content": "Use {name} exactly", "name": "instruction"},
+        {"role": "user", "content": "Value: {value}"},
+    ]
+    original = deepcopy(prompt)
+
+    scrubbed = scrub_formatting_from_prompt(prompt)
+
+    assert prompt == original
+    assert scrubbed == [
+        {"role": "system", "content": "Use {{name}} exactly", "name": "instruction"},
+        {"role": "user", "content": "Value: {{value}}"},
+    ]
+    assert scrubbed is not prompt
+    assert scrubbed[0] is not prompt[0]
+    assert scrubbed[1] is not prompt[1]
+
+
+def test_scrub_formatting_from_chat_prompt_is_stable_across_repeated_calls():
+    prompt = [{"role": "user", "content": "Return {answer}"}]
+
+    first = scrub_formatting_from_prompt(prompt)
+    second = scrub_formatting_from_prompt(prompt)
+
+    assert first == second == [{"role": "user", "content": "Return {{answer}}"}]
+    assert prompt == [{"role": "user", "content": "Return {answer}"}]
+
+
+def test_scrub_formatting_from_string_prompt_preserves_behavior():
+    assert scrub_formatting_from_prompt("Return {answer}") == "Return {{answer}}"


### PR DESCRIPTION
## Summary

Make `scrub_formatting_from_prompt()` return an escaped chat prompt without mutating the caller-owned input messages.

- copy each chat message before replacing braces in `content`
- preserve roles, names, and other message metadata
- keep string-prompt behavior unchanged
- make repeated scrubbing of the same original prompt stable instead of compounding brace escaping
- add regression coverage for immutability, repeated calls, and string prompts

## Why

The current implementation shallow-copies only the outer chat-message list. The dictionaries inside that list remain shared with the caller, so assigning the scrubbed `content` also changes the original prompt.

That side effect is particularly risky in model-graded and custom eval code where prompt objects may be reused across samples or passed to multiple formatting steps. A second call on the same prompt can observe already-escaped content and escape it again, changing `{answer}` into `{{{{answer}}}}`.

The nearby `format_prompt()` helper already follows the correct pattern of copying each message dictionary before updating its content. This change brings `scrub_formatting_from_prompt()` in line with that behavior.

## Tests

Updated `evals/elsuite/utils_test.py` to verify that:

- chat prompt inputs remain byte-for-byte equivalent after scrubbing
- returned message dictionaries are separate objects with escaped content
- repeated calls on the same original prompt produce the same result
- string prompt escaping remains unchanged

Closes #1725.