### PR TITLE
Avoid mutating inputs in jsondumps

### DIFF
--- a/evals/data.py
+++ b/evals/data.py
@@ -210,11 +210,11 @@ class EnhancedJSONEncoder(json.JSONEncoder):
 
 def jsondumps(o: Any, ensure_ascii: bool = False, **kwargs: Any) -> str:
     # The JSONEncoder class's .default method is only applied to dictionary values,
-    # not keys. In order to exclude keys from the output of this jsondumps method
-    # we need to exclude them outside the encoder.
+    # not keys. In order to exclude top-level keys, serialize a filtered copy rather
+    # than deleting entries from the caller-owned dictionary.
     if isinstance(o, dict) and "exclude_keys" in kwargs:
-        for key in kwargs["exclude_keys"]:
-            del o[key]
+        exclude_keys = set(kwargs["exclude_keys"])
+        o = {key: value for key, value in o.items() if key not in exclude_keys}
     return json.dumps(o, cls=EnhancedJSONEncoder, ensure_ascii=ensure_ascii, **kwargs)
 
 

--- a/tests/unit/evals/test_data.py
+++ b/tests/unit/evals/test_data.py
@@ -1,0 +1,21 @@
+import json
+
+from evals.data import jsondumps
+
+
+def test_jsondumps_exclude_keys_does_not_mutate_input() -> None:
+    payload = {"keep": 1, "secret": 2}
+
+    encoded = jsondumps(payload, exclude_keys=["secret"])
+
+    assert json.loads(encoded) == {"keep": 1}
+    assert payload == {"keep": 1, "secret": 2}
+
+
+def test_jsondumps_ignores_missing_excluded_keys() -> None:
+    payload = {"keep": 1}
+
+    encoded = jsondumps(payload, exclude_keys=["missing"])
+
+    assert json.loads(encoded) == payload
+    assert payload == {"keep": 1}


### PR DESCRIPTION
## Summary

Make `evals.data.jsondumps()` exclude top-level keys without mutating the caller's dictionary.

- serialize a filtered top-level copy instead of deleting keys in place
- make excluding a missing key harmless rather than raising `KeyError`
- preserve the existing `EnhancedJSONEncoder` and `exclude_keys` API
- add focused regression tests for immutability and missing keys

## Why

`jsondumps()` currently implements `exclude_keys` by calling `del` directly on the input dictionary. A serialization helper therefore changes application state as a side effect:

```python
payload = {"keep": 1, "secret": 2}
jsondumps(payload, exclude_keys=["secret"])
# payload is now {"keep": 1}
```

It also raises `KeyError` when an excluded key is not present. Neither behavior is necessary to produce the requested JSON output.

## Compatibility

The serialized result for existing keys is unchanged. Only side effects are removed: caller-owned dictionaries stay intact, and absent excluded keys are ignored.

## Tests

Added coverage verifying that:

- excluded keys are omitted from the encoded JSON
- the original dictionary remains unchanged
- excluding a missing key succeeds without changing the payload

Closes #1761.