### PR TITLE
Keep failed eval-set commands out of resume checkpoints

### DIFF
--- a/evals/cli/oaievalset.py
+++ b/evals/cli/oaievalset.py
@@ -122,13 +122,28 @@ def run(
         print("  " + command_str)
 
     num_already_completed = num_evals - len(commands)
+    failed_commands: list[Task] = []
     for idx, command in enumerate(commands):
         real_idx = idx + num_already_completed
         print(highlight("Running command: " + " ".join(command) + f" ({real_idx+1}/{num_evals})"))
-        subprocess.run(command, stdout=subprocess.PIPE, check=args.exit_on_error)
-        progress.add(command)
+        result = subprocess.run(command, stdout=subprocess.PIPE, check=args.exit_on_error)
+        if result.returncode == 0:
+            progress.add(command)
+        else:
+            failed_commands.append(command)
+            logger.error(
+                "Command failed with exit code %d and was not checkpointed: %s",
+                result.returncode,
+                " ".join(command),
+            )
 
-    print(highlight("All done!"))
+    if failed_commands:
+        print(
+            f"Finished with {len(failed_commands)} failed eval(s); "
+            "failed commands were not marked complete."
+        )
+    else:
+        print(highlight("All done!"))
 
 
 def main() -> None:

--- a/tests/unit/evals/cli/test_oaievalset.py
+++ b/tests/unit/evals/cli/test_oaievalset.py
@@ -1,0 +1,73 @@
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from evals.cli import oaievalset
+
+
+class FakeRegistry:
+    def get_eval_set(self, name):
+        return SimpleNamespace(evals=["demo.*"])
+
+    def get_evals(self, patterns):
+        return [SimpleNamespace(key="demo.dev")]
+
+
+def make_args(*, exit_on_error: bool):
+    return SimpleNamespace(
+        model="dummy",
+        eval_set="demo-set",
+        registry_path=None,
+        resume=False,
+        exit_on_error=exit_on_error,
+    )
+
+
+def make_progress():
+    progress = Mock()
+    progress.file = Path("/tmp/test.progress.txt")
+    progress.completed = []
+    progress.load.return_value = False
+    return progress
+
+
+def test_failed_command_is_not_checkpointed_when_continuing(capsys) -> None:
+    progress = make_progress()
+    completed_process = subprocess.CompletedProcess(args=[], returncode=1)
+
+    with patch.object(oaievalset, "Progress", return_value=progress), patch.object(
+        oaievalset.subprocess, "run", return_value=completed_process
+    ) as run_mock:
+        oaievalset.run(
+            make_args(exit_on_error=False),
+            [],
+            registry=FakeRegistry(),
+            run_command="oaieval",
+        )
+
+    run_mock.assert_called_once_with(
+        ["oaieval", "dummy", "demo.dev"],
+        stdout=subprocess.PIPE,
+        check=False,
+    )
+    progress.add.assert_not_called()
+    assert "failed commands were not marked complete" in capsys.readouterr().out
+
+
+def test_successful_command_is_checkpointed(capsys) -> None:
+    progress = make_progress()
+    completed_process = subprocess.CompletedProcess(args=[], returncode=0)
+
+    with patch.object(oaievalset, "Progress", return_value=progress), patch.object(
+        oaievalset.subprocess, "run", return_value=completed_process
+    ):
+        oaievalset.run(
+            make_args(exit_on_error=False),
+            [],
+            registry=FakeRegistry(),
+            run_command="oaieval",
+        )
+
+    progress.add.assert_called_once_with(["oaieval", "dummy", "demo.dev"])
+    assert "All done!" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Fix `oaievalset --no-exit-on-error` so failed child evals are not recorded as completed in the resume checkpoint.

- capture the `CompletedProcess` returned by each child `oaieval` invocation
- checkpoint a command only when its return code is zero
- keep failed commands eligible for retry on the next `--resume` run
- report when an eval set finishes with continued failures instead of always printing `All done!`
- preserve the existing fail-fast behavior when `--exit-on-error` is enabled

## Why

`oaievalset` currently calls `progress.add(command)` unconditionally after `subprocess.run()`. With `--no-exit-on-error`, `subprocess.run(..., check=False)` returns normally for nonzero exit codes, so failed evals are written to the same progress file as successful ones.

On the next run, the default resume logic filters those commands out as already completed. That can silently leave an eval set incomplete while preventing the failed evals from being retried.

A resume checkpoint should represent successful work only.

## Tests

Added focused regression coverage verifying that:

- a nonzero child result with `--no-exit-on-error` is not checkpointed
- continued failures are surfaced in the final output
- a successful child result is checkpointed normally
- the child process still receives the expected `check=False` behavior when continuing on errors

Closes #1739.