### PR TITLE
Require word boundaries in LAMBADA scoring

### DIFF
--- a/evals/elsuite/lambada.py
+++ b/evals/elsuite/lambada.py
@@ -6,6 +6,10 @@ from evals.api import CompletionFn
 from evals.record import RecorderBase
 
 
+def _is_word_separator(char: str) -> bool:
+    return not char.isalnum()
+
+
 class Lambada(evals.Eval):
     def __init__(
         self,
@@ -37,6 +41,7 @@ class Lambada(evals.Eval):
             prompt=prompt,
             sampled=sampled,
             expected=a,
+            separator=_is_word_separator,
         )
 
     def run(self, recorder: RecorderBase):

--- a/tests/unit/evals/test_lambada_scoring.py
+++ b/tests/unit/evals/test_lambada_scoring.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from evals.elsuite.lambada import Lambada
+from evals.record import DummyRecorder
+from evals.utils.test import TestCompletionFn
+
+
+def _score(completion: str) -> bool:
+    evaluator = Lambada(
+        completion_fns=[TestCompletionFn(completion)],
+        subset="en",
+        eval_registry_path=Path("."),
+    )
+    recorder = DummyRecorder(None)
+    with recorder.as_default_recorder("sample"):
+        evaluator.eval_sample({"text": "The cat"}, None)
+    return recorder.get_events("match")[0].data["correct"]
+
+
+def test_lambada_accepts_exact_word_and_continuation() -> None:
+    assert _score("cat")
+    assert _score("cat.")
+    assert _score("cat is sleeping")
+
+
+def test_lambada_rejects_longer_words_with_same_prefix() -> None:
+    assert not _score("caterpillar")
+    assert not _score("cat2")


### PR DESCRIPTION
## Summary

Tighten LAMBADA next-word scoring so a correct target must end at a word boundary rather than merely being a prefix of a longer token.

- pass a separator predicate to `record_and_check_match()`
- continue accepting exact answers and valid continuations such as punctuation or another word
- reject longer alphanumeric tokens that only begin with the expected word
- add focused regression coverage

## Why

LAMBADA currently delegates to `record_and_check_match()` without a separator. That helper uses prefix matching, so an expected next word such as `cat` is incorrectly marked correct for `caterpillar`.

The benchmark should allow a model to continue generating after the correct next word, but the first generated word itself must match the target rather than merely share its prefix.

## Compatibility

Normal outputs such as `cat`, `cat.`, and `cat is sleeping` remain accepted. Only completions such as `caterpillar` or `cat2` stop receiving false-positive credit.

## Tests

Added regression coverage verifying:

- exact target words are accepted
- punctuation and following text are accepted after the target
- longer alphanumeric words with the same prefix are rejected

Closes #1773.