### PR TITLE
Treat missing ML Agent action arguments as invalid

### DIFF
--- a/evals/elsuite/hr_ml_agent_bench/actions.py
+++ b/evals/elsuite/hr_ml_agent_bench/actions.py
@@ -45,7 +45,7 @@ def is_valid_action(action: Action) -> bool:
 
     assert isinstance(action, Action)
 
-    if isinstance(action.args, str):
+    if not isinstance(action.args, dict):
         return False
 
     for valid_action in ACTION_SPACE:

--- a/tests/unit/evals/test_ml_agent_bench_actions.py
+++ b/tests/unit/evals/test_ml_agent_bench_actions.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+
+def _actions(monkeypatch: Any):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.hr_ml_agent_bench import actions
+
+    return actions
+
+
+def test_missing_action_input_is_invalid(monkeypatch: Any) -> None:
+    actions = _actions(monkeypatch)
+    valid_action = actions.ACTION_SPACE[0]
+
+    parsed = actions.get_action(f"Action: {valid_action.name}")
+
+    assert parsed is not None
+    assert parsed.args is None
+    assert not actions.is_valid_action(parsed)
+
+
+def test_valid_action_arguments_are_unchanged(monkeypatch: Any) -> None:
+    actions = _actions(monkeypatch)
+    valid_action = actions.ACTION_SPACE[0]
+    args = {key: None for key in valid_action.usage}
+    action = actions.Action(name=valid_action.name, args=args)
+
+    assert actions.is_valid_action(action)


### PR DESCRIPTION
## Summary

Make HR ML Agent Bench reject missing or otherwise non-dictionary action arguments without crashing.

- require parsed action arguments to be a dictionary before inspecting their keys
- keep malformed string arguments invalid
- preserve valid action-name and argument-key matching
- add focused regression coverage without running an agent or model

## Why

`get_action()` returns an `Action` with `args=None` when a model supplies an action name but omits the `Action Input:` block. `is_valid_action()` currently rejects strings only and then calls `action.args.keys()`, causing an `AttributeError` on this normal malformed-output path.

The surrounding eval loop is already designed to handle invalid actions by re-prompting the model, so validation should return `False` instead of crashing the evaluation.

## Compatibility

Valid dictionary arguments are checked exactly as before. Existing malformed string arguments remain invalid. Missing and other non-dictionary arguments now follow the same invalid-action path.

## Tests

Added regression coverage showing that a parsed action with missing input is invalid rather than exceptional, while a valid action with the expected argument keys remains accepted.

Closes #1804.