### PR TITLE
Document the pipx package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ If you don't want to contribute new evals, but simply want to run them locally, 
 pip install evals
 ```
 
+The published package name is `evals` (not `openai-evals`). If you prefer pipx, use the same package name:
+
+```sh
+pipx install evals
+```
+
 You can find the full instructions to run existing evals in [`run-evals.md`](docs/run-evals.md) and our existing eval templates in [`eval-templates.md`](docs/eval-templates.md). For more advanced use cases like prompt chains or tool-using agents, you can use our [Completion Function Protocol](docs/completion-fns.md).
 
 We provide the option for you to log your eval results to a Snowflake database, if you have one or wish to set one up. For this option, you will further have to specify the `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_DATABASE`, `SNOWFLAKE_USERNAME`, and `SNOWFLAKE_PASSWORD` environment variables.


### PR DESCRIPTION
## Summary

Document the correct package name for pipx installations.

- clarify that the published package is `evals`, not `openai-evals`
- add the corresponding `pipx install evals` command next to the existing pip instructions
- leave the package metadata and installation behavior unchanged

## Why

The reported pipx failure is caused by attempting to install `openai-evals`, which is not the package name published for this project. The README currently shows `pip install evals` but does not mention pipx, making it easy to infer the repository/brand name as the package identifier.

Making the package name explicit gives pipx users the same installation path already documented for pip and avoids the `No matching distribution found for openai-evals` error.

## Validation

Documentation-only change. The command matches the package name declared by this repository and the existing pip installation instructions.

Closes #1588.