### PR TITLE
Preserve separators in FunctionDeduction responses

### DIFF
--- a/evals/elsuite/function_deduction/eval.py
+++ b/evals/elsuite/function_deduction/eval.py
@@ -264,7 +264,7 @@ class FunctionDeductionEval(SolverEval):
 
     def _parse_raw_response(self, response: str) -> Union[Tuple[int], Tuple[int, int, int]]:
         #   Remove all non-numbers first. This way we accept also e.g. "1, 2, 3", "[1, 2, 3]", '"1", "2", "3"' etc.
-        response = re.sub(r"[^0-9\s-]", "", response)
+        response = re.sub(r"[^0-9\s-]", " ", response)
 
         vals = tuple(int(x) for x in response.split())
         if len(vals) not in (1, 3):

--- a/tests/unit/evals/test_function_deduction_parser.py
+++ b/tests/unit/evals/test_function_deduction_parser.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "response, expected",
+    [
+        ("1,2,3", (1, 2, 3)),
+        ("[1,2,3]", (1, 2, 3)),
+        ('"1","2","3"', (1, 2, 3)),
+        ("-1,-2,-3", (-1, -2, -3)),
+        ("42", (42,)),
+    ],
+)
+def test_function_deduction_parser_preserves_integer_separators(
+    response: str, expected: tuple[int, ...], monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.function_deduction.eval import FunctionDeductionEval
+
+    evaluator = object.__new__(FunctionDeductionEval)
+
+    assert evaluator._parse_raw_response(response) == expected


### PR DESCRIPTION
## Summary

Fix `FunctionDeductionEval` parsing so punctuation separates integers instead of silently joining them together.

- replace non-numeric punctuation with whitespace rather than deleting it
- preserve minus signs and existing whitespace
- accept comma-separated and bracketed triples without requiring spaces after punctuation
- add focused parser regression tests

## Why

The parser is designed to accept flexible responses such as comma-separated or bracketed integer guesses, but currently does:

```python
re.sub(r"[^0-9\s-]", "", response)
```

Deleting punctuation means `1,2,3` becomes `123`, which is then interpreted as a single query and rejected as out of range. Replacing separators with whitespace preserves the intended three integers.

## Compatibility

Existing whitespace-separated responses continue to parse identically. Single integer queries remain unchanged. The fix only prevents punctuation from concatenating adjacent numeric tokens.

## Tests

Added regression coverage for `1,2,3`, `[1,2,3]`, quoted comma-separated values, negative triples, and an unchanged single-integer query.

Closes #1787.