### PR TITLE
Forward runtime kwargs through FewShotSolver

### DIFF
--- a/evals/solvers/nested/fewshot_solver.py
+++ b/evals/solvers/nested/fewshot_solver.py
@@ -78,7 +78,7 @@ class FewShotSolver(NestedSolver):
         **kwargs,
     ) -> SolverResult:
         new_task_state = self._modify_task_state(task_state)
-        return self.base_solver(new_task_state)
+        return self.base_solver(task_state=new_task_state, **kwargs)
 
     def _modify_task_state(self, task_state: TaskState) -> TaskState:
         assert all(

--- a/tests/unit/evals/solvers/test_fewshot_solver.py
+++ b/tests/unit/evals/solvers/test_fewshot_solver.py
@@ -1,0 +1,44 @@
+from evals.solvers.nested.fewshot_solver import FewShotSolver
+from evals.solvers.solver import Solver, SolverResult
+from evals.task_state import TaskState
+
+
+class RecordingSolver(Solver):
+    def __init__(self) -> None:
+        super().__init__()
+        self.kwargs = None
+
+    def _solve(self, task_state: TaskState, **kwargs) -> SolverResult:
+        self.kwargs = kwargs
+        return SolverResult("ok")
+
+
+class PassthroughFewShotSolver(FewShotSolver):
+    def __init__(self, base_solver: Solver) -> None:
+        self._base_solver = base_solver
+
+    @property
+    def base_solver(self) -> Solver:
+        return self._base_solver
+
+    def _modify_task_state(self, task_state: TaskState) -> TaskState:
+        return task_state
+
+
+def test_fewshot_solver_forwards_runtime_kwargs() -> None:
+    base_solver = RecordingSolver()
+    solver = PassthroughFewShotSolver(base_solver)
+
+    result = solver._solve(
+        TaskState(task_description="test"),
+        max_tokens=17,
+        temperature=0.25,
+        custom_option="value",
+    )
+
+    assert result.output == "ok"
+    assert base_solver.kwargs == {
+        "max_tokens": 17,
+        "temperature": 0.25,
+        "custom_option": "value",
+    }


### PR DESCRIPTION
## Summary

Fix `FewShotSolver` so invocation-time options are forwarded to its wrapped base solver.

- pass `**kwargs` through from `FewShotSolver._solve()` to `base_solver`
- preserve the modified few-shot task state unchanged
- add a focused regression test for runtime options such as `max_tokens`, `temperature`, and custom solver kwargs

## Why

`FewShotSolver._solve()` accepts `**kwargs` but currently drops them:

```python
return self.base_solver(new_task_state)
```

That means runtime controls supplied by an eval or another nested solver silently disappear whenever the executor is wrapped in `FewShotSolver`. Other nested solvers such as `CoTSolver` and `HHHSolver` already forward invocation kwargs to their child solvers.

This can change generation behavior without any error, for example when a caller expects a per-call token limit or temperature override to reach the underlying model.

## Compatibility

Existing calls that do not pass runtime kwargs behave identically. The wrapper still changes only the task state; it now preserves the rest of the child-solver call contract as well.

## Tests

Added a recording child solver and verified that all invocation-time kwargs arrive unchanged at the wrapped solver.

Closes #1755.