### PR TITLE
Expose the active eval run ID

### DIFF
--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from .api import CompletionFn as CompletionFn
 from .api import CompletionResult as CompletionResult
 from .api import DummyCompletionFn as DummyCompletionFn
@@ -12,3 +14,11 @@ from .data import get_jsonls as get_jsonls
 from .data import get_lines as get_lines
 from .data import iter_jsonls as iter_jsonls
 from .eval import Eval as Eval
+
+
+def current_run_id() -> Optional[str]:
+    """Return the active eval run ID, or None outside an eval sample context."""
+    from .record import default_recorder
+
+    recorder = default_recorder()
+    return None if recorder is None else recorder.run_spec.run_id

--- a/tests/unit/evals/test_run_context.py
+++ b/tests/unit/evals/test_run_context.py
@@ -1,0 +1,41 @@
+import evals
+from evals.base import RunSpec
+from evals.record import RecorderBase
+
+
+def make_run_spec() -> RunSpec:
+    return RunSpec(
+        completion_fns=["dummy"],
+        eval_name="example.dev.v0",
+        base_eval="example",
+        split="dev",
+        run_config={},
+        created_by="test",
+    )
+
+
+def test_current_run_id_is_none_without_active_recorder() -> None:
+    assert evals.current_run_id() is None
+
+
+def test_current_run_id_exposes_active_recorder_run_id() -> None:
+    run_spec = make_run_spec()
+    recorder = RecorderBase(run_spec)
+
+    with recorder.as_default_recorder("example.dev.0"):
+        assert evals.current_run_id() == run_spec.run_id
+
+    assert evals.current_run_id() is None
+
+
+def test_current_run_id_tracks_nested_recorder_contexts() -> None:
+    outer_spec = make_run_spec()
+    inner_spec = make_run_spec()
+    outer = RecorderBase(outer_spec)
+    inner = RecorderBase(inner_spec)
+
+    with outer.as_default_recorder("example.dev.0"):
+        assert evals.current_run_id() == outer_spec.run_id
+        with inner.as_default_recorder("example.dev.1"):
+            assert evals.current_run_id() == inner_spec.run_id
+        assert evals.current_run_id() == outer_spec.run_id


### PR DESCRIPTION
## Summary

Expose the current eval run ID to custom eval code through a small public helper:

```python
import evals

run_id = evals.current_run_id()
```

- return the active recorder's `run_spec.run_id` while an eval sample is executing
- return `None` when called outside an active eval recorder context
- reuse the existing recorder `ContextVar` rather than adding new global or environment state
- preserve correct behavior across threaded and nested recorder contexts

## Why

Custom evals sometimes create sidecar artifacts such as system logs, traces, screenshots, or external records that need to be correlated with the Evals JSONL output. The framework already assigns a run ID and carries it through the recorder, but custom eval code currently has no direct public way to retrieve it.

The recorder context is already established around every `eval_sample()` invocation, so exposing the run ID through that existing context keeps the API small and thread-safe.

## Tests

Added regression coverage verifying that:

- `current_run_id()` returns `None` when no recorder is active
- it returns the active `RunSpec.run_id` inside an eval recorder context
- nested recorder contexts expose the innermost run ID and restore the outer run ID afterward

Closes #1264.