### PR TITLE
Forward typed completion args to OpenAI requests

### DIFF
--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -41,11 +41,11 @@ def _split_key_value_args(param_str: str) -> list[str]:
                 quote = None
             continue
 
-        if char in {'"', "'"}:
+        if char == '"':
             quote = char
-        elif char in "[{(":
+        elif char in "[{":
             depth += 1
-        elif char in "]})":
+        elif char in "]}":
             depth -= 1
             if depth < 0:
                 raise ValueError("Unbalanced brackets in --completion_args")

--- a/evals/cli/oaieval.py
+++ b/evals/cli/oaieval.py
@@ -2,6 +2,7 @@
 This file defines the `oaieval` CLI for running evals.
 """
 import argparse
+import json
 import logging
 import shlex
 import sys
@@ -22,6 +23,72 @@ def _purple(str: str) -> str:
     return f"\033[1;35m{str}\033[0m"
 
 
+def _split_key_value_args(param_str: str) -> list[str]:
+    """Split comma-separated key/value arguments without splitting JSON containers."""
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: Optional[str] = None
+    escaped = False
+
+    for index, char in enumerate(param_str):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+
+        if char in {'"', "'"}:
+            quote = char
+        elif char in "[{(":
+            depth += 1
+        elif char in "]})":
+            depth -= 1
+            if depth < 0:
+                raise ValueError("Unbalanced brackets in --completion_args")
+        elif char == "," and depth == 0:
+            parts.append(param_str[start:index])
+            start = index + 1
+
+    if quote is not None or depth != 0:
+        raise ValueError("Unbalanced quotes or brackets in --completion_args")
+
+    parts.append(param_str[start:])
+    return parts
+
+
+def parse_completion_args(param_str: str) -> dict[str, Any]:
+    """Parse CLI completion options while preserving JSON-compatible value types."""
+    if not param_str:
+        return {}
+
+    parsed: dict[str, Any] = {}
+    for item in _split_key_value_args(param_str):
+        item = item.strip()
+        if not item:
+            continue
+
+        key, separator, raw_value = item.partition("=")
+        key = key.strip()
+        if not separator or not key:
+            raise ValueError(
+                "Completion arguments must use key=value syntax; "
+                f"could not parse {item!r}"
+            )
+
+        raw_value = raw_value.strip()
+        try:
+            value = json.loads(raw_value)
+        except json.JSONDecodeError:
+            value = raw_value
+        parsed[key] = value
+
+    return parsed
+
+
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run evals through the API")
     parser.add_argument(
@@ -35,7 +102,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--completion_args",
         type=str,
         default="",
-        help="Specify additional parameters to modify the behavior of the completion_fn during its creation. Parameters should be passed as a comma-separated list of key-value pairs (e.g., 'key1=value1,key2=value2'). This option allows for the dynamic modification of completion_fn settings, including the ability to override default arguments where necessary.",
+        help="Specify additional parameters to modify the behavior of the completion_fn during its creation. Parameters should be passed as a comma-separated list of key-value pairs (e.g., 'temperature=0.5,max_tokens=100'). JSON-compatible values such as booleans, lists, and dictionaries retain their types.",
     )
     parser.add_argument("--max_samples", type=int, default=None)
     parser.add_argument("--cache", action=argparse.BooleanOptionalAction, default=True)
@@ -97,6 +164,7 @@ class OaiEvalArguments(argparse.Namespace):
     completion_fn: str
     eval: str
     extra_eval_params: str
+    completion_args: str
     max_samples: Optional[int]
     cache: bool
     visible: Optional[bool]
@@ -161,9 +229,7 @@ def run(args: OaiEvalArguments, registry: Optional[Registry] = None) -> str:
     else:
         eval_spec.args.update(extra_eval_params)
 
-    # If the user provided an argument to --completion_args, parse it into a dict here, to be passed to the completion_fn creation **kwargs
-    completion_args = args.completion_args.split(",")
-    additional_completion_args = {k: v for k, v in (kv.split("=") for kv in completion_args if kv)}
+    additional_completion_args = parse_completion_args(args.completion_args)
 
     completion_fns = args.completion_fn.split(",")
     completion_fn_instances = [

--- a/evals/completion_fns/openai.py
+++ b/evals/completion_fns/openai.py
@@ -52,6 +52,13 @@ def openai_chat_completion_create_retrying(client: OpenAI, *args, **kwargs):
     return result
 
 
+def _request_options(extra_options: Optional[dict], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Build constructor-level API options without mutating caller-owned dictionaries."""
+    options = {key: value for key, value in kwargs.items() if key != "registry"}
+    options.update(extra_options or {})
+    return options
+
+
 class OpenAIBaseCompletionResult(CompletionResult):
     def __init__(self, raw_data: Any, prompt: Any):
         self.raw_data = raw_data
@@ -87,14 +94,14 @@ class OpenAICompletionFn(CompletionFn):
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
         n_ctx: Optional[int] = None,
-        extra_options: Optional[dict] = {},
-        **kwargs,
+        extra_options: Optional[dict] = None,
+        **kwargs: Any,
     ):
         self.model = model
         self.api_base = api_base
         self.api_key = api_key
         self.n_ctx = n_ctx
-        self.extra_options = extra_options
+        self.extra_options = _request_options(extra_options, kwargs)
 
     def __call__(
         self,
@@ -138,13 +145,14 @@ class OpenAIChatCompletionFn(CompletionFnSpec):
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
         n_ctx: Optional[int] = None,
-        extra_options: Optional[dict] = {},
+        extra_options: Optional[dict] = None,
+        **kwargs: Any,
     ):
         self.model = model
         self.api_base = api_base
         self.api_key = api_key
         self.n_ctx = n_ctx
