### PR TITLE
Add strict ExactMatch eval template

### DIFF
--- a/docs/eval-templates.md
+++ b/docs/eval-templates.md
@@ -8,8 +8,11 @@ In cases where the desired model response has very little variation, such as ans
 
 For a model completion `a` and a reference list of correct answers `B`, the following evals implement:
 - [`basic/match.py:Match`](../evals/elsuite/basic/match.py): `any([a.startswith(b) for b in B])`
+- [`basic/exact_match.py:ExactMatch`](../evals/elsuite/basic/exact_match.py): `any([a == b for b in B])`
 - [`basic/includes.py:Includes`](../evals/elsuite/basic/includes.py): `any([(b in a) for b in B])`
 - [`basic/fuzzy_match.py:FuzzyMatch`](../evals/elsuite/basic/fuzzy_match.py): `any([(a in b or b in a) for b in B])`
+
+`ExactMatch` is intentionally strict, including whitespace and capitalization. It is useful for algorithmic or structured-output tasks where extra text should make an answer incorrect rather than being accepted as a valid prefix.
 
 To compare a model completion `a` in *JSON format* to a reference list of correct answers `B` also formatted in JSON, use the following eval:
 - [`basic/json_match.py:JsonMatch`](../evals/elsuite/basic/json_match.py) yields a match if `a` is identical to at least one answer from `B`. Two JSON objects are

--- a/evals/elsuite/basic/exact_match.py
+++ b/evals/elsuite/basic/exact_match.py
@@ -1,6 +1,5 @@
 from typing import Any, Union
 
-import evals
 from evals.prompt.base import is_chat_prompt
 from evals.record import record_match
 

--- a/evals/elsuite/basic/exact_match.py
+++ b/evals/elsuite/basic/exact_match.py
@@ -1,0 +1,56 @@
+from typing import Any, Union
+
+import evals
+from evals.prompt.base import is_chat_prompt
+from evals.record import record_match
+
+from .match import Match
+
+
+def record_and_check_exact_match(
+    sampled: str,
+    expected: Union[str, list[str], tuple[str, ...]],
+):
+    """Record and return the expected option that exactly equals ``sampled``."""
+    if isinstance(expected, tuple):
+        expected = list(expected)
+    elif not isinstance(expected, list):
+        expected = [expected]
+
+    picked = next((option for option in expected if sampled == option), None)
+    record_match(
+        picked is not None,
+        expected=expected,
+        picked=picked,
+        sampled=sampled,
+        options=expected,
+    )
+    return picked
+
+
+class ExactMatch(Match):
+    """Match only when the complete model response equals a reference answer."""
+
+    def eval_sample(self, sample: Any, *_):
+        assert isinstance(sample, dict), "sample must be a dict"
+        assert "input" in sample, "sample must have an 'input' key"
+        assert "ideal" in sample, "sample must have an 'ideal' key"
+        assert isinstance(sample["ideal"], str) or isinstance(
+            sample["ideal"], list
+        ), "sample['ideal'] must be a string or list of strings"
+
+        prompt = sample["input"]
+        if self.num_few_shot > 0:
+            assert is_chat_prompt(sample["input"]), "few shot requires chat prompt"
+            prompt = sample["input"][:-1]
+            for s in self.few_shot[: self.num_few_shot]:
+                prompt += s["sample"]
+            prompt += sample["input"][-1:]
+
+        result = self.completion_fn(
+            prompt=prompt,
+            temperature=0.0,
+        )
+        sampled = result.get_completions()[0]
+
+        return record_and_check_exact_match(sampled=sampled, expected=sample["ideal"])

--- a/tests/unit/evals/elsuite/basic/test_exact_match.py
+++ b/tests/unit/evals/elsuite/basic/test_exact_match.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+
+from evals.elsuite.basic.exact_match import record_and_check_exact_match
+
+
+def test_exact_match_accepts_identical_response() -> None:
+    with patch("evals.elsuite.basic.exact_match.record_match") as record_match:
+        picked = record_and_check_exact_match("42", "42")
+
+    assert picked == "42"
+    record_match.assert_called_once_with(
+        True,
+        expected=["42"],
+        picked="42",
+        sampled="42",
+        options=["42"],
+    )
+
+
+def test_exact_match_rejects_prefix_that_match_accepts() -> None:
+    with patch("evals.elsuite.basic.exact_match.record_match") as record_match:
+        picked = record_and_check_exact_match("42 extra", "42")
+
+    assert picked is None
+    record_match.assert_called_once_with(
+        False,
+        expected=["42"],
+        picked=None,
+        sampled="42 extra",
+        options=["42"],
+    )
+
+
+def test_exact_match_accepts_any_identical_reference() -> None:
+    with patch("evals.elsuite.basic.exact_match.record_match") as record_match:
+        picked = record_and_check_exact_match("four", ["4", "four"])
+
+    assert picked == "four"
+    record_match.assert_called_once_with(
+        True,
+        expected=["4", "four"],
+        picked="four",
+        sampled="four",
+        options=["4", "four"],
+    )
+
+
+def test_exact_match_is_whitespace_sensitive() -> None:
+    with patch("evals.elsuite.basic.exact_match.record_match") as record_match:
+        picked = record_and_check_exact_match(" 42", "42")
+
+    assert picked is None
+    record_match.assert_called_once_with(
+        False,
+        expected=["42"],
+        picked=None,
+        sampled=" 42",
+        options=["42"],
+    )


### PR DESCRIPTION
## Summary

Add a dedicated `ExactMatch` basic eval template for tasks where the complete model response must equal one of the reference answers.

- add `evals.elsuite.basic.exact_match:ExactMatch`
- preserve the existing `Match` prefix semantics unchanged
- support either a single `ideal` string or multiple acceptable reference strings
- record the same `match` event fields used by the existing basic templates
- document when to use strict exact matching
- add focused regression coverage for exact equality, multiple references, prefix rejection, and whitespace sensitivity

## Why

`Match` intentionally uses prefix semantics: an expected answer of `42` also accepts `42 extra`. That is useful for many short-answer evals, but it is a poor fit for arithmetic, code tokens, identifiers, protocol outputs, and other algorithmic tasks where extra output should make the answer incorrect.

Using `Includes` or `FuzzyMatch` weakens the comparison further. A separate exact template makes the intended scoring contract explicit without changing backwards-compatible behavior for existing `Match` users.

## Tests

Added regression coverage verifying that:

- identical output matches
- a response that merely starts with the ideal answer is rejected
- any one of multiple exact references can match
- leading whitespace remains significant under strict matching

Closes #1040.