### PR TITLE
Handle uncapped sampling in AlreadySaidThat

### DIFF
--- a/evals/elsuite/already_said_that/eval.py
+++ b/evals/elsuite/already_said_that/eval.py
@@ -156,5 +156,5 @@ class AlreadySaidThat(SolverEval):
 
     def _get_samples(self) -> list[dict]:
         samples = self.get_samples()
-        samples = self.rng.sample(samples, min(self.n_samples, len(samples)))
-        return samples
+        sample_size = len(samples) if self.n_samples is None else min(self.n_samples, len(samples))
+        return self.rng.sample(samples, sample_size)

--- a/tests/unit/evals/test_already_said_that_sampling.py
+++ b/tests/unit/evals/test_already_said_that_sampling.py
@@ -1,0 +1,27 @@
+import random
+from typing import Any, Optional
+
+
+def _get_samples(n_samples: Optional[int], monkeypatch: Any) -> list[dict]:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.already_said_that.eval import AlreadySaidThat
+
+    evaluator = object.__new__(AlreadySaidThat)
+    evaluator.n_samples = n_samples
+    evaluator.rng = random.Random(0)
+    source = [{"id": i} for i in range(4)]
+    evaluator.get_samples = lambda: source
+    return evaluator._get_samples()
+
+
+def test_already_said_that_none_uses_all_samples(monkeypatch: Any) -> None:
+    samples = _get_samples(None, monkeypatch)
+
+    assert len(samples) == 4
+    assert {sample["id"] for sample in samples} == {0, 1, 2, 3}
+
+
+def test_already_said_that_explicit_cap_is_preserved(monkeypatch: Any) -> None:
+    samples = _get_samples(2, monkeypatch)
+
+    assert len(samples) == 2


### PR DESCRIPTION
## Summary

Make `AlreadySaidThat` support its documented optional `n_samples` value.

- treat `n_samples=None` as no sample cap
- continue shuffling the full sample set with the eval RNG
- preserve the existing cap when an integer is supplied
- add focused regression tests for uncapped and capped sampling

## Why

`AlreadySaidThat.__init__()` declares `n_samples: Optional[int]`, but `_get_samples()` currently evaluates:

```python
min(self.n_samples, len(samples))
```

When `n_samples=None`, this raises `TypeError` before the eval can run. Optional sample limits elsewhere in the framework use `None` to mean no cap, and the type already exposes that configuration here.

## Compatibility

The default `n_samples=250` behavior is unchanged. Integer limits are still capped at the dataset size and sampled with the same RNG. The only newly supported case is `n_samples=None`.

## Tests

Added regression coverage verifying that `None` returns every source sample and that an explicit integer cap is still respected.

Closes #1785.