### PR TITLE
Make the MAFAND example Windows-safe and UTF-8 explicit

### DIFF
--- a/examples/lafand-mt.ipynb
+++ b/examples/lafand-mt.ipynb
@@ -99,7 +99,7 @@
     "registry_yaml = {}\n",
     "\n",
     "for input_path in translation_paths:\n",
-    "    langs = input_path.split(\"/\")[-1]\n",
+    "    langs = os.path.basename(os.path.normpath(input_path))\n",
     "    input_lang, output_lang = langs.split('-')\n",
     "    pair_path = os.path.join(output_path, f\"{input_lang}-{output_lang}\")\n",
     "    os.makedirs(pair_path, exist_ok=True)\n",
@@ -133,7 +133,7 @@
     "    }\n",
     "\n",
     "os.makedirs(os.path.join(registry_path, \"evals\"), exist_ok=True)\n",
-    "with open(os.path.join(registry_path, \"evals\", \"mafand.yaml\"), \"w\") as f:\n",
+    "with open(os.path.join(registry_path, \"evals\", \"mafand.yaml\"), \"w\", encoding=\"utf-8\") as f:\n",
     "    yaml.dump(registry_yaml, f)"
    ]
   },
@@ -158,7 +158,7 @@
     "log_name = \"EDIT THIS\"  # copy from above\n",
     "events = f\"/tmp/evallogs/{log_name}\"\n",
     "\n",
-    "with open(events, \"r\") as f:\n",
+    "with open(events, \"r\", encoding=\"utf-8\") as f:\n",
     "    events_df = pd.read_json(f, lines=True)\n",
     "\n",
     "matches_df = events_df[events_df.type == \"match\"].reset_index(drop=True)\n",


### PR DESCRIPTION
## Summary

Fix the cross-platform path and text-encoding problems reported in #379 in the shipped MAFAND/LAFAND example notebook.

- replace manual `input_path.split("/")[-1]` path parsing with `os.path.basename(os.path.normpath(input_path))`
- write the generated `mafand.yaml` registry file explicitly as UTF-8
- read the generated eval log explicitly as UTF-8
- leave notebook outputs and metadata untouched

## Why

The notebook currently assumes `/` is the directory separator when extracting a language pair:

```python
langs = input_path.split("/")[-1]
```

On Windows, paths created by `os.path.join()` use backslashes, so the expression can return a larger path fragment rather than `en-amh`, `fr-wol`, etc. The subsequent `langs.split("-")` can then fail or produce the wrong language identifiers.

The notebook also still relies on the platform default encoding when writing the generated YAML and reading eval logs. On Windows that can be a legacy code page rather than UTF-8, which is the source of the Unicode decode/encode failure described in the issue.

## Scope

This is intentionally a three-line notebook fix. Dataset construction, eval registration, model calls, and scoring are unchanged.

## Validation

The branch is based directly on current upstream `main`. The notebook remains valid JSON and the GitHub diff contains only the three intended source-line replacements.

Closes #379.