### PR TITLE
Validate Match few-shot rows before evaluation

### DIFF
--- a/evals/elsuite/basic/match.py
+++ b/evals/elsuite/basic/match.py
@@ -26,6 +26,20 @@ class Match(evals.Eval):
             assert few_shot_jsonl is not None, "few shot requires few shot sample dataset"
             self.few_shot_jsonl = few_shot_jsonl
             self.few_shot = evals.get_jsonl(self._prefix_registry_path(self.few_shot_jsonl))
+            self._validate_few_shot_samples()
+
+    def _validate_few_shot_samples(self) -> None:
+        for index, row in enumerate(self.few_shot):
+            if not isinstance(row, dict) or "sample" not in row:
+                raise ValueError(
+                    f"Few-shot row {index} in {self.few_shot_jsonl!r} must be an object "
+                    "with a 'sample' key containing a chat prompt"
+                )
+            if not is_chat_prompt(row["sample"]):
+                raise ValueError(
+                    f"Few-shot row {index} in {self.few_shot_jsonl!r} has an invalid "
+                    "'sample'; expected a list of chat-message objects"
+                )
 
     def eval_sample(self, sample: Any, *_):
         assert isinstance(sample, dict), "sample must be a dict"

--- a/evals/elsuite/basic/match_few_shot_test.py
+++ b/evals/elsuite/basic/match_few_shot_test.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from mock import patch
+from pytest import raises
+
+from evals.api import DummyCompletionFn
+from evals.elsuite.basic.match import Match
+
+
+def _make_match() -> Match:
+    return Match(
+        completion_fns=[DummyCompletionFn()],
+        samples_jsonl="samples.jsonl",
+        num_few_shot=1,
+        few_shot_jsonl="few-shot.jsonl",
+        eval_registry_path=Path("."),
+    )
+
+
+def test_missing_sample_key_reports_dataset_and_row() -> None:
+    rows = [{"input": "example"}]
+    with patch("evals.elsuite.basic.match.evals.get_jsonl", return_value=rows):
+        with raises(ValueError, match=r"Few-shot row 0.*few-shot.jsonl.*sample"):
+            _make_match()
+
+
+def test_non_chat_sample_is_rejected_during_initialization() -> None:
+    rows = [{"sample": "example"}]
+    with patch("evals.elsuite.basic.match.evals.get_jsonl", return_value=rows):
+        with raises(ValueError, match=r"Few-shot row 0.*invalid.*sample"):
+            _make_match()


### PR DESCRIPTION
## Summary

Make `Match` validate few-shot dataset rows as soon as they are loaded instead of failing later inside a worker with an unhelpful `KeyError: 'sample'`.

- require every few-shot row to be an object with a `sample` key
- require `sample` to contain a chat-prompt list
- include the few-shot dataset path and zero-based row index in validation errors
- add focused regression tests for a missing `sample` key and an invalid `sample` shape

## Why

Issue #1012 shows a malformed few-shot dataset surfacing as:

```text
KeyError: 'sample'
```

The exception is raised only after threaded evaluation starts, so it gives contributors no useful indication of which input file or row is malformed. `Match` already requires a specific few-shot row schema, so validating that schema during initialization makes the failure deterministic and actionable.

Example error after this change:

```text
Few-shot row 0 in 'few-shot.jsonl' must be an object with a 'sample' key containing a chat prompt
```

## Compatibility

Valid existing few-shot datasets are unchanged. This only moves validation of already-required structure earlier and replaces an incidental `KeyError`/list-concatenation failure with an explicit `ValueError`.

## Tests

Added coverage for:

- a row missing the `sample` field
- a `sample` value that is not a chat prompt
- dataset path and row number appearing in the error

Closes #1012.