### PR TITLE
Restore recorder context after exceptions

### DIFF
--- a/evals/record.py
+++ b/evals/record.py
@@ -283,7 +283,7 @@ class DummyRecorder(RecorderBase):
         super().__init__(run_spec)
         self.log = log
 
-    def record_event(self, type, data=None, sample_id=None):
+    def record_event(self, type, data, sample_id=None):
         from evals.registry import registry
 
         if self.run_spec is None:

--- a/evals/record.py
+++ b/evals/record.py
@@ -91,9 +91,11 @@ class RecorderBase:
     def as_default_recorder(self, sample_id: str):
         sample_id_token = self._sample_id.set(sample_id)
         default_recorder_token = _default_recorder.set(self)
-        yield
-        _default_recorder.reset(default_recorder_token)
-        self._sample_id.reset(sample_id_token)
+        try:
+            yield
+        finally:
+            _default_recorder.reset(default_recorder_token)
+            self._sample_id.reset(sample_id_token)
 
     def current_sample_id(self) -> Optional[str]:
         return self._sample_id.get()
@@ -281,7 +283,7 @@ class DummyRecorder(RecorderBase):
         super().__init__(run_spec)
         self.log = log
 
-    def record_event(self, type, data, sample_id=None):
+    def record_event(self, type, data=None, sample_id=None):
         from evals.registry import registry
 
         if self.run_spec is None:
@@ -586,8 +588,11 @@ class Recorder(RecorderBase):
 #########################################################################
 
 
-def current_sample_id() -> str:
-    return default_recorder().current_sample_id
+def current_sample_id() -> Optional[str]:
+    recorder = default_recorder()
+    if recorder is None:
+        return None
+    return recorder.current_sample_id()
 
 
 def record_match(correct: bool, *, expected=None, picked=None, **extra):

--- a/tests/unit/evals/test_record_context.py
+++ b/tests/unit/evals/test_record_context.py
@@ -1,0 +1,69 @@
+from contextvars import Context
+
+from evals.base import RunSpec
+from evals.record import RecorderBase, current_sample_id, default_recorder
+
+
+def make_recorder() -> RecorderBase:
+    return RecorderBase(
+        RunSpec(
+            completion_fns=["dummy"],
+            eval_name="test.dev",
+            base_eval="test",
+            split="dev",
+            run_config={},
+            created_by="test",
+        )
+    )
+
+
+def test_current_sample_id_returns_active_value() -> None:
+    def check() -> None:
+        recorder = make_recorder()
+        with recorder.as_default_recorder("sample-1"):
+            assert current_sample_id() == "sample-1"
+
+    Context().run(check)
+
+
+def test_nested_recorder_context_restores_outer_context() -> None:
+    def check() -> None:
+        outer = make_recorder()
+        inner = make_recorder()
+
+        with outer.as_default_recorder("outer"):
+            assert default_recorder() is outer
+            assert current_sample_id() == "outer"
+
+            with inner.as_default_recorder("inner"):
+                assert default_recorder() is inner
+                assert current_sample_id() == "inner"
+
+            assert default_recorder() is outer
+            assert current_sample_id() == "outer"
+
+        assert default_recorder() is None
+        assert current_sample_id() is None
+
+    Context().run(check)
+
+
+def test_recorder_context_restores_after_exception() -> None:
+    def check() -> None:
+        outer = make_recorder()
+        inner = make_recorder()
+
+        with outer.as_default_recorder("outer"):
+            try:
+                with inner.as_default_recorder("inner"):
+                    raise RuntimeError("boom")
+            except RuntimeError:
+                pass
+
+            assert default_recorder() is outer
+            assert current_sample_id() == "outer"
+
+        assert default_recorder() is None
+        assert current_sample_id() is None
+
+    Context().run(check)


### PR DESCRIPTION
## Summary

Fix recorder context handling so the active recorder and sample ID are correct and always restored.

- make the public `current_sample_id()` helper return the actual active sample ID instead of a bound method
- return `None` cleanly when no recorder context is active
- restore both recorder `ContextVar`s in a `finally` block so exceptions cannot leak context
- preserve nested recorder behavior by resetting the original context tokens
- add regression coverage for active IDs, nested contexts, and exceptional exits

## Why

Two adjacent recorder bugs can corrupt context-sensitive eval code:

1. `evals.record.current_sample_id()` currently returns `default_recorder().current_sample_id` without calling it, so custom eval code receives a method object rather than a sample ID.
2. `RecorderBase.as_default_recorder()` resets its context variables only after a normal `yield`. If the eval body raises and the exception is handled by surrounding code, the inner recorder/sample context remains active instead of restoring the previous context.

The second issue is particularly risky for nested eval helpers and worker threads because later recording calls can be attributed to the wrong sample after a handled failure.

Using `try/finally` is the standard `ContextVar` token pattern and preserves existing behavior on successful exits.

## Tests

Added focused regression coverage verifying that:

- `current_sample_id()` returns the active string value
- nested recorder contexts restore the outer recorder and sample ID
- exceptional exits restore the outer context
- leaving the outermost context restores the no-recorder state

The exceptional-context tests run inside a fresh `contextvars.Context`, so even the pre-fix behavior cannot leak state into other tests.

Closes #1738.