### PR TITLE
Retry API failures by exception instead of sentinel

### DIFF
--- a/evals/utils/api_utils.py
+++ b/evals/utils/api_utils.py
@@ -7,16 +7,13 @@ EVALS_THREAD_TIMEOUT = float(os.environ.get("EVALS_THREAD_TIMEOUT", "40"))
 logging.getLogger("httpx").setLevel(logging.WARNING)  # suppress "OK" logs from openai API calls
 
 
-@backoff.on_predicate(
-    wait_gen=backoff.expo,
-    max_value=60,
-    factor=1.5,
-)
 def create_retrying(func: callable, retry_exceptions: tuple[Exception], *args, **kwargs):
-    """
-    Retries given function if one of given exceptions is raised
-    """
-    try:
-        return func(*args, **kwargs)
-    except retry_exceptions:
-        return False
+    """Call ``func`` and retry only the configured exceptions."""
+    retrying_func = backoff.on_exception(
+        wait_gen=backoff.expo,
+        exception=retry_exceptions,
+        max_value=60,
+        factor=1.5,
+        max_time=EVALS_THREAD_TIMEOUT,
+    )(func)
+    return retrying_func(*args, **kwargs)

--- a/tests/unit/evals/test_api_utils.py
+++ b/tests/unit/evals/test_api_utils.py
@@ -1,0 +1,44 @@
+import pytest
+
+from evals.utils import api_utils
+
+
+def test_false_result_is_not_retried() -> None:
+    calls = 0
+
+    def return_false() -> bool:
+        nonlocal calls
+        calls += 1
+        return False
+
+    assert api_utils.create_retrying(return_false, (RuntimeError,)) is False
+    assert calls == 1
+
+
+def test_non_retryable_exception_propagates() -> None:
+    def fail() -> None:
+        raise ValueError("invalid request")
+
+    with pytest.raises(ValueError, match="invalid request"):
+        api_utils.create_retrying(fail, (RuntimeError,))
+
+
+def test_retry_configuration_uses_exception_and_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {}
+
+    def fake_on_exception(**config):
+        captured.update(config)
+
+        def decorate(func):
+            return func
+
+        return decorate
+
+    monkeypatch.setattr(api_utils.backoff, "on_exception", fake_on_exception)
+
+    assert api_utils.create_retrying(lambda: "ok", (RuntimeError,)) == "ok"
+    assert captured["wait_gen"] is api_utils.backoff.expo
+    assert captured["exception"] == (RuntimeError,)
+    assert captured["max_value"] == 60
+    assert captured["factor"] == 1.5
+    assert captured["max_time"] == api_utils.EVALS_THREAD_TIMEOUT


### PR DESCRIPTION
## Summary

Replace the `False` sentinel used by `create_retrying()` with exception-based backoff.

- retry only the explicitly configured exception types
- preserve legitimate `False` return values instead of treating them as retry signals
- let exhausted retryable exceptions propagate with their original error details
- bound retries with the existing `EVALS_THREAD_TIMEOUT` setting
- keep the existing exponential backoff parameters

## Why

`create_retrying()` currently catches retryable exceptions and returns `False` under `backoff.on_predicate()`. This loses the original exception from backoff diagnostics, which is why users see messages such as:

```
Backing off create_retrying(...) for 0.8s (False)
```

The sentinel also means a function that legitimately returns `False` is indistinguishable from a failed API request, and the predicate-based decorator has no retry time/attempt limit configured.

`backoff.on_exception()` expresses the intended behavior directly: successful return values pass through unchanged, selected transient exceptions are retried, and the original exception remains available for logging and propagation. Using the existing `EVALS_THREAD_TIMEOUT` value also prevents one request from retrying indefinitely.

## Tests

Added regression coverage verifying that:

- a legitimate `False` result is returned after one call and is not retried
- exceptions outside the retry set propagate immediately
- exception-based backoff receives the expected exception tuple, exponential parameters, and timeout budget

Closes #1571.