### PR TITLE
Add seeded random few-shot selection to Match

### DIFF
--- a/docs/eval-templates.md
+++ b/docs/eval-templates.md
@@ -40,7 +40,7 @@ Refer to the [`classify.py:ModelBasedClassify`](../evals/elsuite/modelgraded/cla
   - `"classify_cot"` (answer then reason) expects that the model response will contain the choice first.
   - `"classify"` expects that the model response will only contain the choice.
 
-  There are two ways to specify `eval_type`. The recommended way is in the `evals/registry/evals` YAML file. If done this way, an instruction will automatically be appended to `prompt` to steer the model towards the expected format (see `ANSWER_PROMPTS` in [the code](../evals/elsuite/modelgraded/classify.py)). Alternatively, you may specify `eval_type` in the `evals/registry/modelgraded` YAML, but you will need to include an appropriate instruction directly in `prompt`.
+  There are two ways to specify `eval_type`. The recommended way is in the `evals/registry/evals` YAML file. If done this way, an instruction will automatically be appended to `prompt` to steer the model towards the expected format (see `ANSWER_PROMPTS` in [the code](../evals/elsuite/modelgraded/classify.py)). Alternatively, you may specify `eval_type` in the `evals/registry/modelgraded` YAML, but you will need to include an appropriate instruction directly in the `prompt`.
 - `output_template` (optional): If specified, determines how the model's output (or outputs, if `n > 1`) will be formatted within the completion.
 
 ### Example model-graded evals

--- a/docs/eval-templates.md
+++ b/docs/eval-templates.md
@@ -40,12 +40,12 @@ Refer to the [`classify.py:ModelBasedClassify`](../evals/elsuite/modelgraded/cla
   - `"classify_cot"` (answer then reason) expects that the model response will contain the choice first.
   - `"classify"` expects that the model response will only contain the choice.
 
-  There are two ways to specify `eval_type`. The recommended way is in the `evals/registry/evals` YAML file. If done this way, an instruction will automatically be appended to `prompt` to steer the model towards the expected format (see `ANSWER_PROMPTS` in [the code](../evals/elsuite/modelgraded/classify.py)). Alternatively, you may specify `eval_type` in the `evals/registry/modelgraded` YAML, but you will need to include an appropriate instruction directly in the `prompt`.
+  There are two ways to specify `eval_type`. The recommended way is in the `evals/registry/evals` YAML file. If done this way, an instruction will automatically be appended to `prompt` to steer the model towards the expected format (see `ANSWER_PROMPTS` in [the code](../evals/elsuite/modelgraded/classify.py)). Alternatively, you may specify `eval_type` in the `evals/registry/modelgraded` YAML, but you will need to include an appropriate instruction directly in `prompt`.
 - `output_template` (optional): If specified, determines how the model's output (or outputs, if `n > 1`) will be formatted within the completion.
 
 ### Example model-graded evals
 
-To instantiate model-graded evals, create a YAML file in `evals/registry/modelgraded` which specifies values for the arguments described above. We have provided a few examples, which illustrate the process for creating model-graded evals, but which we also believe are general enough to be useful out of the box for many evals.
+To instantiate model-graded evals, create a YAML file in `evals/registry/modelgraded` which specifies values for the arguments described above. We have provided a few examples, which illustrate the process for creating a model-graded eval, but which we also believe are general enough to be useful out of the box for many evals.
 
 [`fact.yaml`](../evals/registry/modelgraded/fact.yaml): a factual consistency eval which, given a completion `a` and reference answer `b`, returns:
 - `"A"` if `a` $\subseteq$ `b`, i.e., the submitted answer is a subset of the expert answer and is fully consistent with it.

--- a/docs/eval-templates.md
+++ b/docs/eval-templates.md
@@ -11,6 +11,8 @@ For a model completion `a` and a reference list of correct answers `B`, the foll
 - [`basic/includes.py:Includes`](../evals/elsuite/basic/includes.py): `any([(b in a) for b in B])`
 - [`basic/fuzzy_match.py:FuzzyMatch`](../evals/elsuite/basic/fuzzy_match.py): `any([(a in b or b in a) for b in B])`
 
+`Match` also supports few-shot chat prompts through `num_few_shot` and `few_shot_jsonl`. By default it preserves the historical behavior of taking the first N examples. Set `random_few_shot: true` in the eval arguments to select a seeded random subset for each sample instead; selection is reproducible for the same eval seed and sample ID.
+
 To compare a model completion `a` in *JSON format* to a reference list of correct answers `B` also formatted in JSON, use the following eval:
 - [`basic/json_match.py:JsonMatch`](../evals/elsuite/basic/json_match.py) yields a match if `a` is identical to at least one answer from `B`. Two JSON objects are
 identical if they have the same set of keys and the values for each key are identical. Key order is not significant, and whitespace outside values is ignored. Invalid JSON never matches.
@@ -43,7 +45,7 @@ Refer to the [`classify.py:ModelBasedClassify`](../evals/elsuite/modelgraded/cla
 
 ### Example model-graded evals
 
-To instantiate model-graded evals, create a YAML file in `evals/registry/modelgraded` which specifies values for the arguments described above. We have provided a few examples, which illustrate the process for creating a model-graded eval, but which we also believe are general enough to be useful out of the box for many evals.
+To instantiate model-graded evals, create a YAML file in `evals/registry/modelgraded` which specifies values for the arguments described above. We have provided a few examples, which illustrate the process for creating model-graded evals, but which we also believe are general enough to be useful out of the box for many evals.
 
 [`fact.yaml`](../evals/registry/modelgraded/fact.yaml): a factual consistency eval which, given a completion `a` and reference answer `b`, returns:
 - `"A"` if `a` $\subseteq$ `b`, i.e., the submitted answer is a subset of the expert answer and is fully consistent with it.

--- a/evals/elsuite/basic/match.py
+++ b/evals/elsuite/basic/match.py
@@ -15,6 +15,7 @@ class Match(evals.Eval):
         max_tokens: int = 500,
         num_few_shot: int = 0,
         few_shot_jsonl: str = None,
+        random_few_shot: bool = False,
         **kwargs,
     ):
         super().__init__(completion_fns, *args, **kwargs)
@@ -22,12 +23,30 @@ class Match(evals.Eval):
         self.max_tokens = max_tokens
         self.samples_jsonl = samples_jsonl
         self.num_few_shot = num_few_shot
+        self.random_few_shot = random_few_shot
         if self.num_few_shot > 0:
             assert few_shot_jsonl is not None, "few shot requires few shot sample dataset"
             self.few_shot_jsonl = few_shot_jsonl
             self.few_shot = evals.get_jsonl(self._prefix_registry_path(self.few_shot_jsonl))
 
-    def eval_sample(self, sample: Any, *_):
+    def _select_few_shot(self, rng) -> list[Any]:
+        """Select few-shot examples without changing the source dataset order.
+
+        The historical behavior is preserved by default. When random selection is
+        enabled, the per-sample RNG supplied by Eval is used so the subset remains
+        reproducible for a fixed eval seed and sample ID.
+        """
+        count = min(self.num_few_shot, len(self.few_shot))
+        if not self.random_few_shot or count == len(self.few_shot):
+            return self.few_shot[:count]
+
+        if rng is None:
+            raise ValueError("random_few_shot requires the eval sample RNG")
+
+        selected_indices = sorted(rng.sample(range(len(self.few_shot)), count))
+        return [self.few_shot[index] for index in selected_indices]
+
+    def eval_sample(self, sample: Any, rng):
         assert isinstance(sample, dict), "sample must be a dict"
         assert "input" in sample, "sample must have an 'input' key"
         assert "ideal" in sample, "sample must have an 'ideal' key"
@@ -39,7 +58,7 @@ class Match(evals.Eval):
         if self.num_few_shot > 0:
             assert is_chat_prompt(sample["input"]), "few shot requires chat prompt"
             prompt = sample["input"][:-1]
-            for s in self.few_shot[: self.num_few_shot]:
+            for s in self._select_few_shot(rng):
                 prompt += s["sample"]
             prompt += sample["input"][-1:]
 

--- a/evals/elsuite/basic/match.py
+++ b/evals/elsuite/basic/match.py
@@ -46,7 +46,7 @@ class Match(evals.Eval):
         selected_indices = sorted(rng.sample(range(len(self.few_shot)), count))
         return [self.few_shot[index] for index in selected_indices]
 
-    def eval_sample(self, sample: Any, rng):
+    def eval_sample(self, sample: Any, rng=None):
         assert isinstance(sample, dict), "sample must be a dict"
         assert "input" in sample, "sample must have an 'input' key"
         assert "ideal" in sample, "sample must have an 'ideal' key"

--- a/tests/unit/evals/elsuite/basic/test_match_few_shot.py
+++ b/tests/unit/evals/elsuite/basic/test_match_few_shot.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+
+from evals.elsuite.basic.match import Match
+
+
+class StubRng:
+    def __init__(self, selected_indices):
+        self.selected_indices = selected_indices
+        self.calls = []
+
+    def sample(self, population, count):
+        population = list(population)
+        self.calls.append((population, count))
+        return self.selected_indices
+
+
+class NoSampleRng:
+    def sample(self, *_args, **_kwargs):
+        raise AssertionError("random sampling should not be used")
+
+
+class CaptureResult:
+    def get_completions(self):
+        return ["correct"]
+
+
+class CaptureCompletionFn:
+    def __init__(self):
+        self.prompts = []
+
+    def __call__(self, prompt, **_kwargs):
+        self.prompts.append(prompt)
+        return CaptureResult()
+
+
+def make_match(*, random_few_shot: bool, num_few_shot: int = 2):
+    match = object.__new__(Match)
+    match.num_few_shot = num_few_shot
+    match.random_few_shot = random_few_shot
+    match.few_shot = [
+        {"sample": [{"role": "user", "content": f"few-{index}"}]}
+        for index in range(5)
+    ]
+    return match
+
+
+def test_default_selection_preserves_first_n_behavior():
+    match = make_match(random_few_shot=False)
+
+    selected = match._select_few_shot(NoSampleRng())
+
+    assert selected == match.few_shot[:2]
+
+
+def test_random_selection_uses_rng_and_preserves_dataset_order():
+    match = make_match(random_few_shot=True)
+    rng = StubRng([4, 1])
+
+    selected = match._select_few_shot(rng)
+
+    assert selected == [match.few_shot[1], match.few_shot[4]]
+    assert rng.calls == [(list(range(5)), 2)]
+
+
+def test_random_selection_uses_all_examples_when_requested_count_exceeds_pool():
+    match = make_match(random_few_shot=True, num_few_shot=20)
+
+    selected = match._select_few_shot(NoSampleRng())
+
+    assert selected == match.few_shot
+
+
+def test_eval_sample_inserts_random_subset_before_final_user_message():
+    match = make_match(random_few_shot=True)
+    completion_fn = CaptureCompletionFn()
+    match.completion_fns = [completion_fn]
+    rng = StubRng([3, 0])
+    sample = {
+        "input": [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "question"},
+        ],
+        "ideal": "correct",
+    }
+
+    with patch("evals.record_and_check_match", return_value="correct") as record_match:
+        result = match.eval_sample(sample, rng)
+
+    assert result == "correct"
+    assert completion_fn.prompts == [
+        [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "few-0"},
+            {"role": "user", "content": "few-3"},
+            {"role": "user", "content": "question"},
+        ]
+    ]
+    record_match.assert_called_once()


