### PR TITLE
Forward constructor options through ChainOfThoughtCompletionFn

### DIFF
--- a/evals/completion_fns/cot.py
+++ b/evals/completion_fns/cot.py
@@ -40,11 +40,13 @@ class ChainOfThoughtCompletionFn(CompletionFn):
 
         # This model will use chain of thought to answer the question
         self.cot_template = cot_template
-        self.cot_completion_fn_instance = registry.make_completion_fn(cot_completion_fn)
+        self.cot_completion_fn_instance = registry.make_completion_fn(cot_completion_fn, **kwargs)
 
         # This model will extract the answer from the chain of thought
         self.extract_answer_template = extract_answer_template
-        self.extract_completion_fn_instance = registry.make_completion_fn(extract_completion_fn)
+        self.extract_completion_fn_instance = registry.make_completion_fn(
+            extract_completion_fn, **kwargs
+        )
 
     def __call__(self, prompt, **kwargs) -> ChainOfThoughtCompletionResult:
         # Ensure it is in string format

--- a/tests/unit/evals/test_cot_constructor_kwargs.py
+++ b/tests/unit/evals/test_cot_constructor_kwargs.py
@@ -1,0 +1,29 @@
+from typing import Any, cast
+
+from evals.completion_fns.cot import ChainOfThoughtCompletionFn
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def make_completion_fn(self, name: str, **kwargs: Any) -> object:
+        self.calls.append((name, kwargs))
+        return object()
+
+
+def test_cot_completion_fn_forwards_constructor_kwargs() -> None:
+    registry = RecordingRegistry()
+
+    ChainOfThoughtCompletionFn(
+        cot_completion_fn="reasoner",
+        extract_completion_fn="extractor",
+        registry=cast(Any, registry),
+        temperature=0.25,
+        custom_option="value",
+    )
+
+    assert registry.calls == [
+        ("reasoner", {"temperature": 0.25, "custom_option": "value"}),
+        ("extractor", {"temperature": 0.25, "custom_option": "value"}),
+    ]

--- a/tests/unit/evals/test_cot_constructor_kwargs.py
+++ b/tests/unit/evals/test_cot_constructor_kwargs.py
@@ -1,7 +1,5 @@
 from typing import Any, cast
 
-from evals.completion_fns.cot import ChainOfThoughtCompletionFn
-
 
 class RecordingRegistry:
     def __init__(self) -> None:
@@ -12,7 +10,10 @@ class RecordingRegistry:
         return object()
 
 
-def test_cot_completion_fn_forwards_constructor_kwargs() -> None:
+def test_cot_completion_fn_forwards_constructor_kwargs(monkeypatch: Any) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.completion_fns.cot import ChainOfThoughtCompletionFn
+
     registry = RecordingRegistry()
 
     ChainOfThoughtCompletionFn(


### PR DESCRIPTION
## Summary

Make `ChainOfThoughtCompletionFn` forward its constructor keyword arguments to both wrapped completion functions.

- pass `**kwargs` when creating the reasoning completion function
- pass the same options when creating the answer-extraction completion function
- leave runtime call kwargs and prompt construction unchanged
- add a focused regression test using a recording registry with no API calls

## Why

`ChainOfThoughtCompletionFn.__init__()` accepts arbitrary constructor kwargs but currently discards them when instantiating both child completion functions. This means configuration supplied through the wrapper silently never reaches either child.

The wrapper is compositional: callers should be able to configure the underlying completion functions through the constructor rather than having accepted options disappear.

## Compatibility

Configurations that do not supply extra constructor kwargs behave identically. Runtime kwargs passed to `__call__()` continue to be forwarded to both completion calls exactly as before.

## Tests

Added regression coverage verifying that multiple constructor options arrive unchanged at both `registry.make_completion_fn()` calls.

Closes #1779.