### PR TITLE
Parse EVALS_SHOW_EVAL_PROGRESS as a boolean

### DIFF
--- a/evals/eval.py
+++ b/evals/eval.py
@@ -27,6 +27,14 @@ SHUFFLE_SEED = 123
 _MAX_SAMPLES = None
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    """Return a boolean environment flag while preserving the default when unset."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes"}
+
+
 def _index_samples(samples: List[Any]) -> List[Tuple[Any, int]]:
     """Shuffle `samples` and pair each sample with its index."""
     indices = list(range(len(samples)))
@@ -122,7 +130,7 @@ class Eval(abc.ABC):
         """
         work_items = _index_samples(samples)
         threads = int(os.environ.get("EVALS_THREADS", "10"))
-        show_progress = bool(os.environ.get("EVALS_SHOW_EVAL_PROGRESS", show_progress))
+        show_progress = _env_bool("EVALS_SHOW_EVAL_PROGRESS", show_progress)
 
         def eval_sample(args):
             """
@@ -209,7 +217,7 @@ class SolverEval(Eval):
         """
         work_items = _index_samples(samples)
         threads = int(os.environ.get("EVALS_THREADS", "10"))
-        show_progress = bool(os.environ.get("EVALS_SHOW_EVAL_PROGRESS", show_progress))
+        show_progress = _env_bool("EVALS_SHOW_EVAL_PROGRESS", show_progress)
 
         def eval_sample(args):
             """

--- a/tests/unit/evals/test_eval_env.py
+++ b/tests/unit/evals/test_eval_env.py
@@ -1,0 +1,24 @@
+import pytest
+
+from evals.eval import _env_bool
+
+
+def test_env_bool_preserves_default_when_unset(monkeypatch):
+    monkeypatch.delenv("EVALS_SHOW_EVAL_PROGRESS", raising=False)
+
+    assert _env_bool("EVALS_SHOW_EVAL_PROGRESS", True) is True
+    assert _env_bool("EVALS_SHOW_EVAL_PROGRESS", False) is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", " Yes "])
+def test_env_bool_accepts_true_like_values(monkeypatch, value):
+    monkeypatch.setenv("EVALS_SHOW_EVAL_PROGRESS", value)
+
+    assert _env_bool("EVALS_SHOW_EVAL_PROGRESS", False) is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "FALSE", " No ", ""])
+def test_env_bool_accepts_false_like_values(monkeypatch, value):
+    monkeypatch.setenv("EVALS_SHOW_EVAL_PROGRESS", value)
+
+    assert _env_bool("EVALS_SHOW_EVAL_PROGRESS", True) is False


### PR DESCRIPTION
## Summary

Fix `EVALS_SHOW_EVAL_PROGRESS` so false-like environment values actually disable progress bars.

- add a shared `_env_bool()` helper
- preserve the caller/default value when the environment variable is unset
- accept `1`, `true`, and `yes` as enabled values
- treat `0`, `false`, `no`, and empty values as disabled
- make parsing case-insensitive and whitespace-tolerant
- use the same parser in both `Eval` and `SolverEval`
- add focused unit coverage

## Why

Current code does this in both evaluation paths:

```python
show_progress = bool(os.environ.get("EVALS_SHOW_EVAL_PROGRESS", show_progress))
```

Environment variables are strings, so every non-empty value is truthy. That means common commands such as:

```bash
EVALS_SHOW_EVAL_PROGRESS=0 oaieval ...
EVALS_SHOW_EVAL_PROGRESS=false oaieval ...
```

still enable the progress bar.

This is also inconsistent with the surrounding Evals environment flags, which explicitly recognise true-like string values.

## Compatibility

If `EVALS_SHOW_EVAL_PROGRESS` is not set, behavior is unchanged. The change only makes explicit environment overrides behave as booleans rather than Python truthiness of strings.

## Tests

Added regression coverage for:

- unset variable preserving both `True` and `False` defaults
- true-like values
- false-like values
- case-insensitive values
- surrounding whitespace

Closes #1750.