### PR TITLE
Preserve equal max_replies in TwentyQuestions

### DIFF
--- a/evals/elsuite/twenty_questions/eval.py
+++ b/evals/elsuite/twenty_questions/eval.py
@@ -46,7 +46,7 @@ class TwentyQuestions(SolverEval):
             logger.warn(
                 f"max_replies ({max_replies}) is less than max_questions ({max_questions}). Setting max_replies to {max_questions + 20}"
             )
-        self.max_replies = max_replies if max_replies > max_questions else max_questions + 20
+        self.max_replies = max_replies if max_replies >= max_questions else max_questions + 20
         self.num_shortlist_items = num_shortlist_items
         self.shortlist_variant = shortlist_variant
 

--- a/tests/unit/evals/test_twenty_questions_max_replies.py
+++ b/tests/unit/evals/test_twenty_questions_max_replies.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from typing import Any
+
+
+def _make_eval(max_questions: int, max_replies: int, monkeypatch: Any):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.api import DummyCompletionFn
+    from evals.elsuite.twenty_questions.eval import TwentyQuestions
+
+    return TwentyQuestions(
+        completion_fns=[DummyCompletionFn()],
+        samples_jsonl="unused",
+        gamemaster_spec="dummy",
+        max_questions=max_questions,
+        max_replies=max_replies,
+        eval_registry_path=Path("."),
+    )
+
+
+def test_twenty_questions_preserves_equal_max_replies(monkeypatch: Any) -> None:
+    evaluator = _make_eval(max_questions=20, max_replies=20, monkeypatch=monkeypatch)
+
+    assert evaluator.max_replies == 20
+
+
+def test_twenty_questions_expands_only_lower_max_replies(monkeypatch: Any) -> None:
+    evaluator = _make_eval(max_questions=20, max_replies=19, monkeypatch=monkeypatch)
+
+    assert evaluator.max_replies == 40


### PR DESCRIPTION
## Summary

Make `TwentyQuestions` preserve an explicit `max_replies` value when it is equal to `max_questions`.

- change the normalization comparison from `>` to `>=`
- keep the existing fallback for genuinely insufficient reply limits
- leave conversation and scoring behavior otherwise unchanged
- add focused constructor regression tests with dummy completion functions only

## Why

The constructor warns and adjusts only when:

```python
max_replies < max_questions
```

but the subsequent assignment currently preserves the caller's value only when:

```python
max_replies > max_questions
```

So `max_questions=20, max_replies=20` silently becomes 40 replies even though the preceding condition correctly considers 20 sufficient.

## Compatibility

Values above `max_questions` are unchanged. Values below it still use the existing `max_questions + 20` fallback. Only the equal boundary now preserves the caller's explicit configuration.

## Tests

Added regression coverage verifying that:

- equal question/reply limits remain equal
- a lower reply limit still expands to the existing fallback

Closes #1781.