### PR TITLE
Accept None for optional MultipleChoice instructions

### DIFF
--- a/evals/elsuite/multiple_choice.py
+++ b/evals/elsuite/multiple_choice.py
@@ -60,7 +60,7 @@ class MultipleChoice(evals.Eval):
         super().__init__(completion_fns, *args, **kwargs)
         assert len(completion_fns) == 1, "MultipleChoice only supports one completion fn"
         self.dataset = dataset
-        self.instructions = instructions
+        self.instructions = instructions or ""
 
     def eval_sample(self, sample, rng):
         assert isinstance(sample, Sample)

--- a/evals/elsuite/multiple_choice.py
+++ b/evals/elsuite/multiple_choice.py
@@ -60,7 +60,7 @@ class MultipleChoice(evals.Eval):
         super().__init__(completion_fns, *args, **kwargs)
         assert len(completion_fns) == 1, "MultipleChoice only supports one completion fn"
         self.dataset = dataset
-        self.instructions = instructions or ""
+        self.instructions = "" if instructions is None else instructions
 
     def eval_sample(self, sample, rng):
         assert isinstance(sample, Sample)

--- a/tests/unit/evals/test_multiple_choice_instructions.py
+++ b/tests/unit/evals/test_multiple_choice_instructions.py
@@ -1,0 +1,25 @@
+import random
+from pathlib import Path
+
+from evals.elsuite.multiple_choice import MultipleChoice, Sample
+from evals.record import DummyRecorder
+from evals.utils.test import TestCompletionFn
+
+
+def test_multiple_choice_accepts_none_instructions() -> None:
+    evaluator = MultipleChoice(
+        completion_fns=[TestCompletionFn("A")],
+        dataset="unused",
+        instructions=None,
+        eval_registry_path=Path("."),
+    )
+    recorder = DummyRecorder(None)
+
+    with recorder.as_default_recorder("sample"):
+        evaluator.eval_sample(
+            Sample(question="Question?", answers=["correct", "wrong"], label=0),
+            random.Random(0),
+        )
+
+    assert evaluator.instructions == ""
+    assert len(recorder.get_events("match")) == 1


### PR DESCRIPTION
## Summary

Make `MultipleChoice` treat `instructions=None` the same way as its existing empty-string default.

- normalize `None` to `""` in the constructor
- preserve explicit instruction text unchanged
- keep prompt construction and scoring behavior otherwise identical
- add a focused regression test that evaluates a sample with `instructions=None`

## Why

The public constructor annotates `instructions` as `Optional[str]`, but stores `None` unchanged. `eval_sample()` then concatenates `self.instructions` with strings, causing a `TypeError` before the model call.

A `None` value should therefore represent the absence of additional instructions, just like the default empty string.

## Compatibility

Existing callers using the default or a normal string are unchanged. The only newly supported case is the already type-valid `instructions=None` configuration.

## Tests

Added regression coverage constructing and evaluating a multiple-choice sample with `instructions=None` and verifying that the value is normalized to an empty string without crashing.

Closes #1775.