### PR TITLE
Do not classify empty lists as chat prompts

### DIFF
--- a/evals/prompt/base.py
+++ b/evals/prompt/base.py
@@ -79,7 +79,7 @@ class Prompt(ABC):
 
 
 def is_chat_prompt(prompt: Prompt) -> bool:
-    return isinstance(prompt, list) and all(isinstance(msg, dict) for msg in prompt)
+    return isinstance(prompt, list) and bool(prompt) and all(isinstance(msg, dict) for msg in prompt)
 
 
 @dataclass

--- a/evals/prompt/base.py
+++ b/evals/prompt/base.py
@@ -79,7 +79,11 @@ class Prompt(ABC):
 
 
 def is_chat_prompt(prompt: Prompt) -> bool:
-    return isinstance(prompt, list) and bool(prompt) and all(isinstance(msg, dict) for msg in prompt)
+    return (
+        isinstance(prompt, list)
+        and bool(prompt)
+        and all(isinstance(msg, dict) for msg in prompt)
+    )
 
 
 @dataclass

--- a/tests/unit/evals/test_prompt_empty_chat.py
+++ b/tests/unit/evals/test_prompt_empty_chat.py
@@ -5,7 +5,11 @@ import pytest
 
 def test_empty_list_is_not_a_chat_prompt(monkeypatch: Any) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
-    from evals.prompt.base import CompletionPrompt, chat_prompt_to_text_prompt, is_chat_prompt
+    from evals.prompt.base import (
+        CompletionPrompt,
+        chat_prompt_to_text_prompt,
+        is_chat_prompt,
+    )
 
     assert not is_chat_prompt([])
     assert CompletionPrompt([]).to_formatted_prompt() == []

--- a/tests/unit/evals/test_prompt_empty_chat.py
+++ b/tests/unit/evals/test_prompt_empty_chat.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+import pytest
+
+
+def test_empty_list_is_not_a_chat_prompt(monkeypatch: Any) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.prompt.base import CompletionPrompt, chat_prompt_to_text_prompt, is_chat_prompt
+
+    assert not is_chat_prompt([])
+    assert CompletionPrompt([]).to_formatted_prompt() == []
+    with pytest.raises(AssertionError, match="Expected a chat prompt"):
+        chat_prompt_to_text_prompt([])
+
+
+def test_nonempty_message_list_is_still_a_chat_prompt(monkeypatch: Any) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.prompt.base import is_chat_prompt
+
+    prompt = [{"role": "user", "content": "hello"}]
+
+    assert is_chat_prompt(prompt)
+    assert not is_chat_prompt(["hello"])


### PR DESCRIPTION
## Summary

Make `is_chat_prompt()` require at least one message before classifying a list as a chat prompt.

- reject an empty list as a chat conversation
- keep non-empty message dictionaries classified as chat prompts
- keep non-chat list inputs classified as non-chat
- add focused prompt-routing regression tests

## Why

`is_chat_prompt()` currently relies on `all(isinstance(msg, dict) for msg in prompt)`. Because `all([])` is `True`, an empty list is treated as a valid chat prompt. Downstream, `chat_prompt_to_text_prompt([])` can therefore produce an artificial `Assistant:` prompt even though the caller supplied no messages.

## Compatibility

Normal non-empty chat prompts are unchanged. Empty list inputs are no longer routed through chat rendering and remain available as legacy list-style completion prompts instead.

## Tests

Added coverage for empty lists, normal non-empty chat prompts, non-chat lists, and the empty-list chat renderer assertion.

Closes #1798.