-        self.extra_options = extra_options
+        self.extra_options = _request_options(extra_options, kwargs)
 
     def __call__(
         self,

--- a/tests/unit/evals/test_completion_args.py
+++ b/tests/unit/evals/test_completion_args.py
@@ -24,6 +24,10 @@ def test_parse_completion_args_splits_only_first_equals_sign() -> None:
     }
 
 
+def test_parse_completion_args_preserves_apostrophes_in_literal_strings() -> None:
+    assert parse_completion_args("label=don't-stop") == {"label": "don't-stop"}
+
+
 def test_parse_completion_args_rejects_invalid_syntax() -> None:
     with pytest.raises(ValueError, match="key=value"):
         parse_completion_args("temperature")

--- a/tests/unit/evals/test_completion_args.py
+++ b/tests/unit/evals/test_completion_args.py
@@ -1,0 +1,69 @@
+import pytest
+
+from evals.cli.oaieval import parse_completion_args
+from evals.completion_fns.openai import OpenAIChatCompletionFn, OpenAICompletionFn
+
+
+def test_parse_completion_args_preserves_json_types() -> None:
+    parsed = parse_completion_args(
+        'temperature=0.5,max_tokens=10,stream=false,stop=["END","STOP"],metadata={"a":1,"b":2}'
+    )
+
+    assert parsed == {
+        "temperature": 0.5,
+        "max_tokens": 10,
+        "stream": False,
+        "stop": ["END", "STOP"],
+        "metadata": {"a": 1, "b": 2},
+    }
+
+
+def test_parse_completion_args_splits_only_first_equals_sign() -> None:
+    assert parse_completion_args("base_url=https://example.test?a=b") == {
+        "base_url": "https://example.test?a=b"
+    }
+
+
+def test_parse_completion_args_rejects_invalid_syntax() -> None:
+    with pytest.raises(ValueError, match="key=value"):
+        parse_completion_args("temperature")
+
+
+def test_chat_completion_constructor_forwards_api_options() -> None:
+    completion_fn = OpenAIChatCompletionFn(
+        model="gpt-4",
+        temperature=0.5,
+        max_tokens=64,
+        registry=object(),
+    )
+
+    assert completion_fn.extra_options == {"temperature": 0.5, "max_tokens": 64}
+
+
+def test_legacy_completion_constructor_forwards_api_options() -> None:
+    completion_fn = OpenAICompletionFn(
+        model="text-davinci-003",
+        temperature=0.5,
+        max_tokens=64,
+        registry=object(),
+    )
+
+    assert completion_fn.extra_options == {"temperature": 0.5, "max_tokens": 64}
+
+
+def test_explicit_extra_options_override_convenience_kwargs_without_mutation() -> None:
+    extra_options = {"temperature": 0.2, "stop": ["END"]}
+
+    completion_fn = OpenAIChatCompletionFn(
+        model="gpt-4",
+        extra_options=extra_options,
+        temperature=0.8,
+        max_tokens=32,
+    )
+
+    assert completion_fn.extra_options == {
+        "temperature": 0.2,
+        "stop": ["END"],
+        "max_tokens": 32,
+    }
+    assert extra_options == {"temperature": 0.2, "stop": ["END"]}


### PR DESCRIPTION
## Summary

Fix `--completion_args` so OpenAI chat/completion models can receive API request options from the CLI as intended.

- accept additional constructor options in both `OpenAIChatCompletionFn` and `OpenAICompletionFn`
- forward those options through the existing `extra_options` request path
- stop using mutable dictionary defaults for `extra_options`
- preserve explicit `extra_options` as the highest-precedence constructor setting
- ignore the framework-only `registry` kwarg rather than forwarding it to the OpenAI API
- parse CLI completion arguments into JSON-compatible Python types instead of leaving every value as a string
- support structured list/dict values containing commas
- split `key=value` only on the first equals sign, so URL/query-string values remain intact
- add focused regression coverage

## Why

Issues #1493 and #1504 describe the same broken path from two directions: the CLI exposes `--completion_args`, but `OpenAIChatCompletionFn` rejects arbitrary options and `OpenAICompletionFn` accepts them without storing/forwarding them. In addition, the CLI currently leaves every option as a string, so even options that reach a completion function can have the wrong type.

For example, this should configure the underlying API request rather than raising a constructor error or sending string values:

```bash
oaieval gpt-3.5-turbo test-match --completion_args 'temperature=0.5,max_tokens=100,stream=false'
```

The parser also supports structured JSON-compatible values such as:

```bash
--completion_args 'stop=["END","STOP"],metadata={"source":"eval"}'
```

## Backwards compatibility

- existing `extra_options={...}` usage continues to work
- explicit `extra_options` override same-named convenience kwargs
- ordinary unquoted string values remain strings
- runtime call kwargs are still merged with constructor-level options in the existing order
- no request is made during argument parsing or completion-function construction

## Tests

Added regression tests for:

- numeric, boolean, list, and dict parsing
- values containing additional `=` characters
- invalid CLI syntax
- forwarding constructor options for chat and legacy completion functions
- filtering the framework `registry` argument
- explicit `extra_options` precedence without mutating the caller-owned dictionary

Closes #1493.
Closes #1504.