### PR TITLE
Forward runtime kwargs through LangChain wrappers

### DIFF
--- a/evals/completion_fns/langchain_llm.py
+++ b/evals/completion_fns/langchain_llm.py
@@ -41,7 +41,7 @@ class LangChainLLMCompletionFn(CompletionFn):
 
     def __call__(self, prompt, **kwargs) -> LangChainLLMCompletionResult:
         prompt = CompletionPrompt(prompt).to_formatted_prompt()
-        response = self.llm(prompt)
+        response = self.llm(prompt, **kwargs)
         record_sampling(prompt=prompt, sampled=response)
         return LangChainLLMCompletionResult(response)
 
@@ -84,6 +84,6 @@ class LangChainChatModelCompletionFn(CompletionFn):
             messages = [_convert_dict_to_langchain_message(message) for message in prompt]
         else:
             messages = [HumanMessage(content=prompt)]
-        response = self.llm(messages).content
+        response = self.llm(messages, **kwargs).content
         record_sampling(prompt=prompt, sampled=response)
         return LangChainLLMCompletionResult(response)

--- a/tests/unit/evals/test_langchain_runtime_kwargs.py
+++ b/tests/unit/evals/test_langchain_runtime_kwargs.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from typing import Any
+
+
+def _load_module(monkeypatch: Any):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    from evals.completion_fns import langchain_llm
+
+    monkeypatch.setattr(langchain_llm, "record_sampling", lambda **_kwargs: None)
+    return langchain_llm
+
+
+def test_langchain_llm_forwards_runtime_kwargs(monkeypatch: Any) -> None:
+    langchain_llm = _load_module(monkeypatch)
+
+    class RecordingLLM:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def __call__(self, prompt, **kwargs):
+            self.calls.append((prompt, kwargs))
+            return "ok"
+
+    model = RecordingLLM()
+    completion_fn = object.__new__(langchain_llm.LangChainLLMCompletionFn)
+    completion_fn.llm = model
+
+    result = completion_fn("hello", stop=["END"], custom_option="value")
+
+    assert model.calls == [("hello", {"stop": ["END"], "custom_option": "value"})]
+    assert result.get_completions() == ["ok"]
+
+
+def test_langchain_chat_model_forwards_runtime_kwargs(monkeypatch: Any) -> None:
+    langchain_llm = _load_module(monkeypatch)
+
+    class RecordingChatModel:
+        def __init__(self) -> None:
+            self.kwargs = None
+
+        def __call__(self, messages, **kwargs):
+            self.kwargs = kwargs
+            return SimpleNamespace(content="ok")
+
+    model = RecordingChatModel()
+    completion_fn = object.__new__(langchain_llm.LangChainChatModelCompletionFn)
+    completion_fn.llm = model
+
+    result = completion_fn(
+        [{"role": "user", "content": "hello"}],
+        stop=["END"],
+        custom_option="value",
+    )
+
+    assert model.kwargs == {"stop": ["END"], "custom_option": "value"}
+    assert result.get_completions() == ["ok"]


### PR DESCRIPTION
## Summary

Forward invocation-time keyword arguments through both LangChain completion wrappers.

- pass runtime kwargs to `LangChainLLMCompletionFn`'s wrapped LLM
- pass runtime kwargs to `LangChainChatModelCompletionFn`'s wrapped chat model
- leave prompt conversion and sampling recording unchanged
- add focused recording-model regression tests with no external calls

## Why

Both wrappers accept `**kwargs` in `__call__()`, but currently discard them before invoking the wrapped LangChain object. The shared `CompletionFn` contract documents runtime kwargs as arguments passed through to the underlying API, so options such as `stop`, callbacks, or other supported invocation controls silently disappear when these wrappers are used.

## Compatibility

Calls that do not provide runtime kwargs behave exactly as before. Prompt conversion, response extraction, and sampling events are unchanged; supplied options now reach the wrapped model.

## Tests

Added local recording LLM and chat-model tests verifying that multiple runtime kwargs arrive unchanged and returned completion text is preserved.

Closes #1811.