### PR DESCRIPTION
## Summary

Add opt-in random few-shot selection to the `Match` eval while preserving the existing first-N behavior by default.

- add `random_few_shot: bool = False`
- keep `few_shot[:num_few_shot]` semantics unchanged unless the option is enabled
- use the per-sample RNG already supplied by the Evals framework when random selection is enabled
- preserve source-dataset order after choosing the random subset, so prompt order does not become another source of variation
- preserve the historical behavior when `num_few_shot` exceeds the available pool by using all available examples
- document the option
- add focused regression coverage

## Why

`Match` currently always takes the first `num_few_shot` records from `few_shot_jsonl`. For datasets with a large few-shot pool, such as the 143-example case described in #1382, every evaluated sample is therefore conditioned on the same first few records and the rest of the pool is never used.

The framework already constructs a deterministic per-sample `random.Random` instance from the eval seed and sample ID. Reusing that RNG provides randomised few-shot subsets without sacrificing reproducibility.

## Backwards compatibility

This is opt-in. Existing eval definitions continue using the first N few-shot examples and produce the same prompt construction as before.

When `random_few_shot: true` is configured, each sample draws a seeded subset. The chosen examples are then inserted in their original dataset order.

## Tests

Added regression coverage verifying that:

- default selection still uses the first N examples and does not invoke random sampling
- random selection uses the supplied per-sample RNG
- selected examples are restored to source-dataset order
- requesting more examples than exist uses the complete pool
- `eval_sample` inserts the selected subset before the final user message

Closes #1382.