### PR TITLE
Forward constructor options through RetrievalCompletionFn

### DIFF
--- a/evals/completion_fns/retrieval.py
+++ b/evals/completion_fns/retrieval.py
@@ -64,7 +64,7 @@ class RetrievalCompletionFn(CompletionFn):
         embedding_model: str = "text-embedding-ada-002",
         registry: Optional[Registry] = None,
         registry_path: Optional[str] = None,
-        **_kwargs: Any
+        **kwargs: Any
     ) -> None:
         """
         Args:
@@ -74,7 +74,7 @@ class RetrievalCompletionFn(CompletionFn):
             embeddings_and_text_path: The path to a CSV containing "text" and "embedding" columns.
             registry: Upstream callers may pass in a registry to use.
             registry_path: The path to a registry file to add to default registry.
-            _kwargs: Additional arguments to pass to the completion function instantiation.
+            kwargs: Additional arguments to pass to the completion function instantiation.
         """
         registry = Registry() if not registry else registry
         if registry_path:
@@ -86,7 +86,7 @@ class RetrievalCompletionFn(CompletionFn):
         self.k = k
 
         self.retrieval_template = retrieval_template
-        self.completion_fn_instance = registry.make_completion_fn(completion_fn)
+        self.completion_fn_instance = registry.make_completion_fn(completion_fn, **kwargs)
 
     def __call__(self, prompt: Union[str, list[dict]], **kwargs: Any) -> RetrievalCompletionResult:
         """

--- a/tests/unit/evals/test_retrieval_constructor_kwargs.py
+++ b/tests/unit/evals/test_retrieval_constructor_kwargs.py
@@ -1,0 +1,35 @@
+import os
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from evals.completion_fns.retrieval import RetrievalCompletionFn
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.call = None
+
+    def make_completion_fn(self, completion_fn: str, **kwargs: Any):
+        self.call = (completion_fn, kwargs)
+        return object()
+
+
+def test_retrieval_completion_fn_forwards_constructor_kwargs(tmp_path: Path) -> None:
+    embeddings_path = tmp_path / "embeddings.csv"
+    embeddings_path.write_text('text,embedding\ncontext,"[1.0, 0.0]"\n', encoding="utf-8")
+    registry = RecordingRegistry()
+
+    RetrievalCompletionFn(
+        completion_fn="custom-completion",
+        embeddings_and_text_path=str(embeddings_path),
+        registry=registry,
+        temperature=0.25,
+        custom_option="value",
+    )
+
+    assert registry.call == (
+        "custom-completion",
+        {"temperature": 0.25, "custom_option": "value"},
+    )

--- a/tests/unit/evals/test_retrieval_constructor_kwargs.py
+++ b/tests/unit/evals/test_retrieval_constructor_kwargs.py
@@ -1,10 +1,5 @@
-import os
 from pathlib import Path
-from typing import Any
-
-os.environ.setdefault("OPENAI_API_KEY", "test")
-
-from evals.completion_fns.retrieval import RetrievalCompletionFn
+from typing import Any, cast
 
 
 class RecordingRegistry:
@@ -16,7 +11,12 @@ class RecordingRegistry:
         return object()
 
 
-def test_retrieval_completion_fn_forwards_constructor_kwargs(tmp_path: Path) -> None:
+def test_retrieval_completion_fn_forwards_constructor_kwargs(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.completion_fns.retrieval import RetrievalCompletionFn
+
     embeddings_path = tmp_path / "embeddings.csv"
     embeddings_path.write_text('text,embedding\ncontext,"[1.0, 0.0]"\n', encoding="utf-8")
     registry = RecordingRegistry()
@@ -24,7 +24,7 @@ def test_retrieval_completion_fn_forwards_constructor_kwargs(tmp_path: Path) -> 
     RetrievalCompletionFn(
         completion_fn="custom-completion",
         embeddings_and_text_path=str(embeddings_path),
-        registry=registry,
+        registry=cast(Any, registry),
         temperature=0.25,
         custom_option="value",
     )

--- a/tests/unit/evals/test_retrieval_constructor_kwargs.py
+++ b/tests/unit/evals/test_retrieval_constructor_kwargs.py
@@ -4,9 +4,9 @@ from typing import Any, cast
 
 class RecordingRegistry:
     def __init__(self) -> None:
-        self.call = None
+        self.call: Any = None
 
-    def make_completion_fn(self, completion_fn: str, **kwargs: Any):
+    def make_completion_fn(self, completion_fn: str, **kwargs: Any) -> Any:
         self.call = (completion_fn, kwargs)
         return object()
 


### PR DESCRIPTION
## Summary

Make `RetrievalCompletionFn` pass its documented constructor kwargs to the wrapped completion function when it is instantiated.

- rename the discarded `_kwargs` parameter to `kwargs`
- forward those options to `registry.make_completion_fn()`
- leave retrieval-time call kwargs and embedding behavior unchanged
- add a focused regression test using a recording registry with no API call

## Why

`RetrievalCompletionFn.__init__()` already documents arbitrary keyword arguments as:

> Additional arguments to pass to the completion function instantiation.

However, the implementation currently discards them:

```python
self.completion_fn_instance = registry.make_completion_fn(completion_fn)
```

This silently prevents callers from configuring the wrapped completion function through the retrieval wrapper, even though the public constructor explicitly accepts and documents those options.

## Compatibility

Configurations that do not provide extra constructor kwargs behave identically. Runtime kwargs passed to `RetrievalCompletionFn.__call__()` continue to be forwarded to the wrapped completion call exactly as before.

## Tests

Added regression coverage verifying that multiple constructor options arrive unchanged at `registry.make_completion_fn()` while the embeddings fixture is loaded locally and no API request is made.

Closes #1769.