### PR TITLE
Enforce pre-commit hooks on pull request changes

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -1,0 +1,34 @@
+name: Run pre-commit
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pre_commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
+        with:
+          python-version: 3.9
+
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
+      - name: Run hooks on pull request changes
+        run: >-
+          pre-commit run
+          --from-ref "${{ github.event.pull_request.base.sha }}"
+          --to-ref HEAD
+          --show-diff-on-failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 repository = "https://github.com/openai/evals"
 
 [project.optional-dependencies]
-formatters = ["black", "isort", "autoflake", "ruff"]
+formatters = ["black", "isort", "autoflake", "ruff", "pre-commit"]
 
 torch = ["torch"]
 


### PR DESCRIPTION
## Summary

Finish the pre-commit workflow requested in #384 by enforcing the repository's existing pinned hooks in pull-request CI.

- add a dedicated `Run pre-commit` GitHub Actions workflow for PRs targeting `main`
- run hooks only on files changed by the PR, using the PR base SHA through `HEAD`
- use the repository's existing pinned `.pre-commit-config.yaml` without changing any lint/format rule
- use full git history so `--from-ref` / `--to-ref` works reliably
- add `pre-commit` to the existing `formatters` optional dependency so the documented `pip install -e .[formatters]` followed by `pre-commit install` works as written
- keep workflow permissions read-only

## Why

The repository already documents installing the git hook and already pins Black, isort, mypy, autoflake, and Ruff hook revisions. However, there are two remaining gaps from #384:

1. `pip install -e .[formatters]` installs the individual formatter packages but not the `pre-commit` runner that the next documented command requires.
2. GitHub Actions runs unit/eval tests but does not run the pre-commit configuration, so formatting/lint/type-check regressions can reach review even though contributors are expected to run those checks locally.

Running only against PR changes avoids turning this into a repository-wide cleanup. Existing untouched files do not suddenly become blockers.

## Security / maintenance

The workflow reuses the same immutable `actions/checkout` and `actions/setup-python` commit pins already used by the repository's unit-test workflow. The actual hook revisions remain the immutable commits already pinned in `.pre-commit-config.yaml`.

## Scope

No formatter configuration, lint rule, source code, or test behavior is changed.

Closes #384.