### PR TITLE
Add built-in scoring for precomputed outputs

### DIFF
--- a/docs/completion-fns.md
+++ b/docs/completion-fns.md
@@ -37,6 +37,8 @@ langchain/llm/flan-t5-xl:
   class: evals.completion_fns.langchain_llm:LangChainLLMCompletionFn
   args:
     llm: HuggingFaceHub
+    llm_kwargs:
+      repo_id: google/flan-t5-xl
 ```
 Here is how it breaks down
 `langchain/llm/flan-t5-xl`: This is the top level key that will be used to access this completion function with `oaieval`.

--- a/docs/completion-fns.md
+++ b/docs/completion-fns.md
@@ -13,6 +13,23 @@ We include some example implementations inside `evals/completion_fns`. For examp
 oaieval langchain/llm/flan-t5-xl test-match
 ```
 
+### Scoring already-generated outputs
+
+If your dataset already contains model outputs, use the built-in `precomputed` completion source instead of defining a completion function or making API calls. Store the generated response in an `output` field alongside the normal `input` and `ideal` fields:
+
+```jsonl
+{"input": "what is 2 plus 1?", "output": "3", "ideal": "3"}
+{"input": "what is 2 plus 2?", "output": "3", "ideal": "4"}
+```
+
+Then run the eval normally, replacing the model/completion-function argument with `precomputed`:
+
+```
+oaieval precomputed my-eval
+```
+
+The existing eval template still performs the scoring and records normal sampling/match events, but no model request is made. This works with templates that pass each sample's `input` to their completion function unchanged. If your stored response uses a different field name, specify it with `--completion_args`, for example `--completion_args output_key=prediction`.
+
 ## Registering Completion Functions
 Once you have written a completion function, we need to make the class visible to the `oaieval` CLI. Similar to how we register our evals, we also register Completion Functions inside `evals/registry/completion_fns` as `yaml` files. Here is the registration for our langchain LLM completion function:
 ```yaml
@@ -20,8 +37,6 @@ langchain/llm/flan-t5-xl:
   class: evals.completion_fns.langchain_llm:LangChainLLMCompletionFn
   args:
     llm: HuggingFaceHub
-    llm_kwargs:
-      repo_id: google/flan-t5-xl
 ```
 Here is how it breaks down
 `langchain/llm/flan-t5-xl`: This is the top level key that will be used to access this completion function with `oaieval`.

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -5,12 +5,14 @@ import argparse
 import logging
 import shlex
 import sys
+from pathlib import Path
 from typing import Any, Mapping, Optional, Union, cast
 
 import evals
 import evals.api
 import evals.base
 import evals.record
+from evals.completion_fns.precomputed import PrecomputedCompletionFn
 from evals.eval import Eval
 from evals.record import RecorderBase
 from evals.registry import Registry
@@ -22,12 +24,43 @@ def _purple(str: str) -> str:
     return f"\033[1;35m{str}\033[0m"
 
 
+def _make_completion_fn(
+    name: str,
+    eval_spec: evals.base.EvalSpec,
+    registry: Registry,
+    completion_args: dict[str, str],
+):
+    if name != "precomputed":
+        return registry.make_completion_fn(name, **completion_args)
+
+    unsupported_args = set(completion_args) - {"output_key"}
+    if unsupported_args:
+        raise ValueError(
+            "The precomputed completion source only accepts 'output_key'; got "
+            + ", ".join(sorted(unsupported_args))
+        )
+
+    if eval_spec.args is None or not isinstance(eval_spec.args.get("samples_jsonl"), str):
+        raise ValueError(
+            "The precomputed completion source requires the eval to define a samples_jsonl dataset."
+        )
+
+    samples_jsonl = eval_spec.args["samples_jsonl"]
+    samples_path = Path(samples_jsonl)
+    if not samples_path.is_file():
+        samples_path = eval_spec.registry_path / "data" / samples_jsonl
+
+    samples = evals.get_jsonl(samples_path.as_posix())
+    output_key = completion_args.get("output_key", "output")
+    return PrecomputedCompletionFn(samples=samples, output_key=output_key)
+
+
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run evals through the API")
     parser.add_argument(
         "completion_fn",
         type=str,
-        help="One or more CompletionFn URLs, separated by commas (,). A CompletionFn can either be the name of a model available in the OpenAI API or a key in the registry (see evals/registry/completion_fns).",
+        help="One or more CompletionFn URLs, separated by commas (,). A CompletionFn can either be the name of a model available in the OpenAI API, a key in the registry (see evals/registry/completion_fns), or 'precomputed' to score outputs stored in the eval dataset without making model calls.",
     )
     parser.add_argument("eval", type=str, help="Name of an eval. See registry.")
     parser.add_argument("--extra_eval_params", type=str, default="")
