### PR TITLE
Harden routing for modern OpenAI text models

### DIFF
--- a/docs/completion-fns.md
+++ b/docs/completion-fns.md
@@ -13,6 +13,19 @@ We include some example implementations inside `evals/completion_fns`. For examp
 oaieval langchain/llm/flan-t5-xl test-match
 ```
 
+### Using OpenAI model IDs directly
+
+OpenAI text model IDs can also be passed directly to `oaieval`:
+
+```
+oaieval gpt-4o-mini test-match
+oaieval o3-mini test-match
+```
+
+Evals routes model families that are known to support Chat Completions through the chat adapter, while older base/instruct models use the legacy Completions adapter. Fine-tuned model IDs such as `ft:gpt-4o-mini:...` are routed using their base model family.
+
+The OpenAI model list also contains specialised models that do not use either of those text endpoints. Evals does not guess an endpoint for an unrecognised or specialised API model. If a model is available to your account but Evals cannot determine a supported endpoint for it, register an explicit completion function for that model instead. This avoids accidentally sending a modern model to the legacy `/v1/completions` endpoint.
+
 ## Registering Completion Functions
 Once you have written a completion function, we need to make the class visible to the `oaieval` CLI. Similar to how we register our evals, we also register Completion Functions inside `evals/registry/completion_fns` as `yaml` files. Here is the registration for our langchain LLM completion function:
 ```yaml

--- a/evals/registry.py
+++ b/evals/registry.py
@@ -63,20 +63,16 @@ CHAT_MODEL_PREFIXES = (
     "gpt-4o",
     "gpt-4.1",
     "gpt-4.5",
+    "gpt-5",
     "o1",
     "o3",
     "o4",
 )
 CHAT_MODEL_NAMES = {
+    "chat-latest",
     "gpt-4",
     "gpt-4-32k",
-    "gpt-5",
-    "gpt-5.1",
 }
-CHAT_MODEL_DASH_PREFIXES = (
-    "gpt-5-",
-    "gpt-5.1-",
-)
 
 # These model names can share a GPT/o-series prefix but are not plain text
 # Chat Completions models. Returning None makes Registry emit an actionable
@@ -117,11 +113,7 @@ def openai_model_endpoint(model_name: str) -> Optional[str]:
     if any(marker in base_model_name for marker in NON_CHAT_SPECIALISATION_MARKERS):
         return None
 
-    if (
-        base_model_name in CHAT_MODEL_NAMES
-        or base_model_name.startswith(CHAT_MODEL_PREFIXES)
-        or base_model_name.startswith(CHAT_MODEL_DASH_PREFIXES)
-    ):
+    if base_model_name in CHAT_MODEL_NAMES or base_model_name.startswith(CHAT_MODEL_PREFIXES):
         return "chat"
 
     return None

--- a/evals/registry.py
+++ b/evals/registry.py
@@ -33,6 +33,99 @@ DEFAULT_PATHS = [
 ]
 SPEC_RESERVED_KEYWORDS = ["key", "group", "cls"]
 
