### PR TITLE
Accept user-first chat prompts in SolverCompletionFn

### DIFF
--- a/evals/completion_fns/solver_completion_fn.py
+++ b/evals/completion_fns/solver_completion_fn.py
@@ -49,21 +49,30 @@ class SolverCompletionFn(CompletionFn):
 
         if isinstance(prompt, str):
             prompt = [{"role": "system", "content": prompt}]
-        elif isinstance(prompt, list):
-            assert prompt[0]["role"] == "system", "Unexpected prompt role ordering"
-        else:
+        elif not isinstance(prompt, list):
             raise ValueError(
                 f"Unexpected prompt type: "
                 f"string or OpenAICreateChatPrompt expected, got {type(prompt)}"
             )
 
+        if len(prompt) == 0:
+            raise ValueError("Chat prompt must contain at least one message")
+
         assert set(prompt[0].keys()) == {"role", "content",}, (
             "Unexpected keys in prompt: "
             f"expected exactly {{'role', 'content'}}, got {set(prompt[0].keys())}"
         )
+
+        if prompt[0]["role"] == "system":
+            task_description = prompt[0]["content"]
+            messages = prompt[1:]
+        else:
+            task_description = ""
+            messages = prompt
+
         task_state = TaskState(
-            prompt[0]["content"],
-            [Message(msg["role"], msg["content"]) for msg in prompt[1:]],
+            task_description,
+            [Message(msg["role"], msg["content"]) for msg in messages],
         )
 
         # use a copy to avoid task state surviving across samples

--- a/tests/unit/evals/test_solver_completion_fn.py
+++ b/tests/unit/evals/test_solver_completion_fn.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from evals.completion_fns.solver_completion_fn import SolverCompletionFn
 from evals.solvers.solver import Solver, SolverResult
 from evals.task_state import Message, TaskState
@@ -6,13 +8,13 @@ from evals.task_state import Message, TaskState
 class RecordingSolver(Solver):
     def __init__(self) -> None:
         super().__init__()
-        self.task_state = None
+        self.task_state: Optional[TaskState] = None
 
     def _solve(self, task_state: TaskState, **kwargs) -> SolverResult:
         self.task_state = task_state
         return SolverResult("ok")
 
-    def copy(self):
+    def copy(self) -> "RecordingSolver":
         return self
 
 

--- a/tests/unit/evals/test_solver_completion_fn.py
+++ b/tests/unit/evals/test_solver_completion_fn.py
@@ -1,0 +1,54 @@
+from evals.completion_fns.solver_completion_fn import SolverCompletionFn
+from evals.solvers.solver import Solver, SolverResult
+from evals.task_state import Message, TaskState
+
+
+class RecordingSolver(Solver):
+    def __init__(self) -> None:
+        super().__init__()
+        self.task_state = None
+
+    def _solve(self, task_state: TaskState, **kwargs) -> SolverResult:
+        self.task_state = task_state
+        return SolverResult("ok")
+
+    def copy(self):
+        return self
+
+
+def test_solver_completion_fn_accepts_user_first_chat_prompt() -> None:
+    solver = RecordingSolver()
+    completion_fn = SolverCompletionFn(solver)
+
+    result = completion_fn(
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+    )
+
+    assert result.get_completions() == ["ok"]
+    assert solver.task_state == TaskState(
+        task_description="",
+        messages=[
+            Message(role="user", content="Hello"),
+            Message(role="assistant", content="Hi"),
+        ],
+    )
+
+
+def test_solver_completion_fn_preserves_system_first_behavior() -> None:
+    solver = RecordingSolver()
+    completion_fn = SolverCompletionFn(solver)
+
+    completion_fn(
+        [
+            {"role": "system", "content": "Follow the rules"},
+            {"role": "user", "content": "Question"},
+        ]
+    )
+
+    assert solver.task_state == TaskState(
+        task_description="Follow the rules",
+        messages=[Message(role="user", content="Question")],
+    )


### PR DESCRIPTION
## Summary

Allow `SolverCompletionFn` to adapt normal user-first chat prompts into `TaskState` instead of requiring every chat to begin with a system message.

- preserve current system-first behavior by using the first system message as `task_description`
- map user-first prompts to an empty task description while preserving the complete message history
- keep string prompt behavior unchanged
- reject an empty chat prompt with an explicit `ValueError` instead of an index error
- add focused regression tests for user-first and system-first prompts

## Why

`SolverCompletionFn` lets Solver implementations run inside CompletionFn-based eval classes. The adapter currently asserts that every list prompt begins with a system message:

```python
assert prompt[0]["role"] == "system"
```

OpenAI-style chat prompts do not require a system message; a sample containing only user/assistant history is valid. The current assertion therefore prevents otherwise compatible eval datasets from being used with Solver-backed completion functions.

`TaskState` can represent this case directly: use an empty `task_description` and preserve all chat messages in `messages`.

## Compatibility

System-first and string prompts map exactly as before. The only newly accepted input is a non-empty chat prompt whose first message is not `system`. Solver copying and runtime-kwarg forwarding are unchanged.

## Tests

Added regression coverage verifying that:

- user-first history reaches the solver intact with an empty task description
- system-first prompts still peel the first message into `task_description`
- wrapped solver output remains available through the CompletionFn result

Closes #1768.