### PR TITLE
Count perfect TrackTheStat runs at full length

### DIFF
--- a/evals/elsuite/track_the_stat/eval.py
+++ b/evals/elsuite/track_the_stat/eval.py
@@ -48,6 +48,7 @@ class TrackTheStat(SolverEval):
 
     def _eval_sample(self, solver: Solver, capped_inf_list: list[int]) -> dict:
         violation = False
+        max_length = 0
         task_state = TaskState(task_description=self.task_desc, messages=[])
         for i, num in enumerate(capped_inf_list):
             curr_list = capped_inf_list[: i + 1]
@@ -60,10 +61,11 @@ class TrackTheStat(SolverEval):
                 break
             if round(solver_response, 1) != round(self.task_fn(curr_list), 1):
                 break
+            max_length += 1
             task_state.messages.append(Message(role="assistant", content=solver_output))
 
         return {
-            "max_length": len(curr_list) - 1,
+            "max_length": max_length,
             "violation": violation,
         }
 

--- a/tests/unit/evals/test_track_the_stat_length.py
+++ b/tests/unit/evals/test_track_the_stat_length.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+
+def _make_eval(monkeypatch: Any):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.track_the_stat import utils
+    from evals.elsuite.track_the_stat.eval import TrackTheStat
+
+    evaluator = object.__new__(TrackTheStat)
+    evaluator.task = "median"
+    evaluator.task_desc = ""
+    evaluator.task_fn = utils.median
+    return evaluator
+
+
+def test_track_the_stat_counts_fully_successful_sequence(monkeypatch: Any) -> None:
+    from evals.solvers.solver import SolverResult
+
+    class PerfectSolver:
+        def __call__(self, task_state):
+            values = task_state.current_state["state_data"]
+            values = sorted(values)
+            middle = len(values) // 2
+            if len(values) % 2:
+                answer = values[middle]
+            else:
+                answer = (values[middle - 1] + values[middle]) / 2
+            return SolverResult(f"[median: {answer}]")
+
+    evaluator = _make_eval(monkeypatch)
+    result = evaluator._eval_sample(PerfectSolver(), [1, 5, 3])
+
+    assert result == {"max_length": 3, "violation": False}
+
+
+def test_track_the_stat_keeps_early_failure_count(monkeypatch: Any) -> None:
+    from evals.solvers.solver import SolverResult
+
+    class FailSecondSolver:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, task_state):
+            self.calls += 1
+            if self.calls == 1:
+                return SolverResult("[median: 1]")
+            return SolverResult("[median: 999]")
+
+    evaluator = _make_eval(monkeypatch)
+    result = evaluator._eval_sample(FailSecondSolver(), [1, 5, 3])
+
+    assert result == {"max_length": 1, "violation": False}


### PR DESCRIPTION
## Summary

Make `TrackTheStat` report the number of successfully completed turns directly, including fully successful runs.

- count each correct rolling-stat response as one successful turn
- preserve zero for failure on the first turn
- preserve early-failure counts
- allow a perfect 300-turn run to report the documented maximum of 300
- add focused regression tests without API calls

## Why

The current metric uses `len(curr_list) - 1`. That works when the loop exits on a failing turn because the failing input is already present in `curr_list`, but it undercounts a run that reaches the end of the sequence without failing.

For the standard 300-number sequence, a perfect solver therefore reports `max_length=299`, even though the eval README explicitly documents 300 as the best possible value.

## Compatibility

Failure and violation semantics are unchanged. The metric now represents exactly the number of turns answered correctly in all termination paths.

## Tests

Added regression coverage for a fully successful sequence and for a solver that answers one turn correctly before failing the second.

Closes #1792.