### PR TITLE
Skip undefined no-control samples in post-hoc recall

### DIFF
--- a/evals/elsuite/identifying_variables/metrics.py
+++ b/evals/elsuite/identifying_variables/metrics.py
@@ -62,16 +62,14 @@ def compute_ctrl_recall_posthoc(metric_entries: List[Dict], sampling_entries: Li
         except ValueError:  # in case of invalid solver output (violation)
             preds = None
 
-        if metric_entry["gold_answer"]["valid_hypothesis"]:
-            if preds and preds.ctrl_vars is not None:
-                recall = compute_recall(
-                    set(preds.ctrl_vars), set(metric_entry["gold_answer"]["ctrl_vars"])
-                )
-            else:
-                # worst case scenario in case of violation or incorrect hyp validation
-                recall = 0
-        else:
+        gold_answer = metric_entry["gold_answer"]
+        if not gold_answer["valid_hypothesis"] or len(gold_answer["ctrl_vars"]) == 0:
             recall = np.nan
+        elif preds and preds.ctrl_vars is not None:
+            recall = compute_recall(set(preds.ctrl_vars), set(gold_answer["ctrl_vars"]))
+        else:
+            # worst case scenario in case of violation or incorrect hyp validation
+            recall = 0
         recalls.append(recall)
     return np.nanmean(recalls).astype(float)
 

--- a/tests/unit/evals/test_identifying_variables_posthoc_recall.py
+++ b/tests/unit/evals/test_identifying_variables_posthoc_recall.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+
+def test_posthoc_ctrl_recall_skips_no_control_sample_after_parse_failure(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.identifying_variables.metrics import compute_ctrl_recall_posthoc
+
+    metric_entries = [
+        {
+            "gold_answer": {
+                "valid_hypothesis": True,
+                "ctrl_vars": [],
+            }
+        },
+        {
+            "gold_answer": {
+                "valid_hypothesis": True,
+                "ctrl_vars": ["x"],
+            }
+        },
+    ]
+    sampling_entries = [
+        {"sampled": ["malformed output"]},
+        {
+            "sampled": [
+                "[@answer valid_hyp: true; independent: a; dependent: b; control: x]"
+            ]
+        },
+    ]
+
+    assert compute_ctrl_recall_posthoc(metric_entries, sampling_entries) == 1.0
+
+
+def test_posthoc_ctrl_recall_still_penalizes_parse_failure_when_recall_is_defined(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.identifying_variables.metrics import compute_ctrl_recall_posthoc
+
+    metric_entries = [
+        {
+            "gold_answer": {
+                "valid_hypothesis": True,
+                "ctrl_vars": ["x"],
+            }
+        }
+    ]
+    sampling_entries = [{"sampled": ["malformed output"]}]
+
+    assert compute_ctrl_recall_posthoc(metric_entries, sampling_entries) == 0.0


### PR DESCRIPTION
## Summary

Make the Identifying Variables post-hoc control-recall calculation consistently skip samples for which control recall is undefined.

- skip valid gold labels with no control variables before prediction handling
- continue skipping invalid gold hypotheses
- keep malformed-output penalty at zero when control recall is actually defined
- add focused regression coverage

## Why

`compute_ctrl_recall_posthoc()` explicitly documents that samples with no gold control variables should be skipped because recall is undefined. That happens when solver output parses successfully, because `compute_recall()` returns `NaN` for an empty gold set.

If solver output is malformed, however, `preds` becomes `None` and the same no-control sample is assigned recall `0`. Its inclusion therefore depends on parse success and can incorrectly lower the aggregate score.

## Compatibility

Only samples whose gold control set is empty change. Malformed outputs on samples with defined control recall are still penalized as zero, and normal parsed recall calculations are unchanged.

## Tests

Added a regression combining a malformed no-control sample with a correct defined-recall sample, plus a guard that malformed output with a non-empty gold control set still scores zero.

Closes #1799.