@@ -79,7 +112,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--http-batch-size",
         type=int,
         default=100,
-        help="Number of events to send in each HTTP request when in HTTP mode. Default is 1, i.e., send events individually. Set to a larger number to send events in batches. This option should be used in conjunction with the '--http-run' flag.",
+        help="Number of events to send in each HTTP request when in HTTP mode. Default is 1, i.e. send events individually. Set to a larger number to send events in batches. This option should be used in conjunction with the '--http-run' flag.",
     )
     parser.add_argument(
         "--http-fail-percent-threshold",
@@ -167,7 +200,8 @@ def run(args: OaiEvalArguments, registry: Optional[Registry] = None) -> str:
 
     completion_fns = args.completion_fn.split(",")
     completion_fn_instances = [
-        registry.make_completion_fn(url, **additional_completion_args) for url in completion_fns
+        _make_completion_fn(url, eval_spec, registry, additional_completion_args)
+        for url in completion_fns
     ]
 
     run_config = {

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -112,7 +112,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--http-batch-size",
         type=int,
         default=100,
-        help="Number of events to send in each HTTP request when in HTTP mode. Default is 1, i.e. send events individually. Set to a larger number to send events in batches. This option should be used in conjunction with the '--http-run' flag.",
+        help="Number of events to send in each HTTP request when in HTTP mode. Default is 1, i.e., send events individually. Set to a larger number to send events in batches. This option should be used in conjunction with the '--http-run' flag.",
     )
     parser.add_argument(
         "--http-fail-percent-threshold",

--- a/evals/completion_fns/precomputed.py
+++ b/evals/completion_fns/precomputed.py
@@ -1,0 +1,75 @@
+import json
+from typing import Any, Union
+
+from evals.api import CompletionFn, CompletionResult
+from evals.prompt.base import OpenAICreateChatPrompt
+from evals.record import record_sampling
+
+
+def _prompt_key(prompt: Any) -> str:
+    """Return a stable key for string or structured prompts."""
+    return json.dumps(prompt, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+class PrecomputedCompletionResult(CompletionResult):
+    def __init__(self, completion: str):
+        self.completion = completion
+
+    def get_completions(self) -> list[str]:
+        return [self.completion]
+
+
+class PrecomputedCompletionFn(CompletionFn):
+    """Serve completions already stored alongside eval samples.
+
+    Samples must contain an ``input`` field and a string field named by
+    ``output_key`` (``output`` by default). Inputs are indexed once when the
+    completion function is created, so calls during evaluation perform no
+    network requests.
+    """
+
+    def __init__(self, samples: list[dict[str, Any]], output_key: str = "output"):
+        self.output_key = output_key
+        self._outputs: dict[str, str] = {}
+
+        for index, sample in enumerate(samples):
+            if not isinstance(sample, dict):
+                raise ValueError(f"Precomputed sample #{index} must be a dict")
+            if "input" not in sample:
+                raise ValueError(f"Precomputed sample #{index} is missing 'input'")
+            if output_key not in sample:
+                raise ValueError(
+                    f"Precomputed sample #{index} is missing '{output_key}'. "
+                    f"Add the generated response to that field."
+                )
+
+            output = sample[output_key]
+            if not isinstance(output, str):
+                raise ValueError(
+                    f"Precomputed sample #{index} field '{output_key}' must be a string"
+                )
+
+            key = _prompt_key(sample["input"])
+            if key in self._outputs and self._outputs[key] != output:
+                raise ValueError(
+                    "Precomputed samples contain the same input with different outputs. "
+                    "Inputs must uniquely identify their stored output."
+                )
+            self._outputs[key] = output
+
+    def __call__(
+        self,
+        prompt: Union[str, OpenAICreateChatPrompt],
+        **_kwargs: Any,
+    ) -> PrecomputedCompletionResult:
+        key = _prompt_key(prompt)
+        if key not in self._outputs:
+            raise KeyError(
+                "No precomputed output matches this prompt. The built-in precomputed mode "
+                "expects the eval to pass each sample's 'input' to the completion function unchanged."
+            )
+
+        completion = self._outputs[key]
+        result = PrecomputedCompletionResult(completion)
+        record_sampling(prompt=prompt, sampled=result.get_completions(), model="precomputed")
+        return result

--- a/tests/unit/evals/test_precomputed_completion_fn.py
+++ b/tests/unit/evals/test_precomputed_completion_fn.py
@@ -1,0 +1,77 @@
+import pytest
+
+from evals.base import RunSpec
+from evals.completion_fns.precomputed import PrecomputedCompletionFn
+from evals.record import RecorderBase
+
+
+def make_recorder() -> RecorderBase:
+    return RecorderBase(
+        RunSpec(
+            completion_fns=["precomputed"],
+            eval_name="test.dev",
+            base_eval="test",
+            split="dev",
+            run_config={},
+            created_by="test",
+        )
+    )
+
+
+def test_precomputed_completion_supports_string_and_chat_prompts() -> None:
+    samples = [
+        {"input": "what is 2+1?", "output": "3", "ideal": "3"},
+        {
+            "input": [{"role": "user", "content": "capital of France?"}],
+            "output": "Paris",
+            "ideal": "Paris",
+        },
+    ]
+    completion_fn = PrecomputedCompletionFn(samples)
+    recorder = make_recorder()
+
+    with recorder.as_default_recorder("test.dev.0"):
+        assert completion_fn("what is 2+1?").get_completions() == ["3"]
+
+    with recorder.as_default_recorder("test.dev.1"):
+        assert completion_fn(samples[1]["input"]).get_completions() == ["Paris"]
+
+    sampling_events = recorder.get_events("sampling")
+    assert [event.data["sampled"] for event in sampling_events] == [["3"], ["Paris"]]
+    assert all(event.data["model"] == "precomputed" for event in sampling_events)
+
+
+def test_precomputed_completion_supports_custom_output_key() -> None:
+    completion_fn = PrecomputedCompletionFn(
+        [{"input": "prompt", "prediction": "stored response"}],
+        output_key="prediction",
+    )
+    recorder = make_recorder()
+
+    with recorder.as_default_recorder("test.dev.0"):
+        assert completion_fn("prompt").get_completions() == ["stored response"]
+
+
+def test_precomputed_completion_rejects_missing_output() -> None:
+    with pytest.raises(ValueError, match="missing 'output'"):
+        PrecomputedCompletionFn([{"input": "prompt", "ideal": "answer"}])
+
+
+def test_precomputed_completion_rejects_ambiguous_duplicate_inputs() -> None:
+    with pytest.raises(ValueError, match="same input with different outputs"):
+        PrecomputedCompletionFn(
+            [
+                {"input": "same prompt", "output": "first"},
+                {"input": "same prompt", "output": "second"},
+            ]
+        )
+
+
+def test_precomputed_completion_errors_when_eval_changes_prompt() -> None:
+    completion_fn = PrecomputedCompletionFn([{"input": "original", "output": "answer"}])
+    recorder = make_recorder()
+
+    with recorder.as_default_recorder("test.dev.0"), pytest.raises(
+        KeyError, match="No precomputed output matches this prompt"
+    ):
+        completion_fn("modified prompt")


### PR DESCRIPTION
## Summary

Add a built-in `precomputed` completion source for evaluating model outputs that have already been generated and stored in an eval dataset.

Users can now put `input`, `output`, and `ideal` in the same JSONL file and run the existing eval template without defining a custom completion function or making any model/API calls:

```jsonl
{"input": "what is 2 plus 1?", "output": "3", "ideal": "3"}
{"input": "what is 2 plus 2?", "output": "3", "ideal": "4"}
```

```bash
oaieval precomputed my-eval
```

## What changed

- add `PrecomputedCompletionFn` and `PrecomputedCompletionResult`
- add `precomputed` as a built-in `oaieval` completion source
- load stored outputs from the eval's existing `samples_jsonl`
- support both string and chat-style inputs
- preserve normal `sampling` events so downstream recorder/log tooling still works
- support alternate stored-output field names with `--completion_args output_key=prediction`
- reject missing/non-string outputs with actionable errors
- reject duplicate identical inputs with conflicting outputs rather than choosing one nondeterministically
- clearly fail when an eval transforms the sample prompt before calling the completion function
- document the offline/precomputed workflow

## Why

Evals currently assumes the completion function is responsible for generating every output during the run. That makes it unnecessarily awkward to evaluate outputs produced elsewhere, even though the scoring templates only need a completion string.

A first-class precomputed source keeps the normal Evals execution and recorder path intact while separating generation from evaluation. This is useful for comparing saved model runs, evaluating outputs from external systems, re-scoring historical generations, and running scoring offline.

## Compatibility

The existing model and registry completion-function paths are unchanged. `precomputed` is opt-in and works with eval templates that pass each sample's `input` to the completion function unchanged.

## Tests

Added regression coverage for:

- string and chat prompts
- normal sampling-event recording
- custom output field names
- missing output validation
- ambiguous duplicate-input validation
- clear failure when an eval modifies the prompt

Closes #1342.