### PR TITLE
Report exhausted tool runs with the actual turn count

### DIFF
--- a/evals/elsuite/solver_tools_convo.py
+++ b/evals/elsuite/solver_tools_convo.py
@@ -97,7 +97,7 @@ class Runner:
             task_state = self._add_tool_outputs(task_state, solver_result, tool_outputs)
             turn += 1
 
-        return self._finish_run(task_state, solver_result, None, turn)
+        return self._finish_run(task_state, solver_result, None, turn - 1)
 
     def _get_tool_names_and_descriptions(self, tools: list[Tool]):
         """
@@ -172,7 +172,7 @@ class Runner:
             out = tool(task_state)
         except (TypeError, ValueError, IndexError):
             out = None
-        
+
         if out is None:
             return None
 

--- a/tests/unit/evals/test_solver_tools_convo_turns.py
+++ b/tests/unit/evals/test_solver_tools_convo_turns.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+
+def _make_runner(output: str, max_turns: int, monkeypatch: Any):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.solver_tools_convo import Runner
+    from evals.solvers.solver import SolverResult
+
+    class StaticSolver:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, task_state):
+            self.calls += 1
+            return SolverResult(output)
+
+    solver = StaticSolver()
+    runner = Runner(
+        solver=solver,
+        sample={"task": "Do the task", "answer": "done"},
+        name_to_tool={},
+        max_turns=max_turns,
+        default_task_description="{tool_names_and_descriptions}",
+        default_reminder_message="Try again",
+    )
+    return runner, solver
+
+
+def test_exhausted_tool_run_reports_actual_turn_count(monkeypatch: Any) -> None:
+    runner, solver = _make_runner("still thinking", max_turns=2, monkeypatch=monkeypatch)
+
+    result = runner.run()
+
+    assert solver.calls == 2
+    assert result.metrics["num_turns"] == 2
+    assert not result.metrics["is_correct"]
+
+
+def test_final_answer_turn_count_is_unchanged(monkeypatch: Any) -> None:
+    runner, solver = _make_runner("(@Answer: done)", max_turns=2, monkeypatch=monkeypatch)
+
+    result = runner.run()
+
+    assert solver.calls == 1
+    assert result.metrics["num_turns"] == 1
+    assert result.metrics["is_correct"]


### PR DESCRIPTION
## Summary

Fix the shared tool-conversation runner so a run that exhausts `max_turns` reports the number of solver turns actually executed.

- keep the existing zero-based turn index convention used by `_finish_run()`
- pass the correct final index when the loop exits because the turn limit was exhausted
- leave successful early-final-answer counts unchanged
- add focused local regression tests

## Why

During the loop, `turn` is a zero-based index and `_finish_run()` records `turn + 1`. That is correct when a final answer is produced during a turn.

When the loop exhausts `max_turns`, however, `turn` has already been incremented to the total number of turns executed. Passing that value into the same `turn + 1` calculation overcounts the run. A 10-turn exhausted run is therefore reported as 11 turns.

## Compatibility

Successful runs retain their existing turn counts. Only the exhausted-run path changes, so `num_turns` can no longer exceed the configured `max_turns` merely because the loop hit its limit.

## Tests

Added regression coverage verifying that a two-turn exhausted run reports 2 turns and that a final answer on the first turn still reports 1.

Closes #1793.