### PR TITLE
Reset max_samples state for every oaieval run

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -121,9 +121,9 @@ def run(args: OaiEvalArguments, registry: Optional[Registry] = None) -> str:
 
     visible = args.visible if args.visible is not None else (args.max_samples is None)
 
-    # Establish per-run state even when there is no sample cap. The setter accepts
-    # None at runtime to clear the module-global limit left by an earlier in-process run.
-    evals.eval.set_max_samples(args.max_samples)  # type: ignore[arg-type]
+    # Establish per-run state even when there is no sample cap, clearing any
+    # module-global limit left by an earlier in-process invocation.
+    evals.eval.set_max_samples(args.max_samples)
 
     registry = registry or Registry()
     if args.registry_path:

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -121,8 +121,9 @@ def run(args: OaiEvalArguments, registry: Optional[Registry] = None) -> str:
 
     visible = args.visible if args.visible is not None else (args.max_samples is None)
 
-    if args.max_samples is not None:
-        evals.eval.set_max_samples(args.max_samples)
+    # Establish per-run state even when there is no sample cap. The setter accepts
+    # None at runtime to clear the module-global limit left by an earlier in-process run.
+    evals.eval.set_max_samples(args.max_samples)  # type: ignore[arg-type]
 
     registry = registry or Registry()
     if args.registry_path:

--- a/evals/eval.py
+++ b/evals/eval.py
@@ -38,7 +38,7 @@ def _index_samples(samples: List[Any]) -> List[Tuple[Any, int]]:
     return work_items
 
 
-def set_max_samples(max_samples: int):
+def set_max_samples(max_samples: Optional[int]):
     global _MAX_SAMPLES
     _MAX_SAMPLES = max_samples
 

--- a/tests/unit/evals/test_oaieval_max_samples.py
+++ b/tests/unit/evals/test_oaieval_max_samples.py
@@ -1,5 +1,4 @@
 import os
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,19 +6,22 @@ import pytest
 os.environ.setdefault("OPENAI_API_KEY", "dummy")
 
 import evals.eval
-from evals.cli.oaieval import run
+from evals.cli.oaieval import OaiEvalArguments, run
+
+
+def _args(max_samples):
+    args = OaiEvalArguments()
+    args.debug = False
+    args.visible = None
+    args.max_samples = max_samples
+    args.registry_path = []
+    args.eval = "missing-eval"
+    return args
 
 
 def test_run_without_max_samples_clears_previous_in_process_limit(monkeypatch) -> None:
     monkeypatch.setattr(evals.eval, "_MAX_SAMPLES", 1)
 
-    args = SimpleNamespace(
-        debug=False,
-        visible=None,
-        max_samples=None,
-        registry_path=None,
-        eval="missing-eval",
-    )
     registry = MagicMock()
     registry.get_eval.return_value = None
     registry._evals = {}
@@ -27,7 +29,7 @@ def test_run_without_max_samples_clears_previous_in_process_limit(monkeypatch) -
     # The missing eval stops the run immediately after per-run setup. That is
     # enough to verify that an uncapped invocation clears stale global state.
     with pytest.raises(AssertionError, match="Eval missing-eval not found"):
-        run(args, registry=registry)
+        run(_args(None), registry=registry)
 
     assert evals.eval._MAX_SAMPLES is None
 
@@ -35,18 +37,11 @@ def test_run_without_max_samples_clears_previous_in_process_limit(monkeypatch) -
 def test_run_sets_current_max_samples_before_registry_lookup(monkeypatch) -> None:
     monkeypatch.setattr(evals.eval, "_MAX_SAMPLES", None)
 
-    args = SimpleNamespace(
-        debug=False,
-        visible=None,
-        max_samples=7,
-        registry_path=None,
-        eval="missing-eval",
-    )
     registry = MagicMock()
     registry.get_eval.return_value = None
     registry._evals = {}
 
     with pytest.raises(AssertionError, match="Eval missing-eval not found"):
-        run(args, registry=registry)
+        run(_args(7), registry=registry)
 
     assert evals.eval._MAX_SAMPLES == 7

--- a/tests/unit/evals/test_oaieval_max_samples.py
+++ b/tests/unit/evals/test_oaieval_max_samples.py
@@ -1,0 +1,52 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "dummy")
+
+import evals.eval
+from evals.cli.oaieval import run
+
+
+def test_run_without_max_samples_clears_previous_in_process_limit(monkeypatch) -> None:
+    monkeypatch.setattr(evals.eval, "_MAX_SAMPLES", 1)
+
+    args = SimpleNamespace(
+        debug=False,
+        visible=None,
+        max_samples=None,
+        registry_path=None,
+        eval="missing-eval",
+    )
+    registry = MagicMock()
+    registry.get_eval.return_value = None
+    registry._evals = {}
+
+    # The missing eval stops the run immediately after per-run setup. That is
+    # enough to verify that an uncapped invocation clears stale global state.
+    with pytest.raises(AssertionError, match="Eval missing-eval not found"):
+        run(args, registry=registry)
+
+    assert evals.eval._MAX_SAMPLES is None
+
+
+def test_run_sets_current_max_samples_before_registry_lookup(monkeypatch) -> None:
+    monkeypatch.setattr(evals.eval, "_MAX_SAMPLES", None)
+
+    args = SimpleNamespace(
+        debug=False,
+        visible=None,
+        max_samples=7,
+        registry_path=None,
+        eval="missing-eval",
+    )
+    registry = MagicMock()
+    registry.get_eval.return_value = None
+    registry._evals = {}
+
+    with pytest.raises(AssertionError, match="Eval missing-eval not found"):
+        run(args, registry=registry)
+
+    assert evals.eval._MAX_SAMPLES == 7


### PR DESCRIPTION
## Summary

Prevent `oaieval.run()` from inheriting a stale module-global sample cap from an earlier invocation in the same Python process.

- establish `max_samples` state on every run, including `None`
- clear an earlier cap when the current invocation is uncapped
- keep ordinary one-process CLI behavior unchanged
- add focused regression coverage for both resetting and setting the per-run limit

## Why

`evals.eval._MAX_SAMPLES` is module-global state. The CLI currently calls `set_max_samples()` only when `args.max_samples` is non-`None`, which means a process that runs Evals programmatically can accidentally carry a previous limit forward:

1. run with `max_samples=1`
2. run again with `max_samples=None`
3. the second run still evaluates only one sample

That is silent evaluation undercounting. An omitted `--max_samples` should mean no cap for the current run, regardless of earlier calls in the interpreter.

## Tests

Added regression coverage that seeds the prior global state and verifies setup before any model work begins:

- an uncapped run clears a previous `_MAX_SAMPLES` value
- a capped run installs its current value before registry lookup

The test intentionally stops at a missing eval after setup so it does not require API calls or evaluation data.

Closes #1727.