### PR TITLE
Use scheduled sample count for async progress

### DIFF
--- a/evals/eval.py
+++ b/evals/eval.py
@@ -105,7 +105,7 @@ class Eval(abc.ABC):
         futures = [asyncio.ensure_future(eval_fn_with_semaphore(args)) for args in work_items]
 
         for future in tqdm(
-            asyncio.as_completed(futures), total=len(samples), disable=not show_progress
+            asyncio.as_completed(futures), total=len(work_items), disable=not show_progress
         ):
             await future
 

--- a/tests/unit/evals/test_async_eval_progress.py
+++ b/tests/unit/evals/test_async_eval_progress.py
@@ -1,0 +1,48 @@
+import asyncio
+from pathlib import Path
+from unittest.mock import Mock
+
+import evals.eval as eval_module
+from evals.api import DummyCompletionFn
+
+
+class _AsyncProgressEval(eval_module.Eval):
+    def eval_sample(self, sample, rng):
+        raise NotImplementedError
+
+    def run(self, recorder):
+        raise NotImplementedError
+
+
+def test_async_progress_total_uses_scheduled_work_count(monkeypatch):
+    monkeypatch.setattr(eval_module, "_MAX_SAMPLES", 2)
+
+    progress_totals = []
+
+    def fake_tqdm(iterable, *, total, disable):
+        progress_totals.append(total)
+        return iterable
+
+    monkeypatch.setattr(eval_module, "tqdm", fake_tqdm)
+
+    evaluator = _AsyncProgressEval(
+        completion_fns=[DummyCompletionFn()],
+        eval_registry_path=Path("."),
+        registry=Mock(),
+    )
+    completed = []
+
+    async def eval_fn(item):
+        completed.append(item)
+        return item[1], None
+
+    asyncio.run(
+        evaluator.async_eval_all_samples(
+            eval_fn,
+            samples=list(range(5)),
+            show_progress=True,
+        )
+    )
+
+    assert len(completed) == 2
+    assert progress_totals == [2]


### PR DESCRIPTION
## Summary

Fix async eval progress reporting when `max_samples` caps the scheduled work.

- use `len(work_items)` rather than the uncapped source dataset size for the async tqdm total
- keep scheduling, concurrency, ordering, and evaluation semantics unchanged
- add a focused regression test that caps five source samples to two scheduled futures and verifies the progress total is two

## Why

`async_eval_all_samples()` already applies `_index_samples(samples)` before creating futures. That means a configured sample cap reduces the actual work correctly. However, tqdm is currently initialized with `total=len(samples)`, so the visual total still reflects the uncapped dataset.

For example, a 100-sample dataset with `max_samples=10` runs ten futures successfully but can finish displaying `10/100`, which looks like an incomplete or interrupted evaluation.

The synchronous path already uses `len(work_items)`, so this also makes the two execution paths consistent.

## Compatibility

Only the progress-bar total changes. The selected samples, futures, concurrency behavior, results, and recorder events are unchanged.

## Tests

Added regression coverage verifying that:

- `max_samples` reduces the scheduled async work
- tqdm receives the scheduled-work count rather than the full source-data count

Closes #1753.