### PR TITLE
Support dictionary responses in MakeMeSay get_content

### DIFF
--- a/evals/elsuite/make_me_say/utils.py
+++ b/evals/elsuite/make_me_say/utils.py
@@ -43,4 +43,7 @@ def get_content(response: Union[dict, CompletionResult]) -> str:
         assert len(completions) == 1, f"Got {len(completions)} but expected exactly one"
         return completions[0]
 
+    if isinstance(response, dict):
+        return response["choices"][0]["message"]["content"]
+
     return response.choices[0].message.content

--- a/tests/unit/evals/test_make_me_say_get_content.py
+++ b/tests/unit/evals/test_make_me_say_get_content.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+
+def test_get_content_supports_dictionary_responses(monkeypatch: Any) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.make_me_say.utils import get_content
+
+    response = {"choices": [{"message": {"content": "hello"}}]}
+
+    assert get_content(response) == "hello"
+
+
+def test_get_content_preserves_completion_result_behavior(monkeypatch: Any) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.elsuite.make_me_say.utils import get_content
+
+    class StaticCompletionResult:
+        def get_completions(self) -> list[str]:
+            return ["hello"]
+
+    assert get_content(StaticCompletionResult()) == "hello"


### PR DESCRIPTION
## Summary

Make `MakeMeSay`'s `get_content()` helper support the dictionary response type it already declares.

- extract content from dictionary-style `choices/message/content` responses
- preserve `CompletionResult` handling
- preserve the existing attribute-style response fallback
- add focused local regression coverage

## Why

`get_content()` is annotated to accept `Union[dict, CompletionResult]`, but after the `CompletionResult` path it assumes attribute access with `response.choices[0].message.content`. A normal dictionary response therefore raises `AttributeError` even though dictionaries are explicitly part of the helper's input contract.

## Compatibility

Existing `CompletionResult` responses are unchanged. Attribute-style OpenAI response objects continue through the existing fallback. Only dictionary responses gain the handling already promised by the function signature.

## Tests

Added regression coverage for a dictionary-style response and the existing `get_completions()` path, with no API calls.

Closes #1805.