### PR TITLE
Add --version to oaieval

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -2,6 +2,7 @@
 This file defines the `oaieval` CLI for running evals.
 """
 import argparse
+import importlib.metadata
 import logging
 import shlex
 import sys
@@ -22,8 +23,16 @@ def _purple(str: str) -> str:
     return f"\033[1;35m{str}\033[0m"
 
 
+def _package_version() -> str:
+    try:
+        return importlib.metadata.version("evals")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run evals through the API")
+    parser.add_argument("--version", action="version", version=_package_version())
     parser.add_argument(
         "completion_fn",
         type=str,

--- a/tests/unit/evals/cli/test_oaieval_version.py
+++ b/tests/unit/evals/cli/test_oaieval_version.py
@@ -1,0 +1,30 @@
+import os
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from evals.cli import oaieval
+
+
+def test_version_flag_prints_package_version(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(oaieval, "_package_version", lambda: "9.8.7")
+
+    with pytest.raises(SystemExit) as exc_info:
+        oaieval.get_parser().parse_args(["--version"])
+
+    assert exc_info.value.code == 0
+    assert capsys.readouterr().out.strip() == "9.8.7"
+
+
+def test_package_version_falls_back_when_distribution_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_distribution(name: str) -> str:
+        raise oaieval.importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(oaieval.importlib.metadata, "version", missing_distribution)
+
+    assert oaieval._package_version() == "unknown"


### PR DESCRIPTION
## Summary

Add a standard `--version` option to the `oaieval` CLI.

- `oaieval --version` prints the installed `evals` package version and exits successfully
- read the version from installed distribution metadata instead of duplicating the value from `pyproject.toml`
- fall back to `unknown` when the distribution metadata is unavailable, such as unusual source-only environments

## Why

There is currently no CLI-level way to identify which Evals package version is being run. This makes bug reports and environment debugging unnecessarily difficult, especially when users may have a PyPI install, editable checkout, or multiple Python environments.

Using `importlib.metadata.version("evals")` keeps the CLI output tied to the package that is actually installed and avoids maintaining another version constant.

## Tests

Added regression coverage verifying that:

- `--version` exits with status 0 and prints the resolved package version
- missing distribution metadata falls back cleanly instead of crashing

Closes #1102.