### PR TITLE
Reject empty fuzzy matches in SelfPrompting

### DIFF
--- a/evals/elsuite/self_prompting/eval.py
+++ b/evals/elsuite/self_prompting/eval.py
@@ -106,7 +106,13 @@ class SelfPrompting(SolverEval):
         tasker_output = tasker_completion_fn(full_prompt).get_completions()[0]
 
         exact = 1 if tasker_output == sample["output"] else 0
-        fuzzy = 1 if tasker_output in sample["output"] or sample["output"] in tasker_output else 0
+        fuzzy = (
+            1
+            if tasker_output
+            and sample["output"]
+            and (tasker_output in sample["output"] or sample["output"] in tasker_output)
+            else 0
+        )
 
         output = {
             **sample,

--- a/tests/unit/evals/test_self_prompting_fuzzy.py
+++ b/tests/unit/evals/test_self_prompting_fuzzy.py
@@ -1,0 +1,57 @@
+from typing import Any
+
+import pytest
+
+
+class StaticCompletionResult:
+    def __init__(self, completion: str) -> None:
+        self.completion = completion
+
+    def get_completions(self) -> list[str]:
+        return [self.completion]
+
+
+class StaticCompletionFn:
+    def __init__(self, completion: str) -> None:
+        self.completion = completion
+
+    def __call__(self, prompt: str) -> StaticCompletionResult:
+        return StaticCompletionResult(self.completion)
+
+
+@pytest.mark.parametrize(
+    "completion, expected, exact, fuzzy",
+    [
+        ("", "answer", 0, 0),
+        ("answer", "", 0, 0),
+        ("", "", 1, 0),
+        ("answer", "the answer is here", 0, 1),
+        ("the answer is here", "answer", 0, 1),
+    ],
+)
+def test_self_prompting_empty_outputs_do_not_fuzzy_match(
+    completion: str,
+    expected: str,
+    exact: int,
+    fuzzy: int,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.self_prompting.eval import SelfPrompting
+    from evals.record import DummyRecorder
+
+    evaluator = object.__new__(SelfPrompting)
+    evaluator.tasker_completion_fns = {"dummy": StaticCompletionFn(completion)}
+    recorder = DummyRecorder(None)
+    sample = {
+        "tasker_model": "dummy",
+        "model_instruction": "Respond to this input:",
+        "input": "question",
+        "output": expected,
+    }
+
+    with recorder.as_default_recorder("sample"):
+        result = evaluator._run_tasking(sample)
+
+    assert result["exact"] == exact
+    assert result["fuzzy"] == fuzzy


### PR DESCRIPTION
## Summary

Prevent `SelfPrompting` from awarding fuzzy-match credit to empty strings.

- require both sampled and expected answers to be non-empty before applying substring fuzzy matching
- preserve exact-match behavior, including the `"" == ""` case
- preserve existing fuzzy behavior for non-empty substring matches
- add focused regression coverage without any model API calls

## Why

The current fuzzy score is based directly on Python substring membership:

```python
fuzzy = 1 if tasker_output in sample["output"] or sample["output"] in tasker_output else 0
```

Because `"" in any_string` is `True`, a tasker that returns no answer receives full fuzzy credit for every non-empty expected answer. The inverse is also true when the expected answer is empty.

That is a scoring false positive rather than a modelling choice.

## Compatibility

Non-empty exact and fuzzy matches are unchanged. Empty strings can still match through the separate exact metric when both sides are empty; they simply no longer receive substring-based fuzzy credit.

## Tests

Added regression coverage for:

- empty sampled output against a non-empty expected answer
- non-empty sampled output against an empty expected answer
- both strings empty
- normal non-empty fuzzy substring matches in both directions

Closes #1780.