### PR TITLE
Preflight known context-window overflows

### DIFF
--- a/evals/completion_fns/openai.py
+++ b/evals/completion_fns/openai.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Optional, Union
 
 import openai
+import tiktoken
 from openai import OpenAI
 
 from evals.api import CompletionFn, CompletionResult
@@ -22,6 +23,59 @@ OPENAI_TIMEOUT_EXCEPTIONS = (
     openai.APITimeoutError,
     openai.InternalServerError,
 )
+
+
+def _encoding_for_model(model: Optional[str]):
+    if model is not None:
+        try:
+            return tiktoken.encoding_for_model(model)
+        except KeyError:
+            pass
+    return tiktoken.get_encoding("cl100k_base")
+
+
+def _estimate_prompt_tokens(prompt: Any, model: Optional[str]) -> Optional[int]:
+    """Estimate input tokens for prompt shapes supported by OpenAI completion functions."""
+    encoding = _encoding_for_model(model)
+
+    if isinstance(prompt, str):
+        return len(encoding.encode(prompt))
+
+    if isinstance(prompt, list):
+        if all(isinstance(token, int) for token in prompt):
+            return len(prompt)
+        if all(isinstance(token, str) for token in prompt):
+            return sum(len(encoding.encode(token)) for token in prompt)
+        if all(isinstance(message, dict) for message in prompt):
+            # OpenAI chat token accounting has varied slightly between model versions.
+            # This follows the standard 3-tokens-per-message approximation and is used
+            # only to reject prompts that already exceed a known context window.
+            tokens = 3  # assistant reply priming
+            for message in prompt:
+                tokens += 3
+                for key, value in message.items():
+                    if not isinstance(value, str):
+                        continue
+                    tokens += len(encoding.encode(value))
+                    if key == "name":
+                        tokens += 1
+            return tokens
+
+    return None
+
+
+def _validate_prompt_context(prompt: Any, model: Optional[str], n_ctx: Optional[int]) -> None:
+    if n_ctx is None:
+        return
+
+    prompt_tokens = _estimate_prompt_tokens(prompt, model)
+    if prompt_tokens is not None and prompt_tokens > n_ctx:
+        model_name = model or "the selected model"
+        raise ValueError(
+            f"Prompt is approximately {prompt_tokens} tokens, exceeding {model_name}'s "
+            f"configured context window of {n_ctx} tokens. Use a model with a larger "
+            "context window or shorten the eval prompt."
+        )
 
 
 def openai_completion_create_retrying(client: OpenAI, *args, **kwargs):
@@ -114,6 +168,7 @@ class OpenAICompletionFn(CompletionFn):
             )
 
         openai_create_prompt: OpenAICreatePrompt = prompt.to_formatted_prompt()
+        _validate_prompt_context(openai_create_prompt, self.model, self.n_ctx)
 
         result = openai_completion_create_retrying(
             OpenAI(api_key=self.api_key, base_url=self.api_base),
@@ -164,6 +219,7 @@ class OpenAIChatCompletionFn(CompletionFnSpec):
             )
 
         openai_create_prompt: OpenAICreateChatPrompt = prompt.to_formatted_prompt()
+        _validate_prompt_context(openai_create_prompt, self.model, self.n_ctx)
 
         result = openai_chat_completion_create_retrying(
             OpenAI(api_key=self.api_key, base_url=self.api_base),

--- a/tests/unit/evals/test_openai_context_window.py
+++ b/tests/unit/evals/test_openai_context_window.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+
+import pytest
+
+from evals.completion_fns.openai import OpenAIChatCompletionFn, OpenAICompletionFn
+
+
+def test_chat_completion_rejects_oversized_prompt_before_api_request() -> None:
+    completion_fn = OpenAIChatCompletionFn(
+        model="gpt-3.5-turbo",
+        api_key="test",
+        n_ctx=5,
+    )
+    prompt = [{"role": "user", "content": "This prompt is definitely longer than five tokens."}]
+
+    with patch(
+        "evals.completion_fns.openai.openai_chat_completion_create_retrying"
+    ) as create_completion:
+        with pytest.raises(ValueError, match="configured context window of 5 tokens"):
+            completion_fn(prompt)
+
+    create_completion.assert_not_called()
+
+
+def test_text_completion_rejects_oversized_prompt_before_api_request() -> None:
+    completion_fn = OpenAICompletionFn(
+        model="text-davinci-003",
+        api_key="test",
+        n_ctx=1,
+    )
+
+    with patch(
+        "evals.completion_fns.openai.openai_completion_create_retrying"
+    ) as create_completion:
+        with pytest.raises(ValueError, match="configured context window of 1 tokens"):
+            completion_fn("two words")
+
+    create_completion.assert_not_called()
+
+
+def test_unknown_context_window_skips_preflight() -> None:
+    completion_fn = OpenAICompletionFn(
+        model="custom-model",
+        api_key="test",
+        n_ctx=None,
+    )
+
+    # The request helper is expected to be reached when no context-window metadata
+    # is available. Raising here avoids needing a real API response in this unit test.
+    with patch(
+        "evals.completion_fns.openai.openai_completion_create_retrying",
+        side_effect=RuntimeError("request reached"),
+    ) as create_completion:
+        with pytest.raises(RuntimeError, match="request reached"):
+            completion_fn("a long prompt that cannot be preflighted")
+
+    create_completion.assert_called_once()


### PR DESCRIPTION
## Summary

Add a local preflight check for OpenAI completion functions when the registry knows the selected model's context-window size.

- estimate input-token usage before sending the API request
- reject prompts that already exceed the configured `n_ctx`
- cover both chat and text completion paths
- use `tiktoken.encoding_for_model()` with a `cl100k_base` fallback
- skip preflight when the model has no known context-window metadata

## Why

Today an eval can build a prompt that is already larger than a model's known context window and only discover that after making the API request. The resulting API error is less actionable and wastes a request that the framework already has enough metadata to avoid.

The check is intentionally conservative: it only rejects when the input prompt itself exceeds a known context window. It does not try to predict whether a valid prompt plus the requested output budget will fit, avoiding false positives from approximate chat token accounting.

For chat prompts the estimate uses the standard per-message token accounting approximation; text and token-list prompts are counted directly.

## Tests

Added regression coverage verifying that:

- oversized chat prompts fail before the request helper is called
- oversized text prompts fail before the request helper is called
- completion functions with unknown context-window metadata continue to the normal request path

Closes #1377.