### PR TITLE
Remove only one trailing period in postprocessor

### DIFF
--- a/evals/solvers/postprocessors/postprocessors.py
+++ b/evals/solvers/postprocessors/postprocessors.py
@@ -39,5 +39,6 @@ class RemovePeriod(PostProcessor):
     """
 
     def __call__(self, result: SolverResult) -> SolverResult:
-        result._output = result.output.rstrip(".")
+        if result.output.endswith("."):
+            result._output = result.output[:-1]
         return result

--- a/evals/solvers/postprocessors/postprocessors_test.py
+++ b/evals/solvers/postprocessors/postprocessors_test.py
@@ -45,6 +45,8 @@ def test_remove_period():
     assert RemovePeriod()(result).output == ""
     result = SolverResult(".5")
     assert RemovePeriod()(result).output == ".5"
+    result = SolverResult("wait...")
+    assert RemovePeriod()(result).output == "wait.."
 
 
 def test_combination():


### PR DESCRIPTION
## Summary

Make `RemovePeriod` perform the one-character normalization described by its API instead of stripping every trailing period.

- remove exactly one final `.` when present
- leave outputs without a final period unchanged
- preserve ellipses except for the single period intentionally removed
- extend the existing postprocessor regression tests

## Why

The current implementation uses:

```python
result._output = result.output.rstrip(".")
```

`rstrip(".")` removes an entire run of trailing periods. A response such as `wait...` therefore becomes `wait`, which is substantially more normalization than the class documentation promises and can alter downstream exact-match behavior.

## Compatibility

Existing single-period behavior is unchanged: `answer.` still becomes `answer`, and `answer` remains `answer`. The change only prevents multiple trailing periods from all being removed at once.

## Tests

Extended the existing `RemovePeriod` tests with an ellipsis case verifying that `wait...` becomes `wait..`.

Closes #1774.