### PR TITLE
Use Ruff instead of the duplicate Autoflake hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,23 +19,9 @@ repos:
       - id: isort
         args: [--line-length=100, --profile=black]
 
-  # this is slightly dangerous because python imports have side effects
-  # and this tool removes unused imports, which may be providing
-  # necessary side effects for the code to run
-  - repo: https://github.com/PyCQA/autoflake
-    rev: b567334b9fc699fc169af0ad1ea0ff0fc017fbeb
-    hooks:
-      - id: autoflake
-        args:
-          - "--in-place"
-          - "--expand-star-imports"
-          - "--remove-duplicate-keys"
-          - "--remove-unused-variables"
-          - "--remove-all-unused-imports"
-        exclude: "evals/__init__.py"
-   
-  # This allows ruff to run and autofix the code
-  # The line length is so high because some of the evals are very long
+  # Ruff covers the Pyflakes fixes previously duplicated by the autoflake hook,
+  # including unused imports/variables and duplicate dictionary keys.
+  # The line length is so high because some of the evals are very long.
   # TODO: fix the evals and then reduce the line length here
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 95f113d6340ab4348ecc5d912cf6e6b3465bfb86


### PR DESCRIPTION
## Summary

Complete the pre-commit cleanup requested in #347 by removing the separate Autoflake hook now that the repository already runs Ruff with autofix enabled.

- remove the standalone Autoflake pre-commit repository/hook
- keep the existing Ruff revision and command-line configuration unchanged
- document that Ruff covers the overlapping Pyflakes cleanup performed here
- leave the `formatters` optional dependency untouched for backwards compatibility with contributors who may invoke `autoflake` directly

## Why

The pre-commit configuration currently runs both Autoflake and Ruff sequentially. Their configured responsibilities substantially overlap: unused imports, unused local variables, and duplicate dictionary keys are Pyflakes-class issues handled by the existing Ruff hook with `--fix`.

That means every pre-commit run creates and executes an additional hook environment for cleanup Ruff already performs. Removing the duplicate hook makes local and CI pre-commit runs simpler and faster while retaining Ruff as the single lint/autofix pass.

The old Autoflake hook also opted into `--expand-star-imports`. This PR does not preserve that source-rewriting behaviour; Ruff can report star-import problems without automatically expanding them, avoiding a transformation the existing config itself describes as potentially unsafe because imports can have side effects.

## Scope

This changes only `.pre-commit-config.yaml`. It does not change Ruff rules, Ruff version, formatting rules, application code, or the public formatter dependency extra.

Closes #347.