+# Evals only has adapters for the legacy Completions and Chat Completions
+# endpoints. Keep endpoint selection capability-based instead of treating every
+# model returned by /v1/models as a legacy completion model.
+LEGACY_COMPLETION_MODEL_NAMES = {
+    "ada",
+    "babbage",
+    "babbage-002",
+    "curie",
+    "davinci",
+    "davinci-002",
+    "gpt-4-base",
+}
+LEGACY_COMPLETION_MODEL_PREFIXES = (
+    "text-ada-",
+    "text-babbage-",
+    "text-curie-",
+    "text-davinci-",
+    "code-davinci-",
+    "gpt-3.5-turbo-instruct",
+)
+
+# These families are documented as supporting Chat Completions. The explicit
+# grouping avoids accidentally routing specialised API models (realtime,
+# transcription, Responses-only, etc.) through an incompatible endpoint.
+CHAT_MODEL_PREFIXES = (
+    "gpt-3.5-turbo",
+    "gpt-4-",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.5",
+    "o1",
+    "o3",
+    "o4",
+)
+CHAT_MODEL_NAMES = {
+    "gpt-4",
+    "gpt-4-32k",
+    "gpt-5",
+    "gpt-5.1",
+}
+CHAT_MODEL_DASH_PREFIXES = (
+    "gpt-5-",
+    "gpt-5.1-",
+)
+
+# These model names can share a GPT/o-series prefix but are not plain text
+# Chat Completions models. Returning None makes Registry emit an actionable
+# error instead of silently falling back to /v1/completions.
+NON_CHAT_SPECIALISATION_MARKERS = (
+    "-codex",
+    "-deep-research",
+    "-pro",
+    "-realtime",
+    "-transcribe",
+    "-tts",
+)
+
+
+def _base_model_name(model_name: str) -> str:
+    """Return the base model portion used to route fine-tuned model IDs."""
+    if model_name.startswith("ft:"):
+        parts = model_name.split(":", 2)
+        if len(parts) >= 2 and parts[1]:
+            return parts[1]
+    return model_name
+
+
+def openai_model_endpoint(model_name: str) -> Optional[str]:
+    """Return the Evals endpoint adapter for a known OpenAI text model.
+
+    The return value is ``"chat"`` for Chat Completions models,
+    ``"completions"`` for legacy Completions models, and ``None`` when Evals
+    cannot safely infer a supported endpoint from the model name.
+    """
+    base_model_name = _base_model_name(model_name)
+
+    if base_model_name in LEGACY_COMPLETION_MODEL_NAMES or base_model_name.startswith(
+        LEGACY_COMPLETION_MODEL_PREFIXES
+    ):
+        return "completions"
+
+    if any(marker in base_model_name for marker in NON_CHAT_SPECIALISATION_MARKERS):
+        return None
+
+    if (
+        base_model_name in CHAT_MODEL_NAMES
+        or base_model_name.startswith(CHAT_MODEL_PREFIXES)
+        or base_model_name.startswith(CHAT_MODEL_DASH_PREFIXES)
+    ):
+        return "chat"
+
+    return None
+
 
 def n_ctx_from_model_name(model_name: str) -> Optional[int]:
     """Returns n_ctx for a given API model name. Model list last updated 2023-10-24."""
@@ -81,19 +174,7 @@ def n_ctx_from_model_name(model_name: str) -> Optional[int]:
 
 
 def is_chat_model(model_name: str) -> bool:
-    if model_name in {"gpt-4-base"} or model_name.startswith("gpt-3.5-turbo-instruct"):
-        return False
-
-    CHAT_MODEL_NAMES = {"gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "gpt-4-32k"}
-
-    if model_name in CHAT_MODEL_NAMES:
-        return True
-
-    for model_prefix in {"gpt-3.5-turbo-", "gpt-4-"}:
-        if model_name.startswith(model_prefix):
-            return True
-
-    return False
+    return openai_model_endpoint(model_name) == "chat"
 
 
 T = TypeVar("T")
@@ -131,24 +212,35 @@ class Registry:
             return DummyCompletionFn()
 
         n_ctx = n_ctx_from_model_name(name)
+        endpoint = openai_model_endpoint(name)
 
-        if is_chat_model(name):
+        if endpoint == "chat":
             return OpenAIChatCompletionFn(model=name, n_ctx=n_ctx, **kwargs)
-        elif name in self.api_model_ids:
+        if endpoint == "completions":
             return OpenAICompletionFn(model=name, n_ctx=n_ctx, **kwargs)
 
-        # No match, so try to find a completion-fn-id in the registry
+        # Unknown model names may still be custom completion functions or solvers.
+        # Resolve those before consulting the OpenAI model list so custom registry
+        # entries do not require OpenAI credentials merely to be instantiated.
         spec = self.get_completion_fn(name) or self.get_solver(name)
-        if spec is None:
-            raise ValueError(f"Could not find CompletionFn/Solver in the registry with ID {name}")
-        if spec.args is None:
-            spec.args = {}
-        spec.args.update(kwargs)
+        if spec is not None:
+            if spec.args is None:
+                spec.args = {}
+            spec.args.update(kwargs)
 
-        spec.args["registry"] = self
-        instance = make_object(spec.cls)(**spec.args or {})
-        assert isinstance(instance, CompletionFn), f"{name} must be a CompletionFn"
-        return instance
+            spec.args["registry"] = self
+            instance = make_object(spec.cls)(**spec.args or {})
+            assert isinstance(instance, CompletionFn), f"{name} must be a CompletionFn"
+            return instance
+
+        if name in self.api_model_ids:
+            raise ValueError(
+                f"OpenAI model '{name}' is available, but Evals cannot safely infer a supported "
+                "endpoint for it. Register an explicit completion function for this model instead "
+                "of routing it through the legacy /v1/completions endpoint."
+            )
+
+        raise ValueError(f"Could not find CompletionFn/Solver in the registry with ID {name}")
 
     def get_class(self, spec: EvalSpec) -> Any:
         return make_object(spec.cls, **(spec.args if spec.args else {}))

--- a/evals/registry_test.py
+++ b/evals/registry_test.py
@@ -24,6 +24,7 @@ def test_n_ctx_from_model_name():
 @pytest.mark.parametrize(
     "model_name",
     [
+        "chat-latest",
         "gpt-3.5-turbo",
         "gpt-3.5-turbo-0613",
         "gpt-4",
@@ -41,6 +42,13 @@ def test_n_ctx_from_model_name():
         "gpt-5-2025-08-07",
         "gpt-5.1",
         "gpt-5.1-2025-11-13",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "o1",
         "o1-mini",
         "o1-2024-12-17",
@@ -79,7 +87,10 @@ def test_legacy_models_use_completions(model_name):
         "gpt-4o-realtime-preview",
         "gpt-5-pro",
         "gpt-5.1-codex",
+        "gpt-5.2-codex",
+        "gpt-5.4-pro",
         "o1-pro",
+        "o3-pro",
         "o3-deep-research",
         "o4-mini-deep-research",
     ],
@@ -94,7 +105,9 @@ def test_fine_tuned_model_routes_using_its_base_model():
     assert openai_model_endpoint("ft:davinci-002:acme:eval:abc123") == "completions"
 
 
-@pytest.mark.parametrize("model_name", ["gpt-4o-mini", "o3-mini", "gpt-5-mini"])
+@pytest.mark.parametrize(
+    "model_name", ["gpt-4o-mini", "o3-mini", "gpt-5-mini", "gpt-5.6-terra"]
+)
 def test_registry_routes_modern_models_to_chat_completion_fn(model_name):
     registry = Registry(registry_paths=[])
 
@@ -115,7 +128,7 @@ def test_registry_routes_known_legacy_model_to_completion_fn():
 
 def test_api_listed_unknown_model_is_not_silently_sent_to_legacy_completions():
     registry = Registry(registry_paths=[])
-    registry.__dict__["api_model_ids"] = ["gpt-5-pro"]
+    registry.__dict__["api_model_ids"] = ["gpt-5.4-pro"]
 
     with pytest.raises(ValueError, match="cannot safely infer a supported endpoint"):
-        registry.make_completion_fn("gpt-5-pro")
+        registry.make_completion_fn("gpt-5.4-pro")

--- a/evals/registry_test.py
+++ b/evals/registry_test.py
@@ -1,4 +1,7 @@
-from evals.registry import is_chat_model, n_ctx_from_model_name
+import pytest
+
+from evals import OpenAIChatCompletionFn, OpenAICompletionFn
+from evals.registry import Registry, is_chat_model, n_ctx_from_model_name, openai_model_endpoint
 
 
 def test_n_ctx_from_model_name():
@@ -18,15 +21,101 @@ def test_n_ctx_from_model_name():
     assert n_ctx_from_model_name("gpt-3.5-turbo-16k-0613") == 16384
 
 
-def test_is_chat_model():
-    assert is_chat_model("gpt-3.5-turbo")
-    assert is_chat_model("gpt-3.5-turbo-0613")
-    assert is_chat_model("gpt-3.5-turbo-16k")
-    assert is_chat_model("gpt-3.5-turbo-16k-0613")
-    assert is_chat_model("gpt-4")
-    assert is_chat_model("gpt-4-0613")
-    assert is_chat_model("gpt-4-32k")
-    assert is_chat_model("gpt-4-32k-0613")
-    assert not is_chat_model("text-davinci-003")
-    assert not is_chat_model("gpt4-base")
-    assert not is_chat_model("code-davinci-002")
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-0613",
+        "gpt-4",
+        "gpt-4-0613",
+        "gpt-4-32k",
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4o-2024-11-20",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-2025-04-14",
+        "gpt-4.5-preview",
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-5-2025-08-07",
+        "gpt-5.1",
+        "gpt-5.1-2025-11-13",
+        "o1",
+        "o1-mini",
+        "o1-2024-12-17",
+        "o3",
+        "o3-mini",
+        "o4-mini",
+    ],
+)
+def test_modern_text_models_use_chat_completions(model_name):
+    assert openai_model_endpoint(model_name) == "chat"
+    assert is_chat_model(model_name)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "ada",
+        "babbage-002",
+        "davinci-002",
+        "text-davinci-003",
+        "code-davinci-002",
+        "gpt-3.5-turbo-instruct",
+        "gpt-3.5-turbo-instruct-0914",
+        "gpt-4-base",
+    ],
+)
+def test_legacy_models_use_completions(model_name):
+    assert openai_model_endpoint(model_name) == "completions"
+    assert not is_chat_model(model_name)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "gpt-4o-mini-transcribe",
+        "gpt-4o-realtime-preview",
+        "gpt-5-pro",
+        "gpt-5.1-codex",
+        "o1-pro",
+        "o3-deep-research",
+        "o4-mini-deep-research",
+    ],
+)
+def test_specialised_models_are_not_guessed_as_chat_or_legacy_completions(model_name):
+    assert openai_model_endpoint(model_name) is None
+    assert not is_chat_model(model_name)
+
+
+def test_fine_tuned_model_routes_using_its_base_model():
+    assert openai_model_endpoint("ft:gpt-4o-mini:acme:eval:abc123") == "chat"
+    assert openai_model_endpoint("ft:davinci-002:acme:eval:abc123") == "completions"
+
+
+@pytest.mark.parametrize("model_name", ["gpt-4o-mini", "o3-mini", "gpt-5-mini"])
+def test_registry_routes_modern_models_to_chat_completion_fn(model_name):
+    registry = Registry(registry_paths=[])
+
+    completion_fn = registry.make_completion_fn(model_name)
+
+    assert isinstance(completion_fn, OpenAIChatCompletionFn)
+    assert completion_fn.model == model_name
+
+
+def test_registry_routes_known_legacy_model_to_completion_fn():
+    registry = Registry(registry_paths=[])
+
+    completion_fn = registry.make_completion_fn("davinci-002")
+
+    assert isinstance(completion_fn, OpenAICompletionFn)
+    assert completion_fn.model == "davinci-002"
+
+
+def test_api_listed_unknown_model_is_not_silently_sent_to_legacy_completions():
+    registry = Registry(registry_paths=[])
+    registry.__dict__["api_model_ids"] = ["gpt-5-pro"]
+
+    with pytest.raises(ValueError, match="cannot safely infer a supported endpoint"):
+        registry.make_completion_fn("gpt-5-pro")


### PR DESCRIPTION
## Summary

Fix modern OpenAI model routing by replacing the registry's catch-all legacy-completions fallback with explicit endpoint classification.

This is a broader fix for #1580 than simply adding a few model-name prefixes:

- route modern Chat Completions families including GPT-4o, GPT-4.1, GPT-4.5, the GPT-5 family (including current GPT-5.4/5.6 variants), o1, o3, and o4
- preserve legacy `/v1/completions` routing for base/instruct models such as `davinci-002`, `text-davinci-*`, and `gpt-3.5-turbo-instruct`
- route fine-tuned model IDs according to their base model family
- recognise specialised model IDs that share GPT/o-series prefixes but are not plain Chat Completions models
- stop treating every unrecognised ID returned by `/v1/models` as a legacy completion model
- prefer explicit registry completion functions/solvers for unknown names before consulting the OpenAI model list
- return an actionable error when a model is available but Evals cannot safely infer a supported endpoint
- document the direct-model routing contract

## Why

The current registry has two assumptions that no longer hold:

1. `is_chat_model()` only recognises GPT-3.5 and GPT-4-era chat names.
2. Any other model found in `client.models.list()` is assumed to use the legacy `/v1/completions` endpoint.

That second assumption is the root cause of the issue. Modern reasoning/chat models such as `gpt-4o-mini` or o-series models can be real, available API model IDs while still being sent through the wrong endpoint, producing errors such as:

```
This is a chat model and not supported in the v1/completions endpoint.
```

Merely extending one snapshot list fixes today's examples but leaves the unsafe fallback intact and quickly becomes stale. This PR centralises endpoint classification by model family, while explicitly excluding known specialised variants, so recognised text families are routed intentionally and unknown/specialised models fail clearly instead of being guessed as legacy completions.

## Backwards compatibility

- existing GPT-3.5/GPT-4 Chat Completions routing remains unchanged
- existing legacy completion models continue using `OpenAICompletionFn`
- custom registry completion functions and solvers continue to work and are now resolved before dynamic OpenAI model discovery for unknown names
- no changes to eval scoring, context-window metadata, retry policy, or completion request payloads

## Tests

Expanded `registry_test.py` with a table-driven routing matrix covering:

- GPT-3.5/GPT-4 existing chat models
- GPT-4o, GPT-4.1, GPT-4.5
- GPT-5, GPT-5.1, GPT-5.4, and current GPT-5.6 text families
- `chat-latest`
- o1, o3, and o4 reasoning families
- legacy completion/base/instruct models
- fine-tuned chat and completion model IDs
- specialised IDs such as realtime, transcription, Codex, pro, and deep-research models
- concrete `Registry.make_completion_fn()` routing for modern chat models and legacy completions
- API-listed unknown/specialised models being rejected rather than silently sent to `/v1/completions`

This supersedes the narrow prefix-only approach previously attempted in #1651 while preserving its intended fix and adding safe routing behavior for unknown model IDs.

Closes #1580.