### PR TITLE
Remove only the exact LangChain Answer prefix

### DIFF
--- a/evals/completion_fns/langchain_math.py
+++ b/evals/completion_fns/langchain_math.py
@@ -26,6 +26,6 @@ class LangChainMathChainCompletionFn(CompletionFn):
         prompt = CompletionPrompt(prompt).to_formatted_prompt()
         response = self.llm_math.run(prompt)
         # The LangChain response comes with `Answer: ` ahead of this, let's strip it out
-        response = response.strip("Answer:").strip()
+        response = response.removeprefix("Answer:").strip()
         record_sampling(prompt=prompt, sampled=response)
         return LangChainCompletionResult(response)

--- a/tests/unit/evals/test_langchain_math_answer_prefix.py
+++ b/tests/unit/evals/test_langchain_math_answer_prefix.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+import pytest
+
+
+class StaticMathChain:
+    def __init__(self, response: str) -> None:
+        self.response = response
+
+    def run(self, prompt: str) -> str:
+        return self.response
+
+
+@pytest.mark.parametrize(
+    "response, expected",
+    [
+        ("Answer: ten", "ten"),
+        ("Answer: seven", "seven"),
+        ("Answer: 42", "42"),
+        ("ten", "ten"),
+    ],
+)
+def test_langchain_math_removes_only_exact_answer_prefix(
+    response: str, expected: str, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.completion_fns import langchain_math
+
+    completion_fn = object.__new__(langchain_math.LangChainMathChainCompletionFn)
+    completion_fn.llm_math = StaticMathChain(response)
+    monkeypatch.setattr(langchain_math, "record_sampling", lambda **kwargs: None)
+
+    result = completion_fn("question")
+
+    assert result.get_completions() == [expected]


### PR DESCRIPTION
## Summary

Fix `LangChainMathChainCompletionFn` so removing LangChain's `Answer:` prefix cannot alter the answer text itself.

- replace character-set stripping with exact prefix removal
- keep surrounding-whitespace trimming
- preserve responses that do not begin with `Answer:`
- add focused regression coverage without API calls

## Why

The current code uses `response.strip("Answer:")`. Python treats the argument to `str.strip()` as a set of characters to remove from both ends, not as an exact prefix. This can corrupt valid answers: for example, `Answer: ten` becomes `t`, and even an unprefixed `ten` becomes `t`.

## Compatibility

The project requires Python 3.9+, where `str.removeprefix()` is available. Normal `Answer: <value>` responses retain the intended behavior; only accidental removal of answer characters is eliminated.

## Tests

Added local regression cases for textual and numeric prefixed answers plus an unprefixed textual answer.

Closes #1797.