### PR TITLE
Return no consensus instead of crashing SelfConsistencySolver

### DIFF
--- a/evals/solvers/nested/self_consistency_solver.py
+++ b/evals/solvers/nested/self_consistency_solver.py
@@ -95,6 +95,7 @@ class SelfConsistencySolver(NestedSolver):
                 logger.error(
                     f"Could not detect any answers for mode 'count' among the completions: {reasoning_completions}"
                 )
+                consensus_answer = "[NO CONSENSUS]"
         else:
             if len(task_state.messages) > 0:
                 prompt = task_state.messages[-2].content

--- a/tests/unit/evals/solvers/test_self_consistency_solver.py
+++ b/tests/unit/evals/solvers/test_self_consistency_solver.py
@@ -1,0 +1,53 @@
+from evals.solvers.nested.self_consistency_solver import SelfConsistencySolver
+from evals.solvers.solver import Solver, SolverResult
+from evals.task_state import Message, TaskState
+
+
+class StaticSolver(Solver):
+    def __init__(self, output: str) -> None:
+        super().__init__()
+        self.output = output
+        self.calls = 0
+
+    def _solve(self, task_state: TaskState, **kwargs) -> SolverResult:
+        self.calls += 1
+        return SolverResult(self.output)
+
+
+class TestSelfConsistencySolver(SelfConsistencySolver):
+    def __init__(self, child_solver: Solver) -> None:
+        self._child_solver = child_solver
+        self.num_generations = 3
+        self.answer_prefix = "The answer is"
+        self.cot_template = "Reason, then provide the final answer."
+        self.mode = "count"
+        self.judge_prompt = "unused"
+        self.interaction_cache = None
+
+    @property
+    def solver(self) -> Solver:
+        return self._child_solver
+
+    @property
+    def judge_solver(self) -> Solver:
+        return self._child_solver
+
+
+def test_count_mode_returns_no_consensus_when_no_answer_can_be_extracted() -> None:
+    child_solver = StaticSolver("I could not determine a final answer.")
+    solver = TestSelfConsistencySolver(child_solver)
+
+    result = solver(
+        TaskState(
+            task_description="Answer the question.",
+            messages=[Message(role="user", content="What is the answer?")],
+        )
+    )
+
+    assert result.output == "[NO CONSENSUS]"
+    assert result.metadata["reasoning_completions"] == [
+        "I could not determine a final answer.",
+        "I could not determine a final answer.",
+        "I could not determine a final answer.",
+    ]
+    assert child_solver.calls == 3

--- a/tests/unit/evals/solvers/test_self_consistency_solver.py
+++ b/tests/unit/evals/solvers/test_self_consistency_solver.py
@@ -14,7 +14,7 @@ class StaticSolver(Solver):
         return SolverResult(self.output)
 
 
-class TestSelfConsistencySolver(SelfConsistencySolver):
+class StubSelfConsistencySolver(SelfConsistencySolver):
     def __init__(self, child_solver: Solver) -> None:
         self._child_solver = child_solver
         self.num_generations = 3
@@ -35,7 +35,7 @@ class TestSelfConsistencySolver(SelfConsistencySolver):
 
 def test_count_mode_returns_no_consensus_when_no_answer_can_be_extracted() -> None:
     child_solver = StaticSolver("I could not determine a final answer.")
-    solver = TestSelfConsistencySolver(child_solver)
+    solver = StubSelfConsistencySolver(child_solver)
 
     result = solver(
         TaskState(


### PR DESCRIPTION
## Summary

Make `SelfConsistencySolver` return its existing no-consensus sentinel when count mode cannot extract an answer from any generation.

- set `consensus_answer = "[NO CONSENSUS]"` when the answer counter is empty
- preserve the existing error log with the raw reasoning completions
- keep successful majority-vote behavior unchanged
- add a focused regression test with three generations that all lack the configured answer prefix

## Why

In `mode="count"`, extraction failures are intentionally caught so one malformed generation does not abort the run. However, if every generation fails extraction, the solver logs the condition and then reaches the return statement with `consensus_answer` uninitialised, raising `UnboundLocalError`.

That turns a normal no-consensus outcome into an evaluation crash. The class already uses `[NO CONSENSUS]` when judge-mode extraction fails, and its default judge prompt defines the same sentinel, so using it here makes the two modes consistent.

## Compatibility

Majority-vote results are unchanged whenever at least one answer is extracted. Only the all-invalid path changes, from an exception to an explicit no-consensus result.

## Tests

Added regression coverage verifying that three unparseable generations produce `[NO CONSENSUS]` and preserve the reasoning completions in result metadata.

Closes #1757.