### PR TITLE
Handle JSON null correctly in JsonMatch

### DIFF
--- a/evals/elsuite/basic/json_match.py
+++ b/evals/elsuite/basic/json_match.py
@@ -8,19 +8,25 @@ import evals
 from evals.api import CompletionFn
 from evals.record import RecorderBase
 
+_MISSING = object()
+
 
 def json_match(sampled_json: Any, correct_json: Any) -> bool:
     """Return True if the sampled completion in JSON format
     matches a correct answer, component by component"""
-    if sampled_json is None or correct_json is None:
-        # Missing values are never correct
+    if sampled_json is _MISSING or correct_json is _MISSING:
+        # Missing dictionary keys are never correct. Use a sentinel so a real
+        # JSON null (decoded as None) can still match another JSON null.
         return False
     if isinstance(sampled_json, dict):
         if isinstance(correct_json, dict):
             sample = cast(Mapping[str, Any], sampled_json)
             correct = cast(Mapping[str, Any], correct_json)
             all_keys = set(sample.keys()) | set(correct.keys())
-            return all(json_match(sample.get(key), correct.get(key)) for key in all_keys)
+            return all(
+                json_match(sample.get(key, _MISSING), correct.get(key, _MISSING))
+                for key in all_keys
+            )
         else:
             return False
     elif isinstance(sampled_json, list):
@@ -80,7 +86,7 @@ class JsonMatch(evals.Eval):
             sampled_json = json.loads(sampled)
         except ValueError:
             # If the sampled string is not valid JSON, it will never match
-            sampled_json = None
+            sampled_json = _MISSING
 
         # Allow the following to raise ValueError; the correct answers
         # should always be valid JSON

--- a/tests/unit/evals/test_json_match_null.py
+++ b/tests/unit/evals/test_json_match_null.py
@@ -1,0 +1,17 @@
+from evals.elsuite.basic.json_match import _MISSING, json_match
+
+
+def test_json_null_matches_json_null() -> None:
+    assert json_match(None, None)
+    assert json_match({"value": None}, {"value": None})
+    assert json_match([1, None, 3], [1, None, 3])
+
+
+def test_missing_key_does_not_match_json_null() -> None:
+    assert not json_match({}, {"value": None})
+    assert not json_match({"value": None}, {})
+
+
+def test_missing_sentinel_never_matches_json_null() -> None:
+    assert not json_match(_MISSING, None)
+    assert not json_match(None, _MISSING)


### PR DESCRIPTION
## Summary

Fix `JsonMatch` so legitimate JSON `null` values can match without making missing dictionary keys look equal to `null`.

- introduce a private missing-value sentinel for absent dictionary keys
- allow real `None` values produced by `json.loads("null")` to compare normally
- keep malformed sampled JSON distinct from a real JSON `null`
- add focused regression tests for nulls in objects/lists and missing-key mismatches

## Why

The current helper treats every Python `None` as a missing value:

```python
if sampled_json is None or correct_json is None:
    return False
```

But `json.loads()` uses `None` for valid JSON `null`, while recursive dictionary comparison also uses `.get()` and therefore produces `None` for absent keys. Those two cases need different representations.

Without that distinction, identical JSON such as:

```json
{"value": null}
```

is scored incorrect.

## Compatibility

Existing object/list/scalar exact-match behavior is unchanged. Missing keys remain mismatches. The only newly accepted cases are genuine equal JSON null values.

## Tests

Added coverage for:

- top-level `null == null`
- null values inside objects
- null values inside lists
- missing key vs explicit null remaining incorrect
- the missing sentinel never matching a real null

Closes #1763.