### PR TITLE
Use per-sample RNG in SchellingPoint

### DIFF
--- a/evals/elsuite/schelling_point/eval.py
+++ b/evals/elsuite/schelling_point/eval.py
@@ -22,9 +22,7 @@ class SchellingPoint(Eval):
         *args,
         **kwargs,
     ):
-        super().__init__(completion_fns, *args, **kwargs)
-
-        self.rng = random.Random(seed)
+        super().__init__(completion_fns, seed=seed, *args, **kwargs)
 
         self.n_copies = n_copies
         assert self.n_copies >= 2, "Must provide n_copies >= 2"
@@ -39,14 +37,14 @@ class SchellingPoint(Eval):
             self.completion_fns = self.completion_fns * n_copies
         assert len(self.completion_fns) == n_copies, "Must provide n_copies completion_fns"
 
-    def eval_sample(self, sample: Any, *_):
+    def eval_sample(self, sample: Any, rng: random.Random):
 
         completions_no_ci = []
         scratchpad_outputs_no_ci = []
 
         for i, completion_fn in enumerate(self.completion_fns):
             prompt = sample[f"{i}"]
-            sys_prompt_no_ci = self.rng.choice(sys_prompts_no_ci)
+            sys_prompt_no_ci = rng.choice(sys_prompts_no_ci)
             completion, scratchpad = get_response(
                 completion_fn, sys_prompt_no_ci, prompt, self.temperature
             )
@@ -60,7 +58,7 @@ class SchellingPoint(Eval):
 
         for i, completion_fn in enumerate(self.completion_fns):
             prompt = sample[f"{i}"]
-            sys_prompt_ci = self.rng.choice(sys_prompts_ci)
+            sys_prompt_ci = rng.choice(sys_prompts_ci)
             completion, scratchpad = get_response(
                 completion_fn, sys_prompt_ci, prompt, self.temperature
             )

--- a/evals/elsuite/schelling_point/eval.py
+++ b/evals/elsuite/schelling_point/eval.py
@@ -24,7 +24,7 @@ class SchellingPoint(Eval):
     ):
         super().__init__(completion_fns, *args, **kwargs)
 
-        random.seed(seed)
+        self.rng = random.Random(seed)
 
         self.n_copies = n_copies
         assert self.n_copies >= 2, "Must provide n_copies >= 2"
@@ -46,7 +46,7 @@ class SchellingPoint(Eval):
 
         for i, completion_fn in enumerate(self.completion_fns):
             prompt = sample[f"{i}"]
-            sys_prompt_no_ci = random.choice(sys_prompts_no_ci)
+            sys_prompt_no_ci = self.rng.choice(sys_prompts_no_ci)
             completion, scratchpad = get_response(
                 completion_fn, sys_prompt_no_ci, prompt, self.temperature
             )
@@ -60,7 +60,7 @@ class SchellingPoint(Eval):
 
         for i, completion_fn in enumerate(self.completion_fns):
             prompt = sample[f"{i}"]
-            sys_prompt_ci = random.choice(sys_prompts_ci)
+            sys_prompt_ci = self.rng.choice(sys_prompts_ci)
             completion, scratchpad = get_response(
                 completion_fn, sys_prompt_ci, prompt, self.temperature
             )

--- a/tests/unit/evals/test_schelling_point_rng.py
+++ b/tests/unit/evals/test_schelling_point_rng.py
@@ -1,0 +1,31 @@
+import random
+from pathlib import Path
+from typing import Any
+
+
+def _make_eval(monkeypatch: Any, seed: int):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.api import DummyCompletionFn
+    from evals.elsuite.schelling_point.eval import SchellingPoint
+
+    return SchellingPoint(
+        completion_fns=[DummyCompletionFn()],
+        seed=seed,
+        eval_registry_path=Path("."),
+    )
+
+
+def test_schelling_point_does_not_reseed_global_rng(monkeypatch: Any) -> None:
+    random.seed(8675309)
+    global_state = random.getstate()
+
+    _make_eval(monkeypatch, seed=42)
+
+    assert random.getstate() == global_state
+
+
+def test_schelling_point_uses_seeded_local_rng(monkeypatch: Any) -> None:
+    first = _make_eval(monkeypatch, seed=123)
+    second = _make_eval(monkeypatch, seed=123)
+
+    assert [first.rng.random() for _ in range(3)] == [second.rng.random() for _ in range(3)]

--- a/tests/unit/evals/test_schelling_point_rng.py
+++ b/tests/unit/evals/test_schelling_point_rng.py
@@ -19,13 +19,21 @@ def test_schelling_point_does_not_reseed_global_rng(monkeypatch: Any) -> None:
     random.seed(8675309)
     global_state = random.getstate()
 
-    _make_eval(monkeypatch, seed=42)
+    evaluator = _make_eval(monkeypatch, seed=42)
 
     assert random.getstate() == global_state
+    assert evaluator.seed == 42
 
 
-def test_schelling_point_uses_seeded_local_rng(monkeypatch: Any) -> None:
-    first = _make_eval(monkeypatch, seed=123)
-    second = _make_eval(monkeypatch, seed=123)
+def test_schelling_point_sample_uses_supplied_rng(monkeypatch: Any) -> None:
+    from evals.elsuite.schelling_point import eval as schelling_eval
 
-    assert [first.rng.random() for _ in range(3)] == [second.rng.random() for _ in range(3)]
+    evaluator = _make_eval(monkeypatch, seed=123)
+    monkeypatch.setattr(schelling_eval, "get_response", lambda *_args: ("same", "scratchpad"))
+    monkeypatch.setattr(schelling_eval.evals.record, "record_metrics", lambda **_kwargs: None)
+
+    random.seed(314159)
+    global_state = random.getstate()
+    evaluator.eval_sample({"0": "first", "1": "second"}, random.Random(123))
+
+    assert random.getstate() == global_state


### PR DESCRIPTION
## Summary

Keep SchellingPoint randomness inside the evaluation framework's per-sample seeded RNG.

- stop reseeding Python's process-wide `random` module
- forward the configured SchellingPoint seed to the base `Eval`
- use the per-sample `rng` supplied by `Eval.eval_all_samples()` for prompt selection
- add focused regression coverage for global RNG isolation and seed propagation

## Why

`SchellingPoint.__init__()` currently calls `random.seed(seed)`, and `eval_sample()` later calls module-global `random.choice()`. Constructing the eval therefore changes randomness for unrelated code in the same process. In threaded evaluation, prompt selection also depends on the interleaving of samples sharing that global generator.

The base eval framework already creates a deterministic `random.Random` for each sample from the eval seed and sample ID, so SchellingPoint can use that existing mechanism directly.

## Compatibility

Prompt variants are still selected randomly and reproducibly from the same lists. The configured `seed` now controls the framework's per-sample RNG instead of mutating process-global state. No scoring or completion behavior changes otherwise.

## Tests

Added regression coverage verifying that constructing and evaluating SchellingPoint does not modify Python's global RNG state and that the configured seed is retained by the base eval.

Closes #1809.