### PR TITLE
fix: bound API retries and drop dead error-dict checks

### DIFF
--- a/evals/completion_fns/openai.py
+++ b/evals/completion_fns/openai.py
@@ -29,13 +29,9 @@ def openai_completion_create_retrying(client: OpenAI, *args, **kwargs):
     Helper function for creating a completion.
     `args` and `kwargs` match what is accepted by `openai.Completion.create`.
     """
-    result = create_retrying(
+    return create_retrying(
         client.completions.create, retry_exceptions=OPENAI_TIMEOUT_EXCEPTIONS, *args, **kwargs
     )
-    if "error" in result:
-        logging.warning(result)
-        raise openai.APIError(result["error"])
-    return result
 
 
 def openai_chat_completion_create_retrying(client: OpenAI, *args, **kwargs):
@@ -43,13 +39,9 @@ def openai_chat_completion_create_retrying(client: OpenAI, *args, **kwargs):
     Helper function for creating a completion.
     `args` and `kwargs` match what is accepted by `openai.Completion.create`.
     """
-    result = create_retrying(
+    return create_retrying(
         client.chat.completions.create, retry_exceptions=OPENAI_TIMEOUT_EXCEPTIONS, *args, **kwargs
     )
-    if "error" in result:
-        logging.warning(result)
-        raise openai.APIError(result["error"])
-    return result
 
 
 class OpenAIBaseCompletionResult(CompletionResult):

--- a/evals/completion_fns/openai.py
+++ b/evals/completion_fns/openai.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Optional, Union
 
 import openai

--- a/evals/solvers/providers/anthropic/anthropic_solver.py
+++ b/evals/solvers/providers/anthropic/anthropic_solver.py
@@ -121,12 +121,9 @@ def anthropic_create_retrying(client: Anthropic, *args, **kwargs):
     Helper function for creating a backoff-retry enabled message request.
     `args` and `kwargs` match what is accepted by `client.messages.create`.
     """
-    result = create_retrying(
+    return create_retrying(
         client.messages.create, retry_exceptions=ANTHROPIC_TIMEOUT_EXCEPTIONS, *args, **kwargs
     )
-    if "error" in result:
-        raise Exception(result["error"])
-    return result
 
 
 def anth_to_openai_usage(anth_usage: Usage) -> dict:

--- a/evals/utils/api_utils.py
+++ b/evals/utils/api_utils.py
@@ -4,19 +4,26 @@ import os
 import backoff
 
 EVALS_THREAD_TIMEOUT = float(os.environ.get("EVALS_THREAD_TIMEOUT", "40"))
+EVALS_API_RETRY_MAX_TIME = float(os.environ.get("EVALS_API_RETRY_MAX_TIME", "300"))
 logging.getLogger("httpx").setLevel(logging.WARNING)  # suppress "OK" logs from openai API calls
 
 
-@backoff.on_predicate(
-    wait_gen=backoff.expo,
-    max_value=60,
-    factor=1.5,
-)
 def create_retrying(func: callable, retry_exceptions: tuple[Exception], *args, **kwargs):
     """
-    Retries given function if one of given exceptions is raised
+    Retries given function if one of given exceptions is raised.
+
+    Gives up after EVALS_API_RETRY_MAX_TIME seconds (default 300) so a
+    persistent RateLimit/outage cannot hang an eval worker forever.
     """
-    try:
+
+    @backoff.on_exception(
+        backoff.expo,
+        retry_exceptions,
+        max_value=60,
+        factor=1.5,
+        max_time=EVALS_API_RETRY_MAX_TIME,
+    )
+    def _call():
         return func(*args, **kwargs)
-    except retry_exceptions:
-        return False
+
+    return _call()

--- a/evals/utils/api_utils.py
+++ b/evals/utils/api_utils.py
@@ -12,8 +12,10 @@ def create_retrying(func: callable, retry_exceptions: tuple[Exception], *args, *
     """
     Retries given function if one of given exceptions is raised.
 
-    Gives up after EVALS_API_RETRY_MAX_TIME seconds (default 300) so a
-    persistent RateLimit/outage cannot hang an eval worker forever.
+    Bounds retries with EVALS_API_RETRY_MAX_TIME (default 300 seconds),
+    re-raising the last retryable exception when the budget is exhausted.
+    This does not interrupt an in-flight call; configure request timeouts
+    separately on the underlying client.
     """
 
     @backoff.on_exception(

--- a/tests/test_create_retrying_bounds.py
+++ b/tests/test_create_retrying_bounds.py
@@ -1,0 +1,35 @@
+import importlib.util
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _load_api_utils():
+    path = Path(__file__).resolve().parents[1] / "evals" / "utils" / "api_utils.py"
+    spec = importlib.util.spec_from_file_location("evals_api_utils", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_create_retrying_gives_up_instead_of_looping_forever(monkeypatch):
+    api_utils = _load_api_utils()
+    monkeypatch.setattr(api_utils, "EVALS_API_RETRY_MAX_TIME", 0.2)
+    # Avoid real sleeps during exponential backoff.
+    monkeypatch.setattr(time, "sleep", lambda *_a, **_k: None)
+
+    attempts = {"n": 0}
+
+    def always_fail():
+        attempts["n"] += 1
+        raise ConnectionError("boom")
+
+    started = time.monotonic()
+    with pytest.raises(ConnectionError):
+        api_utils.create_retrying(always_fail, retry_exceptions=(ConnectionError,))
+    elapsed = time.monotonic() - started
+
+    assert attempts["n"] >= 2
+    assert elapsed < 5.0

--- a/tests/test_create_retrying_bounds.py
+++ b/tests/test_create_retrying_bounds.py
@@ -1,6 +1,7 @@
 import importlib.util
 import time
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -16,20 +17,51 @@ def _load_api_utils():
 
 def test_create_retrying_gives_up_instead_of_looping_forever(monkeypatch):
     api_utils = _load_api_utils()
-    monkeypatch.setattr(api_utils, "EVALS_API_RETRY_MAX_TIME", 0.2)
-    # Avoid real sleeps during exponential backoff.
-    monkeypatch.setattr(time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(api_utils, "EVALS_API_RETRY_MAX_TIME", 0)
+    error = ConnectionError("boom")
+    # A second call raises a different exception, so a broken retry bound
+    # fails immediately instead of leaving the regression test in a loop.
+    func = Mock(side_effect=[error, RuntimeError("unexpected retry")])
+    with pytest.raises(ConnectionError) as exc:
+        api_utils.create_retrying(func, retry_exceptions=(ConnectionError,))
+    assert exc.value is error
+    func.assert_called_once_with()
 
-    attempts = {"n": 0}
 
-    def always_fail():
-        attempts["n"] += 1
-        raise ConnectionError("boom")
+@pytest.mark.parametrize("result", [None, False, [], {}, "ok"])
+def test_successful_results_are_not_retried(monkeypatch, result):
+    api_utils = _load_api_utils()
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    func = Mock(side_effect=[result, RuntimeError("unexpected retry")])
+    assert api_utils.create_retrying(func, (ConnectionError,), "input", option=1) is result
+    func.assert_called_once_with("input", option=1)
 
-    started = time.monotonic()
-    with pytest.raises(ConnectionError):
-        api_utils.create_retrying(always_fail, retry_exceptions=(ConnectionError,))
-    elapsed = time.monotonic() - started
 
-    assert attempts["n"] >= 2
-    assert elapsed < 5.0
+def test_retryable_failure_can_recover(monkeypatch):
+    api_utils = _load_api_utils()
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    func = Mock(side_effect=[ConnectionError("retry"), "ok"])
+    assert api_utils.create_retrying(func, (ConnectionError,), option=1) == "ok"
+    assert func.call_count == 2
+    func.assert_called_with(option=1)
+
+
+def test_non_retryable_failure_propagates():
+    api_utils = _load_api_utils()
+    error = ValueError("invalid request")
+    func = Mock(side_effect=error)
+    with pytest.raises(ValueError) as exc:
+        api_utils.create_retrying(func, (ConnectionError,))
+    assert exc.value is error
+    func.assert_called_once_with()
+
+
+def test_retry_budget_does_not_cancel_an_in_flight_call(monkeypatch):
+    api_utils = _load_api_utils()
+    monkeypatch.setattr(api_utils, "EVALS_API_RETRY_MAX_TIME", 0.001)
+
+    def slow_success():
+        time.sleep(0.02)
+        return "ok"
+
+    assert api_utils.create_retrying(slow_success, (ConnectionError,)) == "ok"


### PR DESCRIPTION
## Summary

Fixes #1818. This is an infrastructure bug fix, not a new eval or dataset.

- Replace the unbounded predicate retry loop with exception-based backoff and a configurable `EVALS_API_RETRY_MAX_TIME` budget (default 300 seconds).
- Re-raise the last retryable exception on exhaustion. Successful results, including falsey values, return unchanged; non-retryable errors propagate immediately.
- Remove stale error-dictionary checks from the OpenAI and Anthropic SDK wrappers, plus the now-unused logging import.
- Clarify that this is backoff's retry-time budget, not a strict wall-clock deadline. A slow synchronous request can overrun it; configure underlying client request timeouts separately.

## Eval details

Eval name/description/value: not applicable. This fixes the shared model-I/O retry helper used by existing evals; it does not add evaluation data, grading logic, or a benchmark.

## Criteria for a good eval / Eval structure

The sample-count, registry YAML, GPT-4/GPT-3.5 performance, and Git LFS requirements are not applicable to this code-only change. No model/API calls or dataset submissions were made for verification.

## Verification

- `pytest tests/test_create_retrying_bounds.py -q`: **9 passed**. Coverage includes zero-budget exhaustion with original exception identity and no extra call, falsey/truthy success identity, argument forwarding, retry recovery, non-retryable errors, and successful in-flight calls not being cancelled by the retry budget.
- The tests avoid the original CPU-busy wall-clock loop; an unexpected second call raises a different exception so a regression cannot leave that test retrying forever.
- Repository-pinned pre-commit checks passed on all four Python files in the PR: **mypy, black, isort, autoflake, Ruff**. `git diff --check` also passed.
- Python 3.14 reports backoff's existing `asyncio.iscoroutinefunction` deprecation warnings. No claim of warning-free output or full SDK integration coverage is made.
- Hosted workflows still require maintainer approval; remote CI is not claimed to pass.

## Final checklist

- [x] Relevant code checks executed; pre-commit hook installed
- [x] Tests added/updated and independently reviewed
- [x] No eval JSON/YAML or Git LFS data changes (not applicable)
- [ ] Contributor agreement and account-specific acknowledgments require the account owner's confirmation; no agent has signed or checked them on the owner's behalf

## AI assistance

The initial patch was made with Cursor. Codex removed the unused import, corrected the retry-budget documentation, expanded and ran the regression tests, and used an independent agent review. No human-review or account-agreement attestation is implied.
