### PR TITLE
Restore registry logging after Bluff solver lookup

### DIFF
--- a/evals/elsuite/bluff/eval.py
+++ b/evals/elsuite/bluff/eval.py
@@ -189,9 +189,12 @@ class BluffEval(SolverEval):
     def _create_solver_player(game: Game, solver_name: str) -> Player:
         #   This logger.disabled thing prevents messages saying that completion_fn was
         #   not found (because they are usually emitted )
+        logger_was_disabled = evals.registry.logger.disabled
         evals.registry.logger.disabled = True
-        solver = registry.make_completion_fn(solver_name)
-        evals.registry.logger.disabled = False
+        try:
+            solver = registry.make_completion_fn(solver_name)
+        finally:
+            evals.registry.logger.disabled = logger_was_disabled
         return SolverPlayer(game, solver)
 
     @staticmethod

--- a/tests/unit/evals/test_bluff_registry_logger.py
+++ b/tests/unit/evals/test_bluff_registry_logger.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.parametrize("initially_disabled", [False, True])
+def test_bluff_solver_lookup_restores_registry_logger(
+    initially_disabled: bool, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.bluff import eval as bluff_eval
+
+    def fail_lookup(_solver_name: str):
+        raise ValueError("not a registered solver")
+
+    monkeypatch.setattr(bluff_eval.registry, "make_completion_fn", fail_lookup)
+    monkeypatch.setattr(bluff_eval.evals.registry.logger, "disabled", initially_disabled)
+
+    with pytest.raises(ValueError, match="not a registered solver"):
+        bluff_eval.BluffEval._create_solver_player(object(), "missing-solver")
+
+    assert bluff_eval.evals.registry.logger.disabled is initially_disabled


### PR DESCRIPTION
## Summary

Ensure `BluffEval` always restores the registry logger after temporarily suppressing lookup diagnostics.

- save the logger's previous `disabled` state
- suppress registry messages only during solver lookup
- restore the previous state in `finally`, including when lookup raises
- add a focused regression test for both initially enabled and initially disabled logging

## Why

`BluffEval._create_opponent()` first tries to interpret an opponent as a registered solver and falls back to a bot class when that lookup raises. `_create_solver_player()` currently disables the global registry logger before the lookup and only re-enables it after a successful return.

If lookup raises, the restore line is skipped and registry diagnostics remain globally disabled for the rest of the process.

## Compatibility

Successful solver lookup behaves identically. The change only guarantees restoration of the pre-existing logger state after the temporary suppression, including exceptional paths.

## Tests

Added regression coverage forcing solver lookup to fail and verifying that the registry logger is restored when it started both enabled and disabled.

Closes #1791.