### PR TITLE
Score the final valid MMMU answer marker

### DIFF
--- a/evals/elsuite/mmmu/eval.py
+++ b/evals/elsuite/mmmu/eval.py
@@ -1,6 +1,7 @@
 import ast
 import base64
 import logging
+import re
 from io import BytesIO
 from typing import Optional, Union
 from urllib.parse import parse_qs, urlparse
@@ -16,6 +17,13 @@ from evals.formatting import make_abc
 from evals.record import RecorderBase, record_match
 
 logger = logging.getLogger(__name__)
+
+_MULTIPLE_CHOICE_ANSWER_RE = re.compile(r"ANSWER:\s*([A-D])(?![A-Za-z0-9])")
+
+
+def _extract_multiple_choice_answer(text: str) -> Optional[str]:
+    answers = _MULTIPLE_CHOICE_ANSWER_RE.findall(text)
+    return answers[-1] if answers else None
 
 
 class Sample(BaseModel):
@@ -157,7 +165,10 @@ class MMMU(evals.Eval):
             logging.info(f"Error: {str(e)}")
             sampled = "ERROR: " + str(e)
 
-        match = sampled.find(f"ANSWER: {correct_answer}") != -1
+        if sample.question_type == "multiple-choice":
+            match = _extract_multiple_choice_answer(sampled) == correct_answer
+        else:
+            match = sampled.find(f"ANSWER: {correct_answer}") != -1
 
         if not match and sampled.find("ANSWER") == -1 and sample.question_type == "multiple-choice":
             # The model didn't answer anything, so randomly pick an answer

--- a/tests/unit/evals/test_mmmu_answer_parsing.py
+++ b/tests/unit/evals/test_mmmu_answer_parsing.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pytest import mark
 
 from evals.elsuite.mmmu.eval import _extract_multiple_choice_answer
@@ -14,5 +16,7 @@ from evals.elsuite.mmmu.eval import _extract_multiple_choice_answer
         ("No explicit answer", None),
     ],
 )
-def test_extract_multiple_choice_answer_uses_final_valid_marker(text: str, expected: str) -> None:
+def test_extract_multiple_choice_answer_uses_final_valid_marker(
+    text: str, expected: Optional[str]
+) -> None:
     assert _extract_multiple_choice_answer(text) == expected

--- a/tests/unit/evals/test_mmmu_answer_parsing.py
+++ b/tests/unit/evals/test_mmmu_answer_parsing.py
@@ -1,0 +1,18 @@
+from pytest import mark
+
+from evals.elsuite.mmmu.eval import _extract_multiple_choice_answer
+
+
+@mark.parametrize(
+    "text, expected",
+    [
+        ("ANSWER: A", "A"),
+        ("Reasoning first.\nANSWER: B.", "B"),
+        ("ANSWER: AB", None),
+        ("ANSWER: A1", None),
+        ("ANSWER: A\nActually, ANSWER: B", "B"),
+        ("No explicit answer", None),
+    ],
+)
+def test_extract_multiple_choice_answer_uses_final_valid_marker(text: str, expected: str) -> None:
+    assert _extract_multiple_choice_answer(text) == expected


### PR DESCRIPTION
## Summary

Make MMMU multiple-choice scoring use the model's final valid `ANSWER: X` marker instead of a raw substring search.

- extract only `ANSWER:` markers whose value is exactly one of `A`, `B`, `C`, or `D`
- use the last valid marker as the model's final explicit answer
- reject prefix false positives such as `ANSWER: AB` and `ANSWER: A1`
- preserve the existing random-guess fallback when no `ANSWER` marker is emitted
- leave open-ended MMMU scoring unchanged
- add focused parser regression tests

## Why

The current multiple-choice path checks:

```python
sampled.find(f"ANSWER: {correct_answer}") != -1
```

That can award credit to an incorrect response. If the correct option is `A`, `ANSWER: AB` contains the expected substring. It can also award credit for an earlier discarded answer in a response such as:

```text
ANSWER: A
Actually, ANSWER: B
```

The prompt explicitly asks the model for a final `ANSWER: X`, so scoring should identify a valid answer token and use the final one.

## Compatibility

Normal responses such as `ANSWER: A` and `ANSWER: B.` score as before. The random fallback remains unchanged when no `ANSWER` marker is present. Only ambiguous/prefix responses and responses that later revise their answer are scored more precisely.

## Tests

Added regression coverage for:

- exact answer markers
- punctuation after a valid answer
- `ANSWER: AB` and `ANSWER: A1` prefix false positives
- multiple markers using the final valid answer
- responses with no explicit answer

Closes #1767.