### PR TITLE
Honor every ideal answer in MatchWithSolvers

### DIFF
--- a/evals/elsuite/basic/match_with_solvers.py
+++ b/evals/elsuite/basic/match_with_solvers.py
@@ -57,12 +57,19 @@ class MatchWithSolvers(SolverEval):
         solver_result = solver(task_state)
         output = solver_result._output
 
-        ideal = sample["ideal"] if isinstance(sample["ideal"], str) else sample["ideal"][0]
+        ideals = sample["ideal"] if isinstance(sample["ideal"], list) else [sample["ideal"]]
+        expected = list(
+            dict.fromkeys(
+                candidate
+                for ideal in ideals
+                for candidate in (ideal, ideal.capitalize())
+            )
+        )
 
         return evals.record_and_check_match(
             prompt=sample["input"],
             sampled=output,
-            expected=[ideal, ideal.capitalize()],
+            expected=expected,
         )
 
     def run(self, recorder):

--- a/tests/unit/evals/test_match_with_solvers.py
+++ b/tests/unit/evals/test_match_with_solvers.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from evals.elsuite.basic.match_with_solvers import MatchWithSolvers
+from evals.record import DummyRecorder
+from evals.solvers.solver import DummySolver, Solver, SolverResult
+from evals.task_state import TaskState
+
+
+class StaticSolver(Solver):
+    def __init__(self, output: str) -> None:
+        super().__init__()
+        self.output = output
+
+    def _solve(self, task_state: TaskState, **kwargs) -> SolverResult:
+        return SolverResult(self.output)
+
+
+def _eval() -> MatchWithSolvers:
+    return MatchWithSolvers(
+        completion_fns=[DummySolver()],
+        samples_jsonl="",
+        task_description="Answer the question.",
+        eval_registry_path=Path("."),
+    )
+
+
+def test_match_with_solvers_accepts_non_first_ideal() -> None:
+    evaluator = _eval()
+    recorder = DummyRecorder(None)
+    sample = {
+        "input": [{"role": "user", "content": "Question"}],
+        "ideal": ["first", "second"],
+    }
+
+    with recorder.as_default_recorder("x"):
+        picked = evaluator.eval_sample(StaticSolver("second"), sample, None)
+
+    assert picked == "second"
+
+
+def test_match_with_solvers_capitalizes_every_ideal() -> None:
+    evaluator = _eval()
+    recorder = DummyRecorder(None)
+    sample = {
+        "input": [{"role": "user", "content": "Question"}],
+        "ideal": ["first", "second"],
+    }
+
+    with recorder.as_default_recorder("x"):
+        picked = evaluator.eval_sample(StaticSolver("Second"), sample, None)
+
+    assert picked == "Second"


### PR DESCRIPTION
## Summary

Fix `MatchWithSolvers` so every answer declared in a list-valued `ideal` is accepted.

- normalize a string ideal to a one-element list
- retain all list-valued ideals instead of discarding everything after index 0
- preserve the existing convenience that accepts a capitalized form of each ideal
- deduplicate accepted answers while preserving order
- add focused regression coverage for a non-first ideal and its capitalized form

## Why

`MatchWithSolvers` explicitly allows `sample["ideal"]` to be a string or a list, but the current implementation reduces a list to its first element:

```python
ideal = sample["ideal"] if isinstance(sample["ideal"], str) else sample["ideal"][0]
```

That silently turns valid multi-answer datasets into single-answer datasets. A solver returning the second declared valid answer is therefore scored incorrect.

## Compatibility

String-valued ideals behave exactly as before. For list-valued ideals, the accepted set is expanded to reflect what the dataset already declares as valid. Existing capitalization behavior is preserved for every ideal.

## Tests

Added regression coverage verifying that:

- a solver response matching the second ideal is accepted
- the capitalized form of the second ideal is also accepted

Closes #1765.