### PR TITLE
Add explain mode to HumanCliSolver

### DIFF
--- a/evals/solvers/human_cli_solver.py
+++ b/evals/solvers/human_cli_solver.py
@@ -17,14 +17,25 @@ class HumanCliSolver(Solver):
         input_prompt: str = "assistant (you): ",
         postprocessors: list[str] = [],
         registry: Any = None,
+        explain: bool = False,
     ):
         """
         Args:
             input_prompt: Prompt to be printed before the user input.
                 If None, no prompt is printed.
+            explain: Print structured prompt, sampling, and output details for
+                human-baseline debugging and audit workflows.
         """
         super().__init__(postprocessors=postprocessors)
         self.input_prompt = input_prompt
+        self.explain = explain
+
+    def __call__(self, task_state: TaskState, **kwargs) -> SolverResult:
+        result = super().__call__(task_state, **kwargs)
+        if self.explain:
+            print("\n================ FINAL OUTPUT ================")
+            print(result.output)
+        return result
 
     def _solve(self, task_state: TaskState, **kwargs) -> SolverResult:
         msgs = [Message("system", task_state.task_description)]
@@ -33,7 +44,12 @@ class HumanCliSolver(Solver):
         prompt = (
             "\n".join([f"{msg.role}: {msg.content}" for msg in msgs]) + f"\n{self.input_prompt}"
         )
-        answer = input(prompt)
+
+        if self.explain:
+            self._print_prompt_explanation(task_state, prompt)
+            answer = input(self.input_prompt)
+        else:
+            answer = input(prompt)
 
         record_sampling(
             prompt=prompt,
@@ -41,7 +57,29 @@ class HumanCliSolver(Solver):
             model="human",
         )
 
+        if self.explain:
+            print("\n================ SAMPLING RECORD ================")
+            print("model: human")
+            print(f"prompt_chars: {len(prompt)}")
+            print(f"answer_chars: {len(answer)}")
+            print("\n================ RAW OUTPUT ================")
+            print(answer)
+
         return SolverResult(answer)
+
+    @staticmethod
+    def _print_prompt_explanation(task_state: TaskState, prompt: str) -> None:
+        print("================ TASK CONTEXT (system) ================")
+        print(task_state.task_description)
+        print("\n================ MESSAGE HISTORY ================")
+        if task_state.messages:
+            for i, msg in enumerate(task_state.messages):
+                print(f"[{i}] {msg.role}: {msg.content}")
+        else:
+            print("(empty)")
+        print("\n================ FINAL PROMPT STRING (exact) ================")
+        print(prompt)
+        print("\n================ AWAITING HUMAN INPUT ================")
 
     @property
     def name(self) -> str:

--- a/tests/unit/evals/solvers/test_human_cli_solver.py
+++ b/tests/unit/evals/solvers/test_human_cli_solver.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+from evals.solvers.human_cli_solver import HumanCliSolver
+from evals.solvers.solver import SolverResult
+from evals.task_state import Message, TaskState
+
+
+class UppercasePostprocessor:
+    def __call__(self, result: SolverResult) -> SolverResult:
+        return SolverResult(result.output.upper())
+
+
+def _task_state() -> TaskState:
+    return TaskState(
+        task_description="Answer the task.",
+        messages=[Message(role="user", content="What is 2 + 2?")],
+    )
+
+
+def test_default_mode_preserves_existing_single_prompt_input() -> None:
+    solver = HumanCliSolver()
+    expected_prompt = "system: Answer the task.\nuser: What is 2 + 2?\nassistant (you): "
+
+    with (
+        patch("builtins.input", return_value="4") as human_input,
+        patch("evals.solvers.human_cli_solver.record_sampling") as record_sampling,
+    ):
+        result = solver(_task_state())
+
+    assert result.output == "4"
+    human_input.assert_called_once_with(expected_prompt)
+    record_sampling.assert_called_once_with(
+        prompt=expected_prompt,
+        sampled="4",
+        model="human",
+    )
+
+
+def test_explain_mode_shows_prompt_sampling_and_outputs(capsys) -> None:
+    solver = HumanCliSolver(explain=True)
+    solver.postprocessors = [UppercasePostprocessor()]
+    expected_prompt = "system: Answer the task.\nuser: What is 2 + 2?\nassistant (you): "
+
+    with (
+        patch("builtins.input", return_value="four") as human_input,
+        patch("evals.solvers.human_cli_solver.record_sampling") as record_sampling,
+        patch("evals.solvers.solver.record_event"),
+    ):
+        result = solver(_task_state())
+
+    output = capsys.readouterr().out
+    assert result.output == "FOUR"
+    assert "TASK CONTEXT (system)" in output
+    assert "[0] user: What is 2 + 2?" in output
+    assert "FINAL PROMPT STRING (exact)" in output
+    assert expected_prompt in output
+    assert "model: human" in output
+    assert f"prompt_chars: {len(expected_prompt)}" in output
+    assert "answer_chars: 4" in output
+    assert "RAW OUTPUT" in output
+    assert "four" in output
+    assert "FINAL OUTPUT" in output
+    assert "FOUR" in output
+    human_input.assert_called_once_with("assistant (you): ")
+    record_sampling.assert_called_once_with(
+        prompt=expected_prompt,
+        sampled="four",
+        model="human",
+    )


### PR DESCRIPTION
## Summary

Add an opt-in `explain=True` mode to `HumanCliSolver` for human-baseline debugging and audit workflows.

When enabled, the solver shows structured sections for:

- the task/system context
- indexed message history
- the exact flattened prompt recorded by Evals
- sampling metadata (`model`, prompt length, answer length)
- the raw human answer
- the final answer after any configured postprocessors

Default behavior remains unchanged when `explain=False`.

## Why

`HumanCliSolver` is useful as a human baseline and as a sanity check for solver-based evals, but its current CLI collapses task instructions, conversation history, and the input marker into one opaque prompt. That makes it hard to audit exactly what context the human saw or distinguish raw input from postprocessed output.

The new mode exposes those boundaries without changing the recorded sampling payload or evaluation semantics. This is particularly useful when comparing human and model baselines, debugging prompt construction, or reviewing audit-sensitive eval runs.

## Tests

Added regression coverage verifying that:

- default mode preserves the existing single `input(prompt)` behavior and sampling record
- explain mode exposes task context, message history, exact prompt, and sampling metadata
- raw human input and final postprocessed output are shown separately
- the returned solver result still contains the postprocessed output

Closes #1628.