### PR TITLE
Preserve system messages when reversing Ballots roles

### DIFF
--- a/evals/elsuite/ballots/utils.py
+++ b/evals/elsuite/ballots/utils.py
@@ -127,9 +127,10 @@ def prompt_matches_model(model, prompt):
 
 
 def reverse_roles(messages):
+    role_map = {"assistant": "user", "user": "assistant"}
     return [
         {
-            "role": "user" if message["role"] == "assistant" else "assistant",
+            "role": role_map.get(message["role"], message["role"]),
             "content": message["content"],
         }
         for message in messages

--- a/tests/unit/evals/test_ballots_reverse_roles.py
+++ b/tests/unit/evals/test_ballots_reverse_roles.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+
+def test_reverse_roles_preserves_system_messages(monkeypatch: Any) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.ballots.utils import reverse_roles
+
+    messages = [
+        {"role": "assistant", "content": "assistant message"},
+        {"role": "user", "content": "user message"},
+        {"role": "system", "content": "system instruction"},
+    ]
+
+    assert reverse_roles(messages) == [
+        {"role": "user", "content": "assistant message"},
+        {"role": "assistant", "content": "user message"},
+        {"role": "system", "content": "system instruction"},
+    ]


### PR DESCRIPTION
## Summary

Fix `Ballots` role reversal so only conversational roles are swapped.

- swap `assistant` to `user` and `user` to `assistant`
- preserve `system` messages unchanged
- leave message content untouched
- add focused local regression coverage

## Why

`reverse_roles()` currently maps every non-`assistant` role to `assistant`. In the Ballots eval, the final voting instruction is appended as a `system` message immediately before the voter query is made with `reversed_roles=True`. That turns the system instruction into an assistant message and sends the voter its decision instruction under the wrong role.

## Compatibility

Existing user/assistant role reversal is unchanged. The only behavioral change is that roles outside that pair, including `system`, retain their original role.

## Tests

Added regression coverage for a mixed assistant/user/system history, verifying the conversational roles swap and the system instruction remains system.

Closes #1803.