### PR TITLE
Allow valid_answers without extra completion options

### DIFF
--- a/evals/solvers/providers/openai/openai_solver.py
+++ b/evals/solvers/providers/openai/openai_solver.py
@@ -280,9 +280,8 @@ class OpenAISolver(Solver):
         model = self.completion_fn_options["model"]
         # If valid answers were provided, apply logit bias to those tokens
         if self.valid_answers is not None and len(self.valid_answers) > 0:
-            self.completion_fn_options["extra_options"]["logit_bias"] = self._make_logit_bias(
-                self.valid_answers, model
-            )
+            extra_options = self.completion_fn_options.setdefault("extra_options", {})
+            extra_options["logit_bias"] = self._make_logit_bias(self.valid_answers, model)
 
     def _make_logit_bias(self, valid_answers: list[str], model: str) -> dict[int, float]:
         enc = tiktoken.encoding_for_model(model)

--- a/tests/unit/evals/solvers/providers/openai/test_openai_solver.py
+++ b/tests/unit/evals/solvers/providers/openai/test_openai_solver.py
@@ -1,0 +1,40 @@
+from evals.solvers.providers.openai.openai_solver import OpenAISolver
+
+
+class StubOpenAISolver(OpenAISolver):
+    def _make_logit_bias(self, valid_answers: list[str], model: str) -> dict[int, float]:
+        assert valid_answers == ["A", "B"]
+        assert model == "gpt-4"
+        return {101: 100, 202: 100}
+
+
+def _solver_with_options(completion_fn_options: dict) -> StubOpenAISolver:
+    solver = object.__new__(StubOpenAISolver)
+    solver.valid_answers = ["A", "B"]
+    solver.completion_fn_options = completion_fn_options
+    return solver
+
+
+def test_valid_answers_create_missing_extra_options() -> None:
+    solver = _solver_with_options({"model": "gpt-4"})
+
+    solver._preprocess_completion_fn_options()
+
+    assert solver.completion_fn_options == {
+        "model": "gpt-4",
+        "extra_options": {"logit_bias": {101: 100, 202: 100}},
+    }
+
+
+def test_valid_answers_preserve_existing_extra_options() -> None:
+    solver = _solver_with_options(
+        {"model": "gpt-4", "extra_options": {"temperature": 0.0, "max_tokens": 1}}
+    )
+
+    solver._preprocess_completion_fn_options()
+
+    assert solver.completion_fn_options["extra_options"] == {
+        "temperature": 0.0,
+        "max_tokens": 1,
+        "logit_bias": {101: 100, 202: 100},
+    }


### PR DESCRIPTION
## Summary

Fix `OpenAISolver` so `valid_answers` works with a minimal model-only `completion_fn_options` configuration.

- create `extra_options` lazily when valid-answer logit bias is requested
- preserve any existing completion options when adding `logit_bias`
- keep behavior unchanged when `valid_answers` is unset or empty
- add focused regression coverage without making API requests

## Why

`valid_answers` is a separate optional solver argument, but `_preprocess_completion_fn_options()` currently assumes the caller also supplied `completion_fn_options["extra_options"]`.

This valid configuration therefore crashes during solver construction:

```python
OpenAISolver(
    completion_fn_options={"model": "gpt-4"},
    valid_answers=["A", "B"],
)
```

with `KeyError: 'extra_options'`.

The solver only needs that dictionary as a destination for the generated logit bias, so it should create the dictionary when absent rather than requiring unrelated placeholder configuration.

## Compatibility

Existing `extra_options` are preserved and receive the same generated `logit_bias` as before. Configurations without `valid_answers` are unchanged.

## Tests

Added unit coverage verifying that:

- missing `extra_options` is created automatically
- existing `temperature` and `max_tokens` options are preserved when logit bias is added

Closes